### PR TITLE
Fix TVDB metadata, TMDB fallback, airtime timezone, and delete bugs

### DIFF
--- a/cli_battery/app/direct_api.py
+++ b/cli_battery/app/direct_api.py
@@ -183,10 +183,10 @@ def _persist_item(imdb_id: str, data: dict, session: SqlAlchemySession):
 
     # Seasons + episodes (shows only)
     if seasons_data and isinstance(seasons_data, dict):
-        _upsert_seasons_and_episodes(item, seasons_data, session)
+        _upsert_seasons_and_episodes(item.id, seasons_data, session)
 
 
-def _upsert_seasons_and_episodes(item: Item, seasons_data: dict, session: SqlAlchemySession):
+def _upsert_seasons_and_episodes(item_id: int, seasons_data: dict, session: SqlAlchemySession):
     """Bulk upsert seasons and episodes using SQLite ON CONFLICT."""
     import iso8601
 
@@ -211,7 +211,7 @@ def _upsert_seasons_and_episodes(item: Item, seasons_data: dict, session: SqlAlc
                 episode_count = 0
 
         season_rows.append({
-            'item_id': item.id,
+            'item_id': item_id,
             'season_number': season_number,
             'episode_count': episode_count,
         })
@@ -246,7 +246,7 @@ def _upsert_seasons_and_episodes(item: Item, seasons_data: dict, session: SqlAlc
 
     season_map = {
         s.season_number: s.id
-        for s in session.query(Season.id, Season.season_number).filter_by(item_id=item.id).all()
+        for s in session.query(Season.id, Season.season_number).filter_by(item_id=item_id).all()
     }
 
     ep_rows = []
@@ -398,36 +398,42 @@ class DirectAPI:
                     selectinload(Item.item_metadata),
                 ).filter_by(imdb_id=imdb_id).first()
 
+                item_id = None
+                md = None
+                stale_value = None
                 if item:
+                    item_id = item.id
                     md = next((m for m in item.item_metadata if m.key == 'release_dates'), None)
+                    if md:
+                        stale_value = md.value
                     if md and not is_stale('movie', item.media_status, item.last_trakt_fetch):
                         try:
                             return json.loads(md.value), 'battery'
                         except (json.JSONDecodeError, TypeError):
                             pass
 
-                # Fetch from metadata provider
+                # Fetch from metadata provider (may open nested sessions, detaching item)
                 releases = _get_metadata_client().get_movie_release_dates(imdb_id)
                 source = _get_metadata_source_name()
                 if releases:
                     # Store if we have an item
-                    if item:
-                        existing = session.query(Metadata).filter_by(item_id=item.id, key='release_dates').first()
+                    if item_id is not None:
+                        existing = session.query(Metadata).filter_by(item_id=item_id, key='release_dates').first()
                         now = datetime.now(_get_local_tz())
                         if existing:
                             existing.value = json.dumps(releases)
                             existing.last_updated = now
                         else:
                             session.add(Metadata(
-                                item_id=item.id, key='release_dates',
+                                item_id=item_id, key='release_dates',
                                 value=json.dumps(releases), provider=source, last_updated=now,
                             ))
                     return releases, source
 
                 # Return stale data if available
-                if item and md:
+                if stale_value is not None:
                     try:
-                        return json.loads(md.value), 'battery'
+                        return json.loads(stale_value), 'battery'
                     except (json.JSONDecodeError, TypeError):
                         pass
                 return None, None
@@ -567,28 +573,35 @@ class DirectAPI:
                     selectinload(Item.seasons).selectinload(Season.episodes),
                 ).filter_by(imdb_id=imdb_id, type='show').first()
 
-                if item and item.seasons and not is_stale('show', item.media_status, item.last_trakt_fetch):
-                    seasons = _format_seasons_from_orm(item.seasons)
-                    if imdb_id == LEGO_MASTERS_US_IMDB_ID:
-                        seasons = _apply_lego_masters_us_season_fix(seasons)
-                    return seasons, 'battery'
+                # Eagerly capture item_id and stale seasons before external calls
+                # that may open nested managed_sessions and detach the item
+                item_id = item.id if item else None
+                stale_seasons = None
+                if item and item.seasons:
+                    if not is_stale('show', item.media_status, item.last_trakt_fetch):
+                        seasons = _format_seasons_from_orm(item.seasons)
+                        if imdb_id == LEGO_MASTERS_US_IMDB_ID:
+                            seasons = _apply_lego_masters_us_season_fix(seasons)
+                        return seasons, 'battery'
+                    stale_seasons = _format_seasons_from_orm(item.seasons)
 
-                # Fetch from metadata provider
+                # Fetch from metadata provider (may open nested sessions)
                 seasons_data, source = _get_metadata_client().get_show_seasons_and_episodes(imdb_id, include_specials=True)
-                if seasons_data and item:
-                    _upsert_seasons_and_episodes(item, seasons_data, session)
-                    item.updated_at = datetime.now(_get_local_tz())
+                if seasons_data and item_id is not None:
+                    _upsert_seasons_and_episodes(item_id, seasons_data, session)
+                    session.query(Item).filter_by(id=item_id).update(
+                        {'updated_at': datetime.now(_get_local_tz())}
+                    )
 
                 if seasons_data:
                     if imdb_id == LEGO_MASTERS_US_IMDB_ID:
                         seasons_data = _apply_lego_masters_us_season_fix(seasons_data)
                     return seasons_data, source
 
-                if item and item.seasons:
-                    seasons = _format_seasons_from_orm(item.seasons)
+                if stale_seasons is not None:
                     if imdb_id == LEGO_MASTERS_US_IMDB_ID:
-                        seasons = _apply_lego_masters_us_season_fix(seasons)
-                    return seasons, 'battery'
+                        stale_seasons = _apply_lego_masters_us_season_fix(stale_seasons)
+                    return stale_seasons, 'battery'
                 return None, None
         except Exception as e:
             logging.error(f"DirectAPI.get_show_seasons {imdb_id}: {e}", exc_info=True)

--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -252,14 +252,38 @@ def _extract_aliases(translations: list) -> dict:
     return dict(aliases)
 
 
-def _format_air_date(date_str: str | None) -> str | None:
-    """Convert TVDB 'YYYY-MM-DD' to ISO 8601 for iso8601.parse_date compatibility."""
+def _format_air_date(date_str: str | None, airs_time: str | None = None,
+                     airs_timezone: str | None = None) -> str | None:
+    """Convert TVDB 'YYYY-MM-DD' to ISO 8601 UTC datetime.
+
+    TVDB episode dates are in the show's local timezone (date-only).  When
+    *airs_time* (HH:MM) and *airs_timezone* (IANA tz name) are provided we
+    combine them with the date to produce a proper UTC timestamp, matching what
+    Trakt returns.  Otherwise we fall back to midnight UTC.
+    """
     if not date_str:
         return None
-    # Already ISO 8601 format
+    # Already ISO 8601 format with time component
     if 'T' in date_str:
         return date_str
-    # YYYY-MM-DD → YYYY-MM-DDT00:00:00.000Z
+
+    if airs_time and airs_timezone:
+        try:
+            from zoneinfo import ZoneInfo
+            # Parse "HH:MM" (or "HH:MM:SS")
+            parts = airs_time.split(':')
+            hour = int(parts[0])
+            minute = int(parts[1]) if len(parts) > 1 else 0
+            show_tz = ZoneInfo(airs_timezone)
+            naive_dt = datetime.strptime(date_str[:10], '%Y-%m-%d').replace(
+                hour=hour, minute=minute)
+            local_dt = naive_dt.replace(tzinfo=show_tz)
+            utc_dt = local_dt.astimezone(timezone.utc)
+            return utc_dt.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+        except Exception:
+            pass  # Fall through to midnight UTC
+
+    # Fallback — no airs info available
     return f"{date_str}T00:00:00.000Z"
 
 
@@ -277,7 +301,10 @@ def get_show_data(imdb_id: str) -> Optional[dict]:
     """Get full show metadata + aliases + seasons/episodes."""
     tvdb_id = _resolve_tvdb_id(imdb_id, media_type='show')
     if not tvdb_id:
-        logger.warning(f"TVDB: could not resolve IMDb {imdb_id} to TVDB ID")
+        logger.warning(f"TVDB: could not resolve IMDb {imdb_id} to TVDB ID, trying TMDB fallback")
+        tmdb_api_key = _get_tmdb_api_key()
+        if tmdb_api_key:
+            return _fetch_tmdb_show_data(imdb_id, tmdb_api_key)
         return None
 
     url = f"{TVDB_BASE_URL}/series/{tvdb_id}/extended?meta=translations,episodes"
@@ -395,6 +422,11 @@ def _extract_seasons_from_extended(raw: dict) -> Optional[dict]:
     if not seasons_raw:
         return None
 
+    # Extract show-level airs info for proper datetime construction
+    airs_time = raw.get('airsTime')  # e.g. "20:00"
+    network = raw.get('originalNetwork')
+    airs_timezone = network.get('timezone', 'America/New_York') if isinstance(network, dict) else None
+
     # Group episodes by season number
     eps_by_season: defaultdict = defaultdict(list)
     if episodes_raw:
@@ -430,7 +462,7 @@ def _extract_seasons_from_extended(raw: dict) -> Optional[dict]:
                 'title': ep.get('name', ''),
                 'overview': ep.get('overview', ''),
                 'runtime': ep.get('runtime', 0),
-                'first_aired': _format_air_date(ep.get('aired')),
+                'first_aired': _format_air_date(ep.get('aired'), airs_time, airs_timezone),
                 'imdb_id': None,  # TVDB doesn't provide per-episode IMDb IDs
                 'absolute': ep.get('absoluteNumber'),
             }
@@ -458,9 +490,14 @@ def get_show_seasons_and_episodes(imdb_id: str, include_specials: bool = False) 
     raw = resp.json().get('data', {})
     seasons = _extract_seasons_from_extended(raw)
 
+    # Extract airs info for paginated fallback
+    airs_time = raw.get('airsTime')
+    network = raw.get('originalNetwork')
+    airs_timezone = network.get('timezone', 'America/New_York') if isinstance(network, dict) else None
+
     if not seasons:
         # Fallback: paginated episodes endpoint
-        seasons = _fetch_episodes_paginated(tvdb_id)
+        seasons = _fetch_episodes_paginated(tvdb_id, airs_time, airs_timezone)
 
     if seasons and not include_specials:
         seasons.pop(0, None)
@@ -468,7 +505,8 @@ def get_show_seasons_and_episodes(imdb_id: str, include_specials: bool = False) 
     return seasons, 'tvdb' if seasons else None
 
 
-def _fetch_episodes_paginated(tvdb_id: int) -> Optional[dict]:
+def _fetch_episodes_paginated(tvdb_id: int, airs_time: str | None = None,
+                              airs_timezone: str | None = None) -> Optional[dict]:
     """Fetch episodes via the paginated /episodes/default endpoint."""
     all_episodes: list = []
     page = 0
@@ -513,7 +551,7 @@ def _fetch_episodes_paginated(tvdb_id: int) -> Optional[dict]:
                 'title': ep.get('name', ''),
                 'overview': ep.get('overview', ''),
                 'runtime': ep.get('runtime', 0),
-                'first_aired': _format_air_date(ep.get('aired')),
+                'first_aired': _format_air_date(ep.get('aired'), airs_time, airs_timezone),
                 'imdb_id': None,
                 'absolute': ep.get('absoluteNumber'),
             }
@@ -546,7 +584,10 @@ def get_movie_data(imdb_id: str) -> Optional[dict]:
     """Get full movie metadata + aliases + release dates."""
     tvdb_id = _resolve_tvdb_id(imdb_id, media_type='movie')
     if not tvdb_id:
-        logger.warning(f"TVDB: could not resolve IMDb {imdb_id} to TVDB movie ID")
+        logger.warning(f"TVDB: could not resolve IMDb {imdb_id} to TVDB movie ID, trying TMDB fallback")
+        tmdb_api_key = _get_tmdb_api_key()
+        if tmdb_api_key:
+            return _fetch_tmdb_movie_data(imdb_id, tmdb_api_key)
         return None
 
     url = f"{TVDB_BASE_URL}/movies/{tvdb_id}/extended?meta=translations"
@@ -757,8 +798,8 @@ def _fetch_tmdb_release_dates(tmdb_id: int, api_key: str) -> Optional[dict]:
         return None
 
 
-def _resolve_tmdb_id_from_imdb(imdb_id: str, api_key: str) -> Optional[int]:
-    """Resolve an IMDb ID to a TMDB movie ID via TMDB's /find endpoint."""
+def _resolve_tmdb_id_from_imdb(imdb_id: str, api_key: str, media_type: str = 'movie') -> Optional[int]:
+    """Resolve an IMDb ID to a TMDB ID via TMDB's /find endpoint."""
     try:
         resp = requests.get(
             f"https://api.themoviedb.org/3/find/{imdb_id}",
@@ -769,12 +810,138 @@ def _resolve_tmdb_id_from_imdb(imdb_id: str, api_key: str) -> Optional[int]:
             return None
 
         data = resp.json()
-        movie_results = data.get('movie_results', [])
-        if movie_results:
-            return movie_results[0].get('id')
+        if media_type == 'show':
+            tv_results = data.get('tv_results', [])
+            if tv_results:
+                return tv_results[0].get('id')
+        else:
+            movie_results = data.get('movie_results', [])
+            if movie_results:
+                return movie_results[0].get('id')
         return None
     except Exception as e:
         logger.debug(f"TMDB find by IMDb error for {imdb_id}: {e}")
+        return None
+
+
+def _get_tmdb_api_key() -> str:
+    """Return the configured TMDB API key, or empty string."""
+    try:
+        from utilities.settings import get_setting
+        return get_setting('TMDB', 'api_key', default='') or ''
+    except Exception:
+        return ''
+
+
+def _fetch_tmdb_movie_data(imdb_id: str, api_key: str) -> Optional[dict]:
+    """Fetch movie metadata from TMDB as fallback when TVDB cannot resolve the ID."""
+    tmdb_id = _resolve_tmdb_id_from_imdb(imdb_id, api_key, media_type='movie')
+    if not tmdb_id:
+        return None
+
+    try:
+        resp = requests.get(
+            f"https://api.themoviedb.org/3/movie/{tmdb_id}",
+            params={'api_key': api_key},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            return None
+
+        raw = resp.json()
+        year = None
+        release_date = raw.get('release_date', '')
+        if release_date and len(release_date) >= 4:
+            try:
+                year = int(release_date[:4])
+            except ValueError:
+                pass
+
+        status_raw = (raw.get('status') or '').lower()
+        status = 'released' if status_raw == 'released' else status_raw
+
+        genres = [g.get('name', '') for g in raw.get('genres', []) if isinstance(g, dict)]
+
+        data = {
+            'title': raw.get('title', ''),
+            'year': year,
+            'ids': {'imdb': imdb_id, 'tmdb': tmdb_id},
+            'overview': raw.get('overview', ''),
+            'runtime': raw.get('runtime'),
+            'status': status,
+            'genres': genres,
+            'type': 'movie',
+        }
+
+        logger.info(f"TMDB fallback: got movie metadata for {imdb_id} (tmdb_id={tmdb_id})")
+        return data
+    except Exception as e:
+        logger.debug(f"TMDB movie data error for {imdb_id}: {e}")
+        return None
+
+
+def _fetch_tmdb_show_data(imdb_id: str, api_key: str) -> Optional[dict]:
+    """Fetch show metadata from TMDB as fallback when TVDB cannot resolve the ID."""
+    tmdb_id = _resolve_tmdb_id_from_imdb(imdb_id, api_key, media_type='show')
+    if not tmdb_id:
+        return None
+
+    try:
+        resp = requests.get(
+            f"https://api.themoviedb.org/3/tv/{tmdb_id}",
+            params={'api_key': api_key},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            return None
+
+        raw = resp.json()
+        year = None
+        first_air = raw.get('first_air_date', '')
+        if first_air and len(first_air) >= 4:
+            try:
+                year = int(first_air[:4])
+            except ValueError:
+                pass
+
+        status_raw = (raw.get('status') or '').lower()
+        status_map = {
+            'returning series': 'returning series',
+            'ended': 'ended',
+            'canceled': 'canceled',
+            'in production': 'in production',
+        }
+        status = status_map.get(status_raw, status_raw)
+
+        genres = [g.get('name', '') for g in raw.get('genres', []) if isinstance(g, dict)]
+
+        # Build seasons dict
+        seasons = {}
+        for s in raw.get('seasons', []):
+            sn = s.get('season_number')
+            if sn is not None:
+                seasons[str(sn)] = {
+                    'number': sn,
+                    'episode_count': s.get('episode_count', 0),
+                    'episodes': {},
+                }
+
+        data = {
+            'title': raw.get('name', ''),
+            'year': year,
+            'ids': {'imdb': imdb_id, 'tmdb': tmdb_id},
+            'overview': raw.get('overview', ''),
+            'runtime': (raw.get('episode_run_time') or [None])[0],
+            'status': status,
+            'genres': genres,
+            'type': 'show',
+            'seasons': seasons,
+        }
+
+        logger.info(f"TMDB fallback: got show metadata for {imdb_id} (tmdb_id={tmdb_id})")
+        return data
+    except Exception as e:
+        logger.debug(f"TMDB show data error for {imdb_id}: {e}")
         return None
 
 
@@ -785,7 +952,17 @@ def get_movie_release_dates(imdb_id: str) -> Optional[dict]:
     (digital, physical, etc.) when a TMDB API key is configured.
     """
     tvdb_id = _resolve_tvdb_id(imdb_id, media_type='movie')
+    tmdb_api_key = _get_tmdb_api_key()
+
     if not tvdb_id:
+        # TVDB can't resolve — try TMDB-only release dates
+        if tmdb_api_key:
+            tmdb_id = _resolve_tmdb_id_from_imdb(imdb_id, tmdb_api_key, media_type='movie')
+            if tmdb_id:
+                releases = _fetch_tmdb_release_dates(tmdb_id, tmdb_api_key)
+                if releases:
+                    logger.info(f"TMDB fallback: got release dates for {imdb_id} (tmdb_id={tmdb_id})")
+                    return releases
         return None
 
     url = f"{TVDB_BASE_URL}/movies/{tvdb_id}/extended"
@@ -795,13 +972,6 @@ def get_movie_release_dates(imdb_id: str) -> Optional[dict]:
 
     raw = resp.json().get('data', {})
     releases = _extract_movie_releases(raw) or {}
-
-    # Supplement with TMDB typed release dates if API key is available
-    try:
-        from utilities.settings import get_setting
-        tmdb_api_key = get_setting('TMDB', 'api_key', default='')
-    except Exception:
-        tmdb_api_key = ''
 
     if tmdb_api_key:
         # Try to get TMDB ID from TVDB remoteIds first
@@ -824,6 +994,7 @@ def get_movie_release_dates(imdb_id: str) -> Optional[dict]:
 
         if tmdb_id:
             tmdb_releases = _fetch_tmdb_release_dates(tmdb_id, tmdb_api_key)
+            logger.debug(f"TMDB supplement for {imdb_id} (tmdb_id={tmdb_id}): {tmdb_releases}")
             if tmdb_releases:
                 # Merge: for each country, add TMDB releases for types not already present
                 for country, tmdb_entries in tmdb_releases.items():
@@ -834,6 +1005,8 @@ def get_movie_release_dates(imdb_id: str) -> Optional[dict]:
                     for entry in tmdb_entries:
                         if (entry.get('type') or '').lower() not in existing_types:
                             releases.setdefault(country, []).append(entry)
+        else:
+            logger.debug(f"TMDB supplement for {imdb_id}: could not resolve TMDB ID")
 
     return releases if releases else None
 

--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -166,7 +166,10 @@ def _resolve_tvdb_id(imdb_id: str, media_type: str = None) -> Optional[int]:
     """IMDb → TVDB ID, cached in TVDBToIMDBMapping table."""
     # Check cache first
     with managed_session() as session:
-        mapping = session.query(TVDBToIMDBMapping).filter_by(imdb_id=imdb_id).first()
+        query = session.query(TVDBToIMDBMapping).filter_by(imdb_id=imdb_id)
+        if media_type:
+            query = query.filter_by(media_type=media_type)
+        mapping = query.first()
         if mapping:
             return int(mapping.tvdb_id)
 
@@ -209,15 +212,16 @@ def _resolve_tvdb_id(imdb_id: str, media_type: str = None) -> Optional[int]:
                 _cache_tvdb_mapping(str(tvdb_id), imdb_id, detected_type)
                 return int(tvdb_id)
 
-    # Last resort: take the first result with any ID
-    for item in data:
-        for key in ('series', 'movie'):
-            inner = item.get(key)
-            if isinstance(inner, dict) and inner.get('id'):
-                tvdb_id = inner['id']
-                detected_type = 'show' if key == 'series' else 'movie'
-                _cache_tvdb_mapping(str(tvdb_id), imdb_id, detected_type)
-                return int(tvdb_id)
+    # Last resort: take the first result with any ID (only when no type filter)
+    if not media_type:
+        for item in data:
+            for key in ('series', 'movie'):
+                inner = item.get(key)
+                if isinstance(inner, dict) and inner.get('id'):
+                    tvdb_id = inner['id']
+                    detected_type = 'show' if key == 'series' else 'movie'
+                    _cache_tvdb_mapping(str(tvdb_id), imdb_id, detected_type)
+                    return int(tvdb_id)
 
     return None
 
@@ -607,8 +611,24 @@ def get_movie_data(imdb_id: str) -> Optional[dict]:
     if aliases:
         data['aliases'] = aliases
 
-    # Release dates
-    releases = _extract_movie_releases(raw)
+    # Release dates (TVDB + TMDB supplement)
+    releases = _extract_movie_releases(raw) or {}
+    tmdb_api_key = _get_tmdb_api_key()
+    if tmdb_api_key:
+        tmdb_id = data.get('ids', {}).get('tmdb')
+        if not tmdb_id:
+            tmdb_id = _resolve_tmdb_id_from_imdb(imdb_id, tmdb_api_key, media_type='movie')
+        if tmdb_id:
+            tmdb_releases = _fetch_tmdb_release_dates(tmdb_id, tmdb_api_key)
+            if tmdb_releases:
+                for country, tmdb_entries in tmdb_releases.items():
+                    existing_types = {
+                        (r.get('type') or '').lower()
+                        for r in releases.get(country, [])
+                    }
+                    for entry in tmdb_entries:
+                        if (entry.get('type') or '').lower() not in existing_types:
+                            releases.setdefault(country, []).append(entry)
     if releases:
         data['release_dates'] = releases
 

--- a/metadata/metadata.py
+++ b/metadata/metadata.py
@@ -291,25 +291,30 @@ def create_episode_item(show_item: Dict[str, Any], season_number: int, episode_n
             # Keep release_date as 'Unknown' and airtime as default '19:00'
     else:
         # No first_aired string, try to use show's default airtime if available
+        # Convert from the show's network timezone to the user's local timezone
         airs = show_item.get('airs', {})
         default_airtime_str = airs.get('time')
+        show_timezone_str = airs.get('timezone')
         if default_airtime_str:
             try:
-                 # Try parsing with seconds first (HH:MM:SS)
                 try:
                     air_time_obj = datetime.strptime(default_airtime_str, "%H:%M:%S").time()
                 except ValueError:
-                    # If that fails, try without seconds (HH:MM)
                     air_time_obj = datetime.strptime(default_airtime_str, "%H:%M").time()
-                airtime = air_time_obj.strftime("%H:%M")
-                # logging.debug(f"Using show's default airtime: {airtime} as fallback.")
+
+                if show_timezone_str:
+                    try:
+                        show_tz = ZoneInfo(show_timezone_str)
+                        today = datetime.now().date()
+                        show_air_dt = datetime.combine(today, air_time_obj).replace(tzinfo=show_tz)
+                        local_air_dt = show_air_dt.astimezone(_get_local_timezone())
+                        airtime = local_air_dt.strftime("%H:%M")
+                    except Exception:
+                        airtime = air_time_obj.strftime("%H:%M")
+                else:
+                    airtime = air_time_obj.strftime("%H:%M")
             except ValueError:
                  logging.warning(f"Invalid show default airtime format: {default_airtime_str}. Using default 19:00.")
-                 # airtime remains '19:00'
-        else:
-            # logging.debug("No first_aired data and no default show airtime. Using default 19:00.")
-            # airtime remains '19:00'
-            pass
 
     episode_item = {
         'imdb_id': show_item['imdb_id'],
@@ -960,8 +965,8 @@ def get_release_date(media_details: Dict[str, Any], imdb_id: Optional[str] = Non
         logging.warning(f"No release dates found for IMDb ID: {imdb_id}")
         return media_details.get('released', 'Unknown')
 
-    #logging.debug(f"Release dates: {release_dates}")
-    
+    logging.debug(f"Release dates for {imdb_id}: {release_dates}")
+
     current_date = datetime.now()
     digital_physical_releases = []
     theatrical_releases = []
@@ -1016,7 +1021,11 @@ def get_release_date(media_details: Dict[str, Any], imdb_id: Optional[str] = Non
         return max(old_premiere_releases).strftime("%Y-%m-%d")
 
     # If we've reached this point, there are no suitable release dates
-    logging.warning(f"No valid release date found for IMDb ID: {imdb_id}.")
+    logging.warning(f"No valid release date found for IMDb ID: {imdb_id}. "
+                    f"digital/physical={len(digital_physical_releases)}, "
+                    f"theatrical={len(theatrical_releases)}, "
+                    f"premiere={len(premiere_releases)}, "
+                    f"all={len(all_releases)}")
     return "Unknown"
 
 def parse_date(date_str: Optional[str]) -> Optional[str]:

--- a/routes/database_routes.py
+++ b/routes/database_routes.py
@@ -1319,7 +1319,6 @@ def delete_item():
                             logging.warning(f"Delete item: Direct Plex removal failed for {item['title']}. Trying scan & empty trash...")
                             try:
                                 # Determine section type based on item type
-                                import os
                                 section_type = 'movie' if item.get('type') == 'movie' else 'show'
                                 scan_paths = [os.path.dirname(path_to_remove_from_plex)] if path_to_remove_from_plex else None
                                 scan_and_empty_plex_trash(paths=scan_paths, section_type=section_type)
@@ -1390,9 +1389,8 @@ def delete_item():
                             logging.warning(f"Delete item: Direct Plex removal failed for {item['title']}. Trying scan & empty trash...")
                             try:
                                 # Determine section type based on item type
-                                import os
                                 section_type = 'movie' if item.get('type') == 'movie' else 'show'
-                                scan_paths = [os.path.dirname(path_to_remove_from_plex)] if path_to_remove_from_plex else None
+                                scan_paths = [os.path.dirname(path_for_plex_api_call)] if path_for_plex_api_call else None
                                 scan_and_empty_plex_trash(paths=scan_paths, section_type=section_type)
                                 logging.info(f"Delete item: Triggered library scan and trash empty for {item['title']} (section_type={section_type}).")
                             except Exception as scan_err:


### PR DESCRIPTION
## Summary
- **DetachedInstanceError fix**: Eagerly capture `item.id` and stale data before external calls in `DirectAPI.get_movie_release_dates` and `get_show_seasons` that open nested `managed_session`s, which destroy the scoped session and detach ORM objects
- **TMDB fallback**: When TVDB cannot resolve an IMDb ID, fall back to TMDB for movie/show metadata and release dates (requires TMDB API key in settings)
- **TVDB airtime timezone fix**: Episode `first_aired` dates from TVDB (date-only `YYYY-MM-DD`) are now combined with the show's `airsTime` and network timezone to produce correct UTC datetimes, matching Trakt's behavior
- **Airtime fallback fix**: `create_episode_item` now converts `airs.time` from the show's network timezone to the user's local timezone instead of using the raw value directly
- **Delete item fixes**: Fixed `path_to_remove_from_plex` variable name bug in Symlinked/Local mode, and removed local `import os` statements that shadowed the module-level import causing `cannot access local variable 'os'` errors

## How to test

### DetachedInstanceError fix
- Use TVDB as metadata source
- Trigger movie release date lookups and show season fetches
- Confirm no `DetachedInstanceError` / `is not bound to a Session` errors in logs

### TMDB fallback
- Use TVDB as metadata source with a TMDB API key configured
- Add movies/shows that exist on TMDB but not TVDB (e.g. newer or obscure titles)
- Confirm `TMDB fallback: got movie metadata` / `TMDB fallback: got release dates` appears in logs
- Verify metadata is returned instead of `No metadata returned for IMDb ID` warnings

### TVDB airtime timezone
- Use TVDB as metadata source
- Check episode `first_aired` values in battery DB — should now be full UTC datetimes (e.g. `2025-02-11T02:00:00.000Z` for a 9PM ET show) instead of `2025-02-10T00:00:00.000Z`
- Verify episode airtimes in the UI reflect the correct local time for the user's timezone

### Delete item
- Delete collected items in Symlinked/Local mode
- Confirm no `cannot access local variable 'os'` or `cannot access local variable 'path_to_remove_from_plex'` errors
- Verify symlinks and Plex entries are cleaned up properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)