### PR TITLE
fix: episode filename truncation for extremely long titles

### DIFF
--- a/tests/test_filename_truncation.py
+++ b/tests/test_filename_truncation.py
@@ -1,0 +1,793 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the component-based filename truncation logic.
+
+These tests are self-contained and don't rely on importing the full project,
+which avoids configuration and dependency issues during testing.
+"""
+
+import unittest
+import sys
+import os
+import re
+
+# Add the project root to the path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# Copy the functions we want to test directly here to avoid import issues
+# This allows testing the logic in isolation
+
+def _clean_separators_in_string(s: str) -> str:
+    """
+    Clean up orphaned separators (like ' - ', ' () ', empty brackets) in a string.
+    This is used after removing template components to clean up the resulting string.
+    """
+    # Remove empty parentheses with surrounding spaces/dashes
+    s = re.sub(r'\s*-\s*\(\s*\)', '', s)
+    s = re.sub(r'\(\s*\)', '', s)
+    # Remove empty square brackets with surrounding spaces/dashes
+    s = re.sub(r'\s*-\s*\[\s*\]', '', s)
+    s = re.sub(r'\[\s*\]', '', s)
+    # Remove orphaned dashes (consecutive or leading/trailing)
+    s = re.sub(r'\s*-\s*-\s*', ' - ', s)
+    s = re.sub(r'^\s*-\s*', '', s)
+    s = re.sub(r'\s*-\s*$', '', s)
+    # Remove multiple consecutive spaces
+    s = re.sub(r'\s{2,}', ' ', s)
+    return s.strip()
+
+
+def sanitize_filename(filename: str) -> str:
+    """Simplified sanitize_filename for testing."""
+    import unicodedata
+    filename = unicodedata.normalize('NFKD', filename).encode('ascii', 'ignore').decode('ascii')
+    filename = re.sub(r'[<>|?*:"\'\&/\\]', '_', filename)
+    return filename.strip()
+
+
+def truncate_path_components(
+    template: str,
+    template_vars: dict,
+    base_path: str,
+    directory_parts: list,
+    extension: str,
+    max_path_length: int = 255
+) -> str:
+    """
+    Intelligently truncate filename components to fit within max_path_length.
+
+    This function systematically removes or truncates components in priority order:
+    1. Remove {original_filename} (lowest priority)
+    2. Remove {content_source}
+    3. Remove {tmdb_id}
+    4. Remove {resolution}
+    5. Remove {version}
+    6. Truncate {episode_title}
+    7. Remove {imdb_id}
+    8. Truncate {title} (last resort)
+
+    Critical info (NEVER removed/truncated):
+    - {season_number}, {episode_number}
+    - {year}, {season_year}
+    """
+    # Define the priority order for removal (low priority first)
+    removal_priority = [
+        'original_filename',
+        'content_source',
+        'tmdb_id',
+        'resolution',
+        'version',
+    ]
+
+    # Define components that can be truncated (in order)
+    truncatable_components = [
+        'episode_title',
+        'imdb_id',  # Remove imdb_id before truncating title
+        'title',
+    ]
+
+    # Create a working copy of template_vars
+    working_vars = dict(template_vars)
+
+    def calculate_full_path(filename_part: str) -> str:
+        """Calculate the full path given a filename part."""
+        dir_path = os.path.join(base_path, *directory_parts) if directory_parts else base_path
+        return os.path.join(dir_path, filename_part)
+
+    def format_and_sanitize() -> str:
+        """Format the template with current vars and sanitize."""
+        try:
+            formatted = template.format(**working_vars)
+        except KeyError:
+            formatted = template
+
+        # Clean up orphaned separators
+        formatted = _clean_separators_in_string(formatted)
+
+        # Sanitize the filename
+        sanitized = sanitize_filename(formatted)
+
+        # Ensure extension is present
+        if not sanitized.endswith(extension):
+            sanitized += extension
+
+        return sanitized
+
+    def get_current_length() -> int:
+        """Get the current full path length."""
+        sanitized = format_and_sanitize()
+        full_path = calculate_full_path(sanitized)
+        return len(full_path)
+
+    # Check if path is already valid
+    if get_current_length() <= max_path_length:
+        return format_and_sanitize()
+
+    # Phase 1: Remove components in priority order
+    for component in removal_priority:
+        if component in working_vars and working_vars[component]:
+            working_vars[component] = ''
+
+            current_length = get_current_length()
+            if current_length <= max_path_length:
+                return format_and_sanitize()
+
+    # Phase 2: Truncate components in priority order
+    for component in truncatable_components:
+        if component == 'imdb_id':
+            # Special case: remove imdb_id completely before truncating title
+            if component in working_vars and working_vars[component]:
+                working_vars[component] = ''
+
+                current_length = get_current_length()
+                if current_length <= max_path_length:
+                    return format_and_sanitize()
+            continue
+
+        if component in working_vars and working_vars[component]:
+            original_value = str(working_vars[component])
+            if len(original_value) <= 4:  # Too short to truncate meaningfully
+                continue
+
+            excess = get_current_length() - max_path_length
+            chars_to_remove = excess + 3
+
+            if len(original_value) > chars_to_remove:
+                truncated_value = original_value[:-(chars_to_remove)] + '...'
+                working_vars[component] = truncated_value
+
+                current_length = get_current_length()
+                if current_length <= max_path_length:
+                    return format_and_sanitize()
+                else:
+                    # More aggressive truncation
+                    min_length = 13
+                    while len(working_vars[component]) > min_length:
+                        working_vars[component] = working_vars[component][:-4] + '...'
+                        current_length = get_current_length()
+                        if current_length <= max_path_length:
+                            return format_and_sanitize()
+
+    # Fall back to legacy truncation as a last resort
+    sanitized = format_and_sanitize()
+    full_path = calculate_full_path(sanitized)
+
+    if len(full_path) > max_path_length:
+        excess = len(full_path) - max_path_length
+        filename_without_ext = os.path.splitext(sanitized)[0]
+        if len(filename_without_ext) > excess + 3:
+            truncated_filename = filename_without_ext[:-(excess + 3)] + "..."
+            sanitized = truncated_filename + extension
+
+    return sanitized
+
+
+class TestCleanSeparators(unittest.TestCase):
+    """Tests for the _clean_separators_in_string helper function."""
+
+    def test_removes_empty_parentheses(self):
+        """Empty parentheses should be removed."""
+        result = _clean_separators_in_string("Title () - Version")
+        self.assertNotIn("()", result)
+        self.assertIn("Title", result)
+        self.assertIn("Version", result)
+
+    def test_removes_dash_with_empty_parentheses(self):
+        """Dash followed by empty parentheses should be removed."""
+        result = _clean_separators_in_string("Title - () - Version")
+        self.assertNotIn("()", result)
+        self.assertEqual(result, "Title - Version")
+
+    def test_removes_empty_brackets(self):
+        """Empty square brackets should be removed."""
+        result = _clean_separators_in_string("Title [] - Version")
+        self.assertNotIn("[]", result)
+
+    def test_removes_orphaned_leading_dash(self):
+        """Leading dashes should be removed."""
+        result = _clean_separators_in_string(" - Title")
+        self.assertEqual(result, "Title")
+
+    def test_removes_orphaned_trailing_dash(self):
+        """Trailing dashes should be removed."""
+        result = _clean_separators_in_string("Title - ")
+        self.assertEqual(result, "Title")
+
+    def test_collapses_consecutive_dashes(self):
+        """Consecutive dashes should be collapsed."""
+        result = _clean_separators_in_string("Title - - Version")
+        self.assertEqual(result, "Title - Version")
+
+    def test_collapses_multiple_spaces(self):
+        """Multiple spaces should be collapsed to single space."""
+        result = _clean_separators_in_string("Title    Version")
+        self.assertEqual(result, "Title Version")
+
+
+class TestTruncatePathComponents(unittest.TestCase):
+    """Tests for the truncate_path_components function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.base_path = "/media/symlinks"
+        self.extension = ".mkv"
+
+    def test_path_already_short_enough(self):
+        """A path that is already short enough should not be modified."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d} - {episode_title}"
+        template_vars = {
+            'title': 'Short Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 5,
+            'episode_title': 'Pilot',
+            'imdb_id': 'tt1234567',
+            'version': '1080p',
+            'original_filename': 'source.file',
+            'content_source': 'usenet',
+            'tmdb_id': '12345',
+            'resolution': '1080p',
+        }
+        directory_parts = ['TV Shows', 'Short Show (2024)', 'Season 01']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        # The result should contain the essential information
+        self.assertIn('Short Show', result)
+        self.assertIn('2024', result)
+        self.assertIn('S01E05', result)
+        self.assertIn('Pilot', result)
+        self.assertTrue(result.endswith('.mkv'))
+
+    def test_removes_original_filename_first(self):
+        """original_filename should be removed first when path is too long."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d} - {episode_title} - {version} - ({original_filename})"
+        template_vars = {
+            'title': 'A Very Long Show Title That Takes Up Space',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 5,
+            'episode_title': 'The Episode With A Very Long Title',
+            'imdb_id': 'tt1234567',
+            'version': '1080p.BluRay.x264',
+            'original_filename': 'This.Is.A.Very.Long.Original.Filename.That.Should.Be.Removed.First',
+            'content_source': 'usenet',
+            'tmdb_id': '12345',
+            'resolution': '1080p',
+        }
+        directory_parts = ['TV Shows', 'A Very Long Show Title That Takes Up Space (2024)', 'Season 01']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=200
+        )
+
+        # original_filename should be removed
+        self.assertNotIn('This.Is.A.Very.Long.Original.Filename', result)
+        # Critical info should still be present
+        self.assertIn('S01E05', result)
+        self.assertIn('2024', result)
+
+    def test_removes_multiple_components(self):
+        """Multiple components should be removed in priority order."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d} - {episode_title} - {imdb_id} - {tmdb_id} - {version} - {resolution} - ({original_filename})"
+        template_vars = {
+            'title': 'A Very Long Show Title',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 5,
+            'episode_title': 'Episode Title',
+            'imdb_id': 'tt1234567',
+            'version': '1080p.BluRay',
+            'original_filename': 'Original.File.Name',
+            'content_source': 'usenet',
+            'tmdb_id': '12345',
+            'resolution': '1080p',
+        }
+        directory_parts = ['TV Shows', 'A Very Long Show Title (2024)', 'Season 01']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=150
+        )
+
+        # The essential info should still be there
+        self.assertIn('S01E05', result)
+        self.assertIn('2024', result)
+        # At this low limit, several components should be removed
+        full_path_length = len(os.path.join(self.base_path, *directory_parts, result))
+        self.assertLessEqual(full_path_length, 150)
+
+    def test_truncates_episode_title(self):
+        """Episode title should be truncated if removal isn't sufficient."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d} - {episode_title}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 5,
+            'episode_title': 'This Is A Very Long Episode Title That Should Be Truncated To Fit The Path Length Limit',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows', 'Show (2024)', 'Season 01']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=100
+        )
+
+        # Critical info should still be present
+        self.assertIn('S01E05', result)
+        self.assertIn('2024', result)
+        self.assertIn('Show', result)
+        full_path_length = len(os.path.join(self.base_path, *directory_parts, result))
+        self.assertLessEqual(full_path_length, 100)
+
+    def test_truncates_title_as_last_resort(self):
+        """Title should only be truncated as a last resort."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d}"
+        template_vars = {
+            'title': 'This Is An Extremely Long Show Title That Will Need To Be Truncated As A Last Resort',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 5,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows', 'This Is An Extremely Long Show Title (2024)', 'Season 01']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=120
+        )
+
+        # Critical info should still be present
+        self.assertIn('S01E05', result)
+        self.assertIn('2024', result)
+        full_path_length = len(os.path.join(self.base_path, *directory_parts, result))
+        self.assertLessEqual(full_path_length, 120)
+
+    def test_preserves_season_episode_numbers(self):
+        """Season and episode numbers should NEVER be removed or truncated."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d} - {episode_title} - {version}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 12,
+            'episode_number': 99,
+            'episode_title': 'Episode Title',
+            'imdb_id': 'tt1234567',
+            'version': '1080p',
+            'original_filename': 'source',
+            'content_source': 'usenet',
+            'tmdb_id': '12345',
+            'resolution': '1080p',
+        }
+        directory_parts = ['TV Shows', 'Show (2024)', 'Season 12']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=100
+        )
+
+        # Season and episode numbers must be present
+        self.assertIn('S12E99', result)
+        self.assertIn('2024', result)
+
+    def test_preserves_year(self):
+        """Year should NEVER be removed or truncated."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d}"
+        template_vars = {
+            'title': 'Show Title',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        self.assertIn('2024', result)
+
+    def test_movie_template_truncation(self):
+        """Movie templates should also be handled correctly."""
+        template = "{title} ({year}) - {imdb_id} - {version} - ({original_filename})"
+        template_vars = {
+            'title': 'A Very Long Movie Title That Might Need Truncation',
+            'year': '2024',
+            'imdb_id': 'tt1234567',
+            'version': '1080p.BluRay.x264.DTS',
+            'original_filename': 'A.Very.Long.Original.Filename.That.Should.Be.Removed',
+            'content_source': 'usenet',
+            'tmdb_id': '12345',
+            'resolution': '1080p',
+        }
+        directory_parts = ['Movies', 'A Very Long Movie Title That Might Need Truncation (2024)']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=180
+        )
+
+        # Year should be preserved, original_filename should be removed first
+        self.assertIn('2024', result)
+        full_path_length = len(os.path.join(self.base_path, *directory_parts, result))
+        self.assertLessEqual(full_path_length, 180)
+
+    def test_handles_empty_optional_fields(self):
+        """Empty optional fields should be handled gracefully."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d} - {episode_title} - {imdb_id} - {version}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows', 'Show (2024)', 'Season 01']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        # Should handle empty fields without error
+        self.assertIn('Show', result)
+        self.assertIn('2024', result)
+        self.assertIn('S01E01', result)
+        self.assertTrue(result.endswith('.mkv'))
+
+    def test_extension_always_present(self):
+        """The file extension should always be present in the result."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=".mkv",
+            max_path_length=255
+        )
+
+        self.assertTrue(result.endswith('.mkv'))
+
+    def test_content_source_removed_before_tmdb_id(self):
+        """Content source should be removed before tmdb_id in priority order."""
+        template = "{title} - {content_source} - {tmdb_id}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': 'MyContentSource',
+            'tmdb_id': '99999',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=60
+        )
+
+        full_path_length = len(os.path.join(self.base_path, *directory_parts, result))
+        self.assertLessEqual(full_path_length, 60)
+
+
+class TestTruncatePathComponentsEdgeCases(unittest.TestCase):
+    """Edge case tests for truncate_path_components."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.base_path = "/media/symlinks"
+        self.extension = ".mkv"
+
+    def test_very_long_base_path(self):
+        """Should handle very long base paths."""
+        long_base_path = "/media/" + "a" * 100 + "/symlinks"
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=long_base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        # Should still work and contain critical info
+        self.assertIn('S01E01', result)
+        self.assertIn('2024', result)
+
+    def test_unicode_characters_in_title(self):
+        """Should handle unicode characters in title."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d}"
+        template_vars = {
+            'title': 'Show with Unicode: cafe resume',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        self.assertIn('2024', result)
+        self.assertIn('S01E01', result)
+
+    def test_special_characters_in_version(self):
+        """Should handle special characters in version string."""
+        template = "{title} ({year}) - {version}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '1080p.BluRay.x264-GROUP',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['Movies']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        self.assertIn('2024', result)
+
+    def test_empty_directory_parts(self):
+        """Should handle empty directory_parts list."""
+        template = "{title} ({year}) - S{season_number:02d}E{episode_number:02d}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=[],
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        self.assertIn('Show', result)
+        self.assertIn('2024', result)
+        self.assertIn('S01E01', result)
+
+    def test_multi_episode_format(self):
+        """Should handle multi-episode format like E17-E18."""
+        template = "{title} ({year}) - S{season_number:02d}{episode_number}"
+        template_vars = {
+            'title': 'Show',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 'E17-E18',
+            'episode_title': '',
+            'imdb_id': '',
+            'version': '',
+            'original_filename': '',
+            'content_source': '',
+            'tmdb_id': '',
+            'resolution': '',
+        }
+        directory_parts = ['TV Shows', 'Show (2024)', 'Season 01']
+
+        result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        self.assertIn('E17-E18', result)
+        self.assertIn('2024', result)
+
+    def test_removal_order_verified(self):
+        """Verify components are removed in correct priority order."""
+        # Create a scenario where we can verify the order
+        template = "{title} - {original_filename} - {content_source} - {tmdb_id} - {resolution} - {version}"
+        template_vars = {
+            'title': 'T',
+            'year': '2024',
+            'season_number': 1,
+            'episode_number': 1,
+            'episode_title': '',
+            'imdb_id': '',
+            'version': 'VERSION',
+            'original_filename': 'ORIGINAL',
+            'content_source': 'SOURCE',
+            'tmdb_id': 'TMDB',
+            'resolution': 'RES',
+        }
+        directory_parts = []
+
+        # Start with max length that requires removing original_filename only
+        base_result = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=255
+        )
+
+        # With full length, all should be present
+        self.assertIn('ORIGINAL', base_result)
+        self.assertIn('SOURCE', base_result)
+
+        # Now with tighter constraint - original_filename should be removed first
+        result_tight = truncate_path_components(
+            template=template,
+            template_vars=template_vars,
+            base_path=self.base_path,
+            directory_parts=directory_parts,
+            extension=self.extension,
+            max_path_length=60
+        )
+
+        # At tight constraint, ORIGINAL should be gone (lowest priority)
+        self.assertNotIn('ORIGINAL', result_tight)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -393,6 +393,198 @@ def remap_plex_paths_to_mount(items: List[Dict[str, Any]], mount_path: str) -> L
 
     return remapped_items
 
+
+def _clean_separators_in_string(s: str) -> str:
+    """
+    Clean up orphaned separators (like ' - ', ' () ', empty brackets) in a string.
+    This is used after removing template components to clean up the resulting string.
+    """
+    # Remove empty parentheses with surrounding spaces/dashes
+    s = re.sub(r'\s*-\s*\(\s*\)', '', s)
+    s = re.sub(r'\(\s*\)', '', s)
+    # Remove empty square brackets with surrounding spaces/dashes
+    s = re.sub(r'\s*-\s*\[\s*\]', '', s)
+    s = re.sub(r'\[\s*\]', '', s)
+    # Remove orphaned dashes (consecutive or leading/trailing)
+    s = re.sub(r'\s*-\s*-\s*', ' - ', s)
+    s = re.sub(r'^\s*-\s*', '', s)
+    s = re.sub(r'\s*-\s*$', '', s)
+    # Remove multiple consecutive spaces
+    s = re.sub(r'\s{2,}', ' ', s)
+    return s.strip()
+
+
+def truncate_path_components(
+    template: str,
+    template_vars: Dict[str, Any],
+    base_path: str,
+    directory_parts: List[str],
+    extension: str,
+    max_path_length: int = 255
+) -> str:
+    """
+    Intelligently truncate filename components to fit within max_path_length.
+
+    This function systematically removes or truncates components in priority order:
+    1. Remove {original_filename} (lowest priority)
+    2. Remove {content_source}
+    3. Remove {tmdb_id}
+    4. Remove {resolution}
+    5. Remove {version}
+    6. Truncate {episode_title}
+    7. Remove {imdb_id}
+    8. Truncate {title} (last resort)
+
+    Critical info (NEVER removed/truncated):
+    - {season_number}, {episode_number}
+    - {year}, {season_year}
+
+    Args:
+        template: The filename template string (just the filename part, not directories)
+        template_vars: Dictionary of template variables and their values
+        base_path: The base path (symlink root)
+        directory_parts: List of directory parts between base_path and filename
+        extension: File extension (including the dot)
+        max_path_length: Maximum allowed path length (default 255)
+
+    Returns:
+        The sanitized filename (including extension) that fits within the path limit
+    """
+    # Define the priority order for removal (low priority first)
+    # These are removed completely before moving to truncation
+    removal_priority = [
+        'original_filename',
+        'content_source',
+        'tmdb_id',
+        'resolution',
+        'version',
+    ]
+
+    # Define components that can be truncated (in order)
+    truncatable_components = [
+        'episode_title',
+        'imdb_id',  # Remove imdb_id before truncating title
+        'title',
+    ]
+
+    # Create a working copy of template_vars
+    working_vars = dict(template_vars)
+
+    def calculate_full_path(filename_part: str) -> str:
+        """Calculate the full path given a filename part."""
+        dir_path = os.path.join(base_path, *directory_parts) if directory_parts else base_path
+        return os.path.join(dir_path, filename_part)
+
+    def format_and_sanitize() -> str:
+        """Format the template with current vars and sanitize."""
+        try:
+            formatted = template.format(**working_vars)
+        except KeyError as e:
+            logging.warning(f"[TruncatePath] Missing template variable: {e}")
+            formatted = template
+
+        # Clean up orphaned separators
+        formatted = _clean_separators_in_string(formatted)
+
+        # Sanitize the filename
+        sanitized = sanitize_filename(formatted)
+
+        # Ensure extension is present
+        if not sanitized.endswith(extension):
+            sanitized += extension
+
+        return sanitized
+
+    def get_current_length() -> int:
+        """Get the current full path length."""
+        sanitized = format_and_sanitize()
+        full_path = calculate_full_path(sanitized)
+        return len(full_path)
+
+    # Check if path is already valid
+    if get_current_length() <= max_path_length:
+        return format_and_sanitize()
+
+    logging.debug(f"[TruncatePath] Path too long ({get_current_length()} > {max_path_length}). Starting component-based truncation.")
+
+    # Phase 1: Remove components in priority order
+    for component in removal_priority:
+        if component in working_vars and working_vars[component]:
+            original_value = working_vars[component]
+            working_vars[component] = ''
+
+            current_length = get_current_length()
+            if current_length <= max_path_length:
+                logging.info(f"[TruncatePath] Removed '{component}' (was: '{str(original_value)[:50]}...'). Path now valid ({current_length} chars).")
+                return format_and_sanitize()
+            else:
+                logging.debug(f"[TruncatePath] Removed '{component}' (was: '{str(original_value)[:50]}...'). Still too long ({current_length} chars). Continuing...")
+
+    # Phase 2: Truncate components in priority order
+    for component in truncatable_components:
+        if component == 'imdb_id':
+            # Special case: remove imdb_id completely before truncating title
+            if component in working_vars and working_vars[component]:
+                original_value = working_vars[component]
+                working_vars[component] = ''
+
+                current_length = get_current_length()
+                if current_length <= max_path_length:
+                    logging.info(f"[TruncatePath] Removed '{component}' (was: '{original_value}'). Path now valid ({current_length} chars).")
+                    return format_and_sanitize()
+                else:
+                    logging.debug(f"[TruncatePath] Removed '{component}' (was: '{original_value}'). Still too long ({current_length} chars). Continuing...")
+            continue
+
+        if component in working_vars and working_vars[component]:
+            original_value = str(working_vars[component])
+            if len(original_value) <= 4:  # Too short to truncate meaningfully
+                continue
+
+            excess = get_current_length() - max_path_length
+            # We need to remove 'excess' characters, but also add '...' (3 chars)
+            # So we remove (excess + 3) characters from the component
+            chars_to_remove = excess + 3
+
+            if len(original_value) > chars_to_remove:
+                truncated_value = original_value[:-(chars_to_remove)] + '...'
+                working_vars[component] = truncated_value
+
+                current_length = get_current_length()
+                if current_length <= max_path_length:
+                    logging.info(f"[TruncatePath] Truncated '{component}' from '{original_value[:30]}...' to '{truncated_value}'. Path now valid ({current_length} chars).")
+                    return format_and_sanitize()
+                else:
+                    # If still too long, try more aggressive truncation
+                    # Keep at least 10 characters + '...'
+                    min_length = 13  # 10 chars + '...'
+                    while len(working_vars[component]) > min_length:
+                        working_vars[component] = working_vars[component][:-4] + '...'
+                        current_length = get_current_length()
+                        if current_length <= max_path_length:
+                            logging.info(f"[TruncatePath] Aggressively truncated '{component}' to '{working_vars[component]}'. Path now valid ({current_length} chars).")
+                            return format_and_sanitize()
+
+                    logging.debug(f"[TruncatePath] Truncated '{component}' to minimum length. Still too long ({get_current_length()} chars). Continuing...")
+
+    # If we get here, we've done everything we can with the component-based approach
+    # Fall back to the legacy truncation as a last resort
+    sanitized = format_and_sanitize()
+    full_path = calculate_full_path(sanitized)
+
+    if len(full_path) > max_path_length:
+        excess = len(full_path) - max_path_length
+        filename_without_ext = os.path.splitext(sanitized)[0]
+        if len(filename_without_ext) > excess + 3:
+            truncated_filename = filename_without_ext[:-(excess + 3)] + "..."
+            sanitized = truncated_filename + extension
+            logging.warning(f"[TruncatePath] Used legacy truncation as final fallback. Result: '{sanitized}'")
+        else:
+            logging.error(f"[TruncatePath] Cannot truncate filename sufficiently. Path will exceed limit: {full_path}")
+
+    return sanitized
+
+
 def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup: bool = False) -> str:
     """Get the full path for the symlink based on settings and metadata."""
     import json
@@ -787,27 +979,19 @@ def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup
         for i, part_template_segment in enumerate(path_parts_from_template):
             formatted_part = part_template_segment.format(**template_vars)
             sanitized_template_part = sanitize_filename(formatted_part)
-            
+
             if i == len(path_parts_from_template) - 1: # This is the filename part
-                if not sanitized_template_part.endswith(extension):
-                    sanitized_template_part += extension
-                
-                # Path length check
-                # 'parts' at this point contains: ordered_prefix_parts + any preceding template directory parts
-                current_dir_parts_for_check = os.path.join(final_symlinked_path_root, *parts)
-                potential_full_path = os.path.join(current_dir_parts_for_check, sanitized_template_part)
-                
-                max_path_length = 255 
-                if len(potential_full_path) > max_path_length:
-                    excess = len(potential_full_path) - max_path_length
-                    filename_without_ext = os.path.splitext(sanitized_template_part)[0]
-                    if len(filename_without_ext) > excess + 3: # +3 for "..."
-                        truncated_filename = filename_without_ext[:-(excess + 3)] + "..."
-                        sanitized_template_part = truncated_filename + extension
-                        logging.debug(f"[SymlinkPath] Truncated filename from {len(potential_full_path)} to {len(os.path.join(current_dir_parts_for_check, sanitized_template_part))} due to path length limit.")
-                    else:
-                        logging.warning(f"[SymlinkPath] Filename '{sanitized_template_part}' too short to truncate meaningfully for path length limit. Full path: {potential_full_path}")
-                final_filename = sanitized_template_part
+                # Use the new component-based truncation strategy
+                # This will intelligently remove/truncate components in priority order
+                max_path_length = 255
+                final_filename = truncate_path_components(
+                    template=part_template_segment,
+                    template_vars=template_vars,
+                    base_path=final_symlinked_path_root,
+                    directory_parts=parts,
+                    extension=extension,
+                    max_path_length=max_path_length
+                )
             else: # This is a directory part from the template
                 if sanitized_template_part: # Ensure not empty
                     parts.append(sanitized_template_part)

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -395,21 +395,14 @@ def remap_plex_paths_to_mount(items: List[Dict[str, Any]], mount_path: str) -> L
 
 
 def _clean_separators_in_string(s: str) -> str:
-    """
-    Clean up orphaned separators (like ' - ', ' () ', empty brackets) in a string.
-    This is used after removing template components to clean up the resulting string.
-    """
-    # Remove empty parentheses with surrounding spaces/dashes
+    """Clean up orphaned separators after removing template components."""
     s = re.sub(r'\s*-\s*\(\s*\)', '', s)
     s = re.sub(r'\(\s*\)', '', s)
-    # Remove empty square brackets with surrounding spaces/dashes
     s = re.sub(r'\s*-\s*\[\s*\]', '', s)
     s = re.sub(r'\[\s*\]', '', s)
-    # Remove orphaned dashes (consecutive or leading/trailing)
     s = re.sub(r'\s*-\s*-\s*', ' - ', s)
     s = re.sub(r'^\s*-\s*', '', s)
     s = re.sub(r'\s*-\s*$', '', s)
-    # Remove multiple consecutive spaces
     s = re.sub(r'\s{2,}', ' ', s)
     return s.strip()
 
@@ -423,164 +416,91 @@ def truncate_path_components(
     max_path_length: int = 255
 ) -> str:
     """
-    Intelligently truncate filename components to fit within max_path_length.
+    Truncate filename components to fit within max_path_length.
 
-    This function systematically removes or truncates components in priority order:
-    1. Remove {original_filename} (lowest priority)
-    2. Remove {content_source}
-    3. Remove {tmdb_id}
-    4. Remove {resolution}
-    5. Remove {version}
-    6. Truncate {episode_title}
-    7. Remove {imdb_id}
-    8. Truncate {title} (last resort)
-
-    Critical info (NEVER removed/truncated):
-    - {season_number}, {episode_number}
-    - {year}, {season_year}
-
-    Args:
-        template: The filename template string (just the filename part, not directories)
-        template_vars: Dictionary of template variables and their values
-        base_path: The base path (symlink root)
-        directory_parts: List of directory parts between base_path and filename
-        extension: File extension (including the dot)
-        max_path_length: Maximum allowed path length (default 255)
-
-    Returns:
-        The sanitized filename (including extension) that fits within the path limit
+    Removal priority (lowest first): original_filename, content_source, tmdb_id, resolution, version
+    Then truncates: episode_title, imdb_id (removed), title
+    Never touches: season_number, episode_number, year, season_year
     """
-    # Define the priority order for removal (low priority first)
-    # These are removed completely before moving to truncation
-    removal_priority = [
-        'original_filename',
-        'content_source',
-        'tmdb_id',
-        'resolution',
-        'version',
-    ]
-
-    # Define components that can be truncated (in order)
-    truncatable_components = [
-        'episode_title',
-        'imdb_id',  # Remove imdb_id before truncating title
-        'title',
-    ]
-
-    # Create a working copy of template_vars
+    removal_priority = ['original_filename', 'content_source', 'tmdb_id', 'resolution', 'version']
+    truncatable_components = ['episode_title', 'imdb_id', 'title']
     working_vars = dict(template_vars)
 
     def calculate_full_path(filename_part: str) -> str:
-        """Calculate the full path given a filename part."""
         dir_path = os.path.join(base_path, *directory_parts) if directory_parts else base_path
         return os.path.join(dir_path, filename_part)
 
     def format_and_sanitize() -> str:
-        """Format the template with current vars and sanitize."""
         try:
             formatted = template.format(**working_vars)
         except KeyError as e:
             logging.warning(f"[TruncatePath] Missing template variable: {e}")
             formatted = template
-
-        # Clean up orphaned separators
         formatted = _clean_separators_in_string(formatted)
-
-        # Sanitize the filename
         sanitized = sanitize_filename(formatted)
-
-        # Ensure extension is present
         if not sanitized.endswith(extension):
             sanitized += extension
-
         return sanitized
 
     def get_current_length() -> int:
-        """Get the current full path length."""
-        sanitized = format_and_sanitize()
-        full_path = calculate_full_path(sanitized)
-        return len(full_path)
+        return len(calculate_full_path(format_and_sanitize()))
 
-    # Check if path is already valid
     if get_current_length() <= max_path_length:
         return format_and_sanitize()
 
-    logging.debug(f"[TruncatePath] Path too long ({get_current_length()} > {max_path_length}). Starting component-based truncation.")
+    logging.debug(f"[TruncatePath] Path too long ({get_current_length()} > {max_path_length}), truncating...")
 
-    # Phase 1: Remove components in priority order
+    # Remove components in priority order
     for component in removal_priority:
         if component in working_vars and working_vars[component]:
             original_value = working_vars[component]
             working_vars[component] = ''
-
             current_length = get_current_length()
             if current_length <= max_path_length:
-                logging.info(f"[TruncatePath] Removed '{component}' (was: '{str(original_value)[:50]}...'). Path now valid ({current_length} chars).")
+                logging.info(f"[TruncatePath] Removed '{component}'. Path now valid ({current_length} chars).")
                 return format_and_sanitize()
-            else:
-                logging.debug(f"[TruncatePath] Removed '{component}' (was: '{str(original_value)[:50]}...'). Still too long ({current_length} chars). Continuing...")
+            logging.debug(f"[TruncatePath] Removed '{component}', still too long ({current_length} chars).")
 
-    # Phase 2: Truncate components in priority order
+    # Truncate remaining components
     for component in truncatable_components:
         if component == 'imdb_id':
-            # Special case: remove imdb_id completely before truncating title
             if component in working_vars and working_vars[component]:
-                original_value = working_vars[component]
                 working_vars[component] = ''
-
-                current_length = get_current_length()
-                if current_length <= max_path_length:
-                    logging.info(f"[TruncatePath] Removed '{component}' (was: '{original_value}'). Path now valid ({current_length} chars).")
+                if get_current_length() <= max_path_length:
+                    logging.info(f"[TruncatePath] Removed 'imdb_id'. Path now valid.")
                     return format_and_sanitize()
-                else:
-                    logging.debug(f"[TruncatePath] Removed '{component}' (was: '{original_value}'). Still too long ({current_length} chars). Continuing...")
             continue
 
         if component in working_vars and working_vars[component]:
             original_value = str(working_vars[component])
-            if len(original_value) <= 4:  # Too short to truncate meaningfully
+            if len(original_value) <= 4:
                 continue
 
-            excess = get_current_length() - max_path_length
-            # We need to remove 'excess' characters, but also add '...' (3 chars)
-            # So we remove (excess + 3) characters from the component
-            chars_to_remove = excess + 3
-
+            chars_to_remove = get_current_length() - max_path_length + 3
             if len(original_value) > chars_to_remove:
-                truncated_value = original_value[:-(chars_to_remove)] + '...'
-                working_vars[component] = truncated_value
-
-                current_length = get_current_length()
-                if current_length <= max_path_length:
-                    logging.info(f"[TruncatePath] Truncated '{component}' from '{original_value[:30]}...' to '{truncated_value}'. Path now valid ({current_length} chars).")
+                working_vars[component] = original_value[:-(chars_to_remove)] + '...'
+                if get_current_length() <= max_path_length:
+                    logging.info(f"[TruncatePath] Truncated '{component}'. Path now valid.")
                     return format_and_sanitize()
-                else:
-                    # If still too long, try more aggressive truncation
-                    # Keep at least 10 characters + '...'
-                    min_length = 13  # 10 chars + '...'
-                    while len(working_vars[component]) > min_length:
-                        working_vars[component] = working_vars[component][:-4] + '...'
-                        current_length = get_current_length()
-                        if current_length <= max_path_length:
-                            logging.info(f"[TruncatePath] Aggressively truncated '{component}' to '{working_vars[component]}'. Path now valid ({current_length} chars).")
-                            return format_and_sanitize()
 
-                    logging.debug(f"[TruncatePath] Truncated '{component}' to minimum length. Still too long ({get_current_length()} chars). Continuing...")
+                # Aggressive truncation
+                while len(working_vars[component]) > 13:
+                    working_vars[component] = working_vars[component][:-4] + '...'
+                    if get_current_length() <= max_path_length:
+                        logging.info(f"[TruncatePath] Truncated '{component}' to '{working_vars[component]}'.")
+                        return format_and_sanitize()
 
-    # If we get here, we've done everything we can with the component-based approach
-    # Fall back to the legacy truncation as a last resort
+    # Legacy fallback
     sanitized = format_and_sanitize()
     full_path = calculate_full_path(sanitized)
-
     if len(full_path) > max_path_length:
         excess = len(full_path) - max_path_length
         filename_without_ext = os.path.splitext(sanitized)[0]
         if len(filename_without_ext) > excess + 3:
-            truncated_filename = filename_without_ext[:-(excess + 3)] + "..."
-            sanitized = truncated_filename + extension
-            logging.warning(f"[TruncatePath] Used legacy truncation as final fallback. Result: '{sanitized}'")
+            sanitized = filename_without_ext[:-(excess + 3)] + "..." + extension
+            logging.warning(f"[TruncatePath] Legacy fallback used: '{sanitized}'")
         else:
-            logging.error(f"[TruncatePath] Cannot truncate filename sufficiently. Path will exceed limit: {full_path}")
+            logging.error(f"[TruncatePath] Cannot truncate sufficiently: {full_path}")
 
     return sanitized
 


### PR DESCRIPTION
The current truncation logic will only remove from the end of the filename until it fits 255 chars, but in case the combination  of title + episode title is much longer than the original filename of the torrent, important data is erased. 


For the following: https://www.imdb.com/title/tt15441076, the result was "Title...S0....mkv"

This PR adds gradual removal based on what's needed per episode. 

1. Remove {original_filename} (lowest priority)
2. Remove {content_source}
3. Remove {tmdb_id}
4. Remove {resolution}
5. Remove {version}
6. Truncate {episode_title}
7. Remove {imdb_id}
8. Truncate {title} (last resort)

Includes 24 unit tests covering various truncation scenarios.