### PR TITLE
Fix magnet assigner prefill for season packs and individual episodes

### DIFF
--- a/routes/magnet_routes.py
+++ b/routes/magnet_routes.py
@@ -360,8 +360,10 @@ def assign_magnet():
         prefill_version = request.args.get('prefill_version')
         prefill_selection_raw = request.args.get('prefill_selection')
         prefill_seasons_raw = request.args.get('prefill_seasons')
+        prefill_episode_raw = request.args.get('prefill_episode')
         prefill_selection = None
         prefill_seasons_csv = None
+        prefill_episode = None
 
         # Normalize selection type to expected values: 'all', 'seasons', 'episode'
         if prefill_selection_raw:
@@ -393,6 +395,18 @@ def assign_magnet():
             except Exception as e:
                 logging.warning(f"Error processing prefill_seasons '{prefill_seasons_raw}': {e}")
 
+        # Parse episode number
+        if prefill_episode_raw:
+            try:
+                ep = prefill_episode_raw.strip()
+                if ep.isdigit():
+                    prefill_episode = ep
+                    logging.info(f"Prefill episode provided: {prefill_episode}")
+                else:
+                    logging.warning(f"Invalid prefill_episode value: '{prefill_episode_raw}'")
+            except Exception as e:
+                logging.warning(f"Error processing prefill_episode '{prefill_episode_raw}': {e}")
+
         if prefill_id and prefill_type:
             # Determine if prefill_id is IMDb ID or TMDB ID
             id_kind = 'tmdb'  # Default to TMDB
@@ -419,16 +433,17 @@ def assign_magnet():
                 # The helper already formats title, year, posterPath, mediaType, and id (TMDB)
                 # We can directly use this single_result.
                 logging.info(f"Prefilled data via helper: {single_result}, Version: {prefill_version}")
-                return render_template('magnet_assign.html', 
+                return render_template('magnet_assign.html',
                                     search_results=[single_result], # Pass as a list
-                                    search_term=prefill_title or single_result['title'], 
+                                    search_term=prefill_title or single_result['title'],
                                     content_type=single_result['mediaType'], # Use mediaType from helper
                                     step='results',
                                     is_prefilled=True,
                                     prefill_magnet=prefill_magnet,
                                     prefill_version=prefill_version,
                                     prefill_selection=prefill_selection,
-                                    prefill_seasons=prefill_seasons_csv)
+                                    prefill_seasons=prefill_seasons_csv,
+                                    prefill_episode=prefill_episode)
             else:
                 logging.warning(f"Could not fetch details via helper for prefill ID: {prefill_id} ({id_kind.upper()}), Type: {prefill_type}")
                 flash(f'Could not find details for {prefill_title} ({prefill_year}). Please search manually.', 'warning')

--- a/static/js/scraper.js
+++ b/static/js/scraper.js
@@ -236,17 +236,17 @@ function displayEpisodeResults(episodeResults, title, year, version, mediaId, me
         episodeDiv.className = 'episode';
         var options = {year: 'numeric', month: 'long', day: 'numeric' };
         var date = item.air_date ? new Date(item.air_date) : null;
-        episodeDiv.innerHTML = `        
+        episodeDiv.innerHTML = `
             <button ${isRequester ? 'disabled' : ''}><span class="episode-rating">${(item.vote_average || 0).toFixed(1)}</span>
-            <img src="${item.still_path ? `/scraper/tmdb_image/w300${item.still_path}` : '/static/image/placeholder-horizontal.png'}" 
-                alt="${item.episode_title || ''}" 
+            <img src="${item.still_path ? `/scraper/tmdb_image/w300${item.still_path}` : '/static/image/placeholder-horizontal.png'}"
+                alt="${item.episode_title || ''}"
                 class="${item.still_path ? '' : 'placeholder-episode'}">
             <div class="episode-info">
                 <h2 class="episode-title">${item.episode_num}. ${item.episode_title || ''}</h2>
                 <p class="episode-sub">${date ? date.toLocaleDateString("en-US", options) : 'Air date unknown'}</p>
             </div></button>
         `;
-        
+
         // Only add click handler for non-requester users
         if (!isRequester) {
             episodeDiv.onclick = function() {
@@ -267,7 +267,7 @@ function displayEpisodeResults(episodeResults, title, year, version, mediaId, me
             episodeDiv.style.cursor = 'default';
             episodeDiv.style.opacity = '0.8';
         }
-        
+
         gridContainer.appendChild(episodeDiv);
     });
 
@@ -424,16 +424,27 @@ function displayTorrentResults(data, title, year, version, mediaId, mediaType, s
                     assignIcon.onclick = function(e) {
                         e.preventDefault();
                         e.stopPropagation();
-                        const currentVersion = document.getElementById('version-select')?.value || '';
                         const assignUrlParams = new URLSearchParams({
                             prefill_id: mediaId,
                             prefill_type: mediaType,
                             prefill_title: title,
                             prefill_year: year,
-                            prefill_version: currentVersion,
+                            prefill_version: version,
                         });
                         if (torrent.magnet) {
                             assignUrlParams.set('prefill_magnet', torrent.magnet);
+                        }
+                        // Set selection type based on whether this is an episode or season pack
+                        if (season) {
+                            assignUrlParams.set('prefill_seasons', season);
+                            if (episode) {
+                                // Individual episode
+                                assignUrlParams.set('prefill_selection', 'episode');
+                                assignUrlParams.set('prefill_episode', episode);
+                            } else {
+                                // Season pack
+                                assignUrlParams.set('prefill_selection', 'seasons');
+                            }
                         }
                         const assignUrl = `/magnet/assign_magnet?${assignUrlParams.toString()}`;
                         window.location.href = assignUrl;
@@ -508,11 +519,22 @@ function displayTorrentResults(data, title, year, version, mediaId, mediaType, s
                     torrent.magnet_link = torrent.magnet;
                 }
 
-                const currentVersion = document.getElementById('version-select').value;
                 const assignUrlParams = new URLSearchParams({
                     prefill_id: mediaId, prefill_type: mediaType, prefill_title: title,
-                    prefill_year: year, prefill_magnet: torrent.magnet, prefill_version: currentVersion
+                    prefill_year: year, prefill_magnet: torrent.magnet, prefill_version: version
                 });
+                // Set selection type based on whether this is an episode or season pack
+                if (season) {
+                    assignUrlParams.set('prefill_seasons', season);
+                    if (episode) {
+                        // Individual episode
+                        assignUrlParams.set('prefill_selection', 'episode');
+                        assignUrlParams.set('prefill_episode', episode);
+                    } else {
+                        // Season pack
+                        assignUrlParams.set('prefill_selection', 'seasons');
+                    }
+                }
                 const assignUrl = `/magnet/assign_magnet?${assignUrlParams.toString()}`;
 
                 // Create bitrate tooltip for desktop

--- a/templates/magnet_assign.html
+++ b/templates/magnet_assign.html
@@ -98,6 +98,34 @@ document.addEventListener('DOMContentLoaded', function() {
                     selectionType.value = 'seasons';
                     updateSelectionFields('seasons');
                 }
+
+                // Apply prefilled episode after options are ready
+                if (prefillSelection === 'episode' && prefillSeasons) {
+                    const seasonValue = prefillSeasons.split(',')[0]?.trim();
+                    if (seasonValue && data[seasonValue]) {
+                        // Select the prefilled season
+                        seasonSelect.value = seasonValue;
+                        seasonInput.value = seasonValue;
+
+                        // Populate episodes for the selected season
+                        populateEpisodes(data[seasonValue]);
+
+                        // Select the prefilled episode if provided
+                        if (prefillEpisode) {
+                            episodeSelect.value = prefillEpisode;
+                            episodeInput.value = prefillEpisode;
+                        }
+
+                        // Ensure selection type is set
+                        selectionType.value = 'episode';
+                        updateSelectionFields('episode');
+
+                        // Force show magnet fields since we have all values
+                        if (seasonInput.value && episodeInput.value) {
+                            showMagnetFields();
+                        }
+                    }
+                }
             } catch (error) {
                 console.error('Error loading season data:', error);
                 showError('Failed to load season data');
@@ -115,6 +143,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const prefillDataElement = document.getElementById('prefill-data');
         const prefillSelection = (prefillDataElement?.dataset?.prefillSelection || '').trim();
         const prefillSeasons = (prefillDataElement?.dataset?.prefillSeasons || '').trim();
+        const prefillEpisode = (prefillDataElement?.dataset?.prefillEpisode || '').trim();
         const initialSelectionType = prefillSelection || selectionType.value;
         if (prefillSelection) {
             const validValues = ['all','seasons','episode'];
@@ -489,7 +518,8 @@ document.addEventListener('DOMContentLoaded', function() {
      data-is-prefilled="{{ is_prefilled|default(false)|tojson }}"
      data-prefill-version="{{ prefill_version|default('') }}"
      data-prefill-selection="{{ prefill_selection|default('') }}"
-     data-prefill-seasons="{{ prefill_seasons|default('') }}">
+     data-prefill-seasons="{{ prefill_seasons|default('') }}"
+     data-prefill-episode="{{ prefill_episode|default('') }}">
 </div>
 {# --- END HIDDEN DIV --- #}
 


### PR DESCRIPTION
## Summary
- Season packs now prefill with "Seasons" selection type and the specific season pre-selected
- Individual episodes now prefill with "Episode" selection type with season and episode pre-selected
- Use the actual scrape version instead of reading from dropdown (fixes 2160p defaulting to 1080p)
- Fix magnet fields not showing on initial page load for episode prefills

## Changes
- `routes/magnet_routes.py`: Add `prefill_episode` parameter support
- `templates/magnet_assign.html`: Handle episode prefill in `loadSeasonData()`, add data attribute
- `static/js/scraper.js`: Pass season/episode/version correctly to assign URL

## Test plan
- [ ] Scrape for a season pack → click Assign → verify "Seasons" is selected with correct season
- [ ] Scrape for individual episode (e.g., S01E05) → click Assign → verify "Single Episode" selected with S01 and E05 pre-selected
- [ ] Scrape for 2160p version → click Assign → verify version dropdown shows 2160p, not 1080p
- [ ] Verify magnet link field is visible on page load (no need to toggle selection type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)