### PR TITLE
Improvements

### DIFF
--- a/database/wanted_items.py
+++ b/database/wanted_items.py
@@ -705,7 +705,99 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input):
 
         if movies_to_insert or episodes_to_insert or updated_any_title:
             conn.commit()
-        
+
+        # Send notifications for newly added items
+        if (movies_to_insert or episodes_to_insert) and items_added > 0:
+            try:
+                from routes.notifications import send_notifications
+                from routes.settings_routes import get_enabled_notifications_for_category
+                from routes.extensions import app
+                from database.database_reading import get_media_items_by_state
+
+                with app.app_context():
+                    response = get_enabled_notifications_for_category('wanted')
+                    if response.json['success']:
+                        enabled_notifications = response.json['enabled_notifications']
+                        if enabled_notifications:
+                            # Get the newly inserted items from the database
+                            notifications_to_send = []
+
+                            # Build a set of unique identifiers for the items we just inserted
+                            inserted_identifiers = set()
+                            for movie_data in movies_to_insert:
+                                # movie_data tuple: (imdb_id, tmdb_id, title, year, release_date, state, type, last_updated, version, ...)
+                                imdb_id, tmdb_id, title, year = movie_data[0], movie_data[1], movie_data[2], movie_data[3]
+                                version = movie_data[8]
+                                inserted_identifiers.add((imdb_id, tmdb_id, title, year, version, 'movie'))
+
+                            for episode_data in episodes_to_insert:
+                                # episode_data tuple: (imdb_id, tmdb_id, title, year, release_date, state, type, season_number, episode_number, ...)
+                                imdb_id, tmdb_id, title, year = episode_data[0], episode_data[1], episode_data[2], episode_data[3]
+                                season_num, episode_num = episode_data[7], episode_data[8]
+                                version = episode_data[11]
+                                inserted_identifiers.add((imdb_id, tmdb_id, title, year, version, 'episode', season_num, episode_num))
+
+                            # Query for items in Wanted state that match our inserted items
+                            wanted_items = get_media_items_by_state('Wanted')
+
+                            for db_item in wanted_items:
+                                # Check if this item matches one we just inserted
+                                item_type = db_item.get('type', 'unknown')
+                                if item_type == 'movie':
+                                    identifier = (
+                                        db_item.get('imdb_id'),
+                                        db_item.get('tmdb_id'),
+                                        db_item.get('title'),
+                                        db_item.get('year'),
+                                        db_item.get('version'),
+                                        'movie'
+                                    )
+                                    if identifier in inserted_identifiers and not db_item.get('upgrading'):
+                                        notification_data = {
+                                            'id': db_item.get('id'),
+                                            'title': db_item.get('title', 'Unknown Title'),
+                                            'type': item_type,
+                                            'year': db_item.get('year', ''),
+                                            'version': db_item.get('version', ''),
+                                            'season_number': None,
+                                            'episode_number': None,
+                                            'new_state': 'Wanted',
+                                            'is_upgrade': False,
+                                            'upgrading_from': None
+                                        }
+                                        notifications_to_send.append(notification_data)
+                                elif item_type == 'episode':
+                                    identifier = (
+                                        db_item.get('imdb_id'),
+                                        db_item.get('tmdb_id'),
+                                        db_item.get('title'),
+                                        db_item.get('year'),
+                                        db_item.get('version'),
+                                        'episode',
+                                        db_item.get('season_number'),
+                                        db_item.get('episode_number')
+                                    )
+                                    if identifier in inserted_identifiers and not db_item.get('upgrading'):
+                                        notification_data = {
+                                            'id': db_item.get('id'),
+                                            'title': db_item.get('title', 'Unknown Title'),
+                                            'type': item_type,
+                                            'year': db_item.get('year', ''),
+                                            'version': db_item.get('version', ''),
+                                            'season_number': str(db_item.get('season_number', '')) if db_item.get('season_number') is not None else None,
+                                            'episode_number': str(db_item.get('episode_number', '')) if db_item.get('episode_number') is not None else None,
+                                            'new_state': 'Wanted',
+                                            'is_upgrade': False,
+                                            'upgrading_from': None
+                                        }
+                                        notifications_to_send.append(notification_data)
+
+                            if notifications_to_send:
+                                send_notifications(notifications_to_send, enabled_notifications, notification_category='state_change')
+                                logging.info(f"Sent Wanted state notifications for {len(notifications_to_send)} items")
+            except Exception as e:
+                logging.error(f"Failed to send Wanted state change notifications: {str(e)}")
+
         # Immediately trigger a Wanted queue run if new items were added
         if items_added > 0:
             try:

--- a/queues/queue_manager.py
+++ b/queues/queue_manager.py
@@ -557,6 +557,38 @@ class QueueManager:
         logging.debug(f"Moving item to Scraping: {item_identifier}")
         self._move_item_to_queue(item, from_queue, "Scraping", "Scraping")
 
+        # Send notification for the state change
+        from routes.notifications import send_notifications
+        from routes.settings_routes import get_enabled_notifications_for_category
+        from routes.extensions import app
+        from database.database_reading import get_media_item_by_id
+
+        try:
+            # Get fresh item data from DB
+            db_item = get_media_item_by_id(item['id'])
+            if db_item and not db_item.get('upgrading'):
+                with app.app_context():
+                    response = get_enabled_notifications_for_category('scraping')
+                    if response.json['success']:
+                        enabled_notifications = response.json['enabled_notifications']
+                        if enabled_notifications:
+                            notification_data = {
+                                'id': item['id'],
+                                'title': item.get('title', 'Unknown Title'),
+                                'type': item.get('type', 'unknown'),
+                                'year': item.get('year', ''),
+                                'version': item.get('version', ''),
+                                'season_number': str(item.get('season_number', '')) if item.get('season_number') is not None else None,
+                                'episode_number': str(item.get('episode_number', '')) if item.get('episode_number') is not None else None,
+                                'new_state': 'Scraping',
+                                'is_upgrade': False,
+                                'upgrading_from': None
+                            }
+                            send_notifications([notification_data], enabled_notifications, notification_category='state_change')
+                            logging.debug(f"Sent Scraping notification for item {item['id']}")
+        except Exception as e:
+            logging.error(f"Failed to send Scraping state change notification: {str(e)}")
+
     def move_to_adding(self, item: Dict[str, Any], from_queue: str, filled_by_title: str, scrape_results: List[Dict]):
         item_identifier = self.generate_identifier(item)
 
@@ -579,6 +611,38 @@ class QueueManager:
             filled_by_title=filled_by_title,
             scrape_results=scrape_results
         )
+
+        # Send notification for the state change
+        from routes.notifications import send_notifications
+        from routes.settings_routes import get_enabled_notifications_for_category
+        from routes.extensions import app
+        from database.database_reading import get_media_item_by_id
+
+        try:
+            # Get fresh item data from DB
+            db_item = get_media_item_by_id(item['id'])
+            if db_item and not db_item.get('upgrading'):
+                with app.app_context():
+                    response = get_enabled_notifications_for_category('adding')
+                    if response.json['success']:
+                        enabled_notifications = response.json['enabled_notifications']
+                        if enabled_notifications:
+                            notification_data = {
+                                'id': item['id'],
+                                'title': item.get('title', 'Unknown Title'),
+                                'type': item.get('type', 'unknown'),
+                                'year': item.get('year', ''),
+                                'version': item.get('version', ''),
+                                'season_number': str(item.get('season_number', '')) if item.get('season_number') is not None else None,
+                                'episode_number': str(item.get('episode_number', '')) if item.get('episode_number') is not None else None,
+                                'new_state': 'Adding',
+                                'is_upgrade': False,
+                                'upgrading_from': None
+                            }
+                            send_notifications([notification_data], enabled_notifications, notification_category='state_change')
+                            logging.debug(f"Sent Adding notification for item {item['id']}")
+        except Exception as e:
+            logging.error(f"Failed to send Adding state change notification: {str(e)}")
 
     def move_to_checking(self, item: Dict[str, Any], from_queue: str, title: str, link: str, filled_by_file: str, torrent_id: str = None):
         item_identifier = self.generate_identifier(item)

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -135,7 +135,18 @@ def format_notification_content(notifications, notification_type, notification_c
         'queue_start': "▶️",
         'queue_stop': "⏹️",
         'upgrade_failed': "❌",
-        'blacklisted': "🚫" # New emoji for blacklisted
+        'collected': "✅",
+        'downloading': "📥",
+        'checking': "🔎",
+        'upgrading': "🔧",
+        'upgraded': "✨",
+        'blacklisted': "🚫",
+        'wanted': "🎯",
+        'scraping': "🔍",
+        'adding': "➕",
+        'sleeping': "😴",
+        'unreleased': "📅",
+        'pending_uncached': "⏳"
     }
 
     # Get content source display names mapping once for efficiency
@@ -212,17 +223,29 @@ def format_notification_content(notifications, notification_type, notification_c
         
         # Choose prefix based on state and upgrade status
         if new_state == 'Downloading':
-            prefix = "⬇️"  # Download emoji for downloading state
+            prefix = EMOJIS['downloading']
         elif new_state == 'Checking':
-            prefix = EMOJIS['show'] if media_type == 'episode' else EMOJIS['movie']
+            prefix = EMOJIS['checking']
         elif new_state == 'Upgrading':
-            prefix = EMOJIS['movie'] if media_type == 'movie' else EMOJIS['show']
+            prefix = EMOJIS['upgrading']
         elif new_state == 'Upgraded':
-            prefix = EMOJIS['upgrade']
+            prefix = EMOJIS['upgraded']
         elif new_state == 'Collected':
-            prefix = EMOJIS['new']
-        elif new_state == 'Blacklisted': # New case for Blacklisted
+            prefix = EMOJIS['collected']
+        elif new_state == 'Blacklisted':
             prefix = EMOJIS['blacklisted']
+        elif new_state == 'Wanted':
+            prefix = EMOJIS['wanted']
+        elif new_state == 'Scraping':
+            prefix = EMOJIS['scraping']
+        elif new_state == 'Adding':
+            prefix = EMOJIS['adding']
+        elif new_state == 'Sleeping':
+            prefix = EMOJIS['sleeping']
+        elif new_state == 'Unreleased':
+            prefix = EMOJIS['unreleased']
+        elif new_state == 'Pending Uncached':
+            prefix = EMOJIS['pending_uncached']
         else:
             prefix = EMOJIS['show'] if media_type == 'episode' else EMOJIS['movie']
         
@@ -646,10 +669,34 @@ def _send_notifications(notifications, enabled_notifications, notification_categ
                         notification_title = "Content Upgraded"
                         final_message = f"Successfully upgraded {base_message}"
                         notif_type = 'success'
-                    elif new_state == 'Blacklisted': # New case for Blacklisted
+                    elif new_state == 'Blacklisted':
                         notification_title = "Item Blacklisted"
                         final_message = f"Item has been blacklisted: {base_message}"
-                        notif_type = 'warning' # Or 'info'
+                        notif_type = 'warning'
+                    elif new_state == 'Wanted':
+                        notification_title = "Item Wanted"
+                        final_message = f"Item added to wanted list: {base_message}"
+                        notif_type = 'info'
+                    elif new_state == 'Scraping':
+                        notification_title = "Scraping for Content"
+                        final_message = f"Scraping torrents for {base_message}"
+                        notif_type = 'info'
+                    elif new_state == 'Adding':
+                        notification_title = "Adding Content"
+                        final_message = f"Adding {base_message} to debrid service"
+                        notif_type = 'info'
+                    elif new_state == 'Sleeping':
+                        notification_title = "Content Sleeping"
+                        final_message = f"Item moved to sleep: {base_message}"
+                        notif_type = 'info'
+                    elif new_state == 'Unreleased':
+                        notification_title = "Content Unreleased"
+                        final_message = f"Item not yet released: {base_message}"
+                        notif_type = 'info'
+                    elif new_state == 'Pending Uncached':
+                        notification_title = "Pending Uncached"
+                        final_message = f"Item waiting for cache: {base_message}"
+                        notif_type = 'info'
                     else: # Default Collected
                         notification_title = "New Content Available"
                         if notification.get('is_upgrade'):
@@ -770,9 +817,20 @@ def _send_notifications(notifications, enabled_notifications, notification_categ
                     item_category = 'downloading'
                 elif state == 'Checking':
                     item_category = 'checking'
-                elif state == 'Blacklisted': # New case for Blacklisted
+                elif state == 'Blacklisted':
                     item_category = 'blacklisted'
-                # Add elif for other states if they map to specific notify_on keys
+                elif state == 'Wanted':
+                    item_category = 'wanted'
+                elif state == 'Scraping':
+                    item_category = 'scraping'
+                elif state == 'Adding':
+                    item_category = 'adding'
+                elif state == 'Sleeping':
+                    item_category = 'sleeping'
+                elif state == 'Unreleased':
+                    item_category = 'unreleased'
+                elif state == 'Pending Uncached':
+                    item_category = 'pending_uncached'
 
                 # Check if the target is enabled for this specific item's category
                 item_category_enabled = notify_on.get(item_category, True) # Default to True if key missing
@@ -1122,20 +1180,25 @@ def send_email_notification(smtp_config, content, notification_category):
         'program_stop': "Program Stopped",
         'program_start': "Program Started",
         'queue_pause': "Queue Paused",
-        'queue_resume': "Queue Resumed", # Corrected: was "Queue Resumed"
+        'queue_resume': "Queue Resumed",
         'queue_start': "Queue Started",
         'queue_stop': "Queue Stopped",
         'upgrade_failed': "Upgrade Failed",
-        'collected': "Media Notification", # Generic for various content states
-        'downloading': "Downloading Content", # Using title from storage logic
-        'checking': "Checking Content",     # Using title from storage logic
-        'upgrading': "Upgrading Content",   # Using title from storage logic
-        'upgraded': "Content Upgraded",      # Using title from storage logic
+        'collected': "Media Notification",
+        'downloading': "Downloading Content",
+        'checking': "Checking Content",
+        'upgrading': "Upgrading Content",
+        'upgraded': "Content Upgraded",
         'scraping_error': "Scraping Error",
         'content_error': "Content Error",
         'database_error': "Database Error",
-        'blacklisted': "Item Blacklisted" # New subject for blacklisted
-        # Add other categories as needed
+        'blacklisted': "Item Blacklisted",
+        'wanted': "Item Wanted",
+        'scraping': "Scraping for Content",
+        'adding': "Adding Content",
+        'sleeping': "Content Sleeping",
+        'unreleased': "Content Unreleased",
+        'pending_uncached': "Pending Uncached"
     }
     # Default subject if category not in map or None
     subject = subject_map.get(notification_category, "Media Notification") # Keep default

--- a/routes/settings_routes.py
+++ b/routes/settings_routes.py
@@ -1181,6 +1181,7 @@ def ensure_notification_defaults(notification_config):
         'scraping': False,
         'adding': False,
         'checking': False,
+        'downloading': False,
         'sleeping': False,
         'unreleased': False,
         'blacklisted': False,

--- a/routes/statistics_routes.py
+++ b/routes/statistics_routes.py
@@ -1298,7 +1298,7 @@ def move_to_wanted():
         if season_number is not None and episode_number is not None:
             # Episode
             query = """
-                UPDATE media_items 
+                UPDATE media_items
                 SET state = 'Wanted',
                     filled_by_file = NULL,
                     filled_by_title = NULL,
@@ -1316,13 +1316,13 @@ def move_to_wanted():
                 WHERE (imdb_id = ? OR tmdb_id = ?)
                 AND season_number = ?
                 AND episode_number = ?
-                AND state IN ('Collected', 'Upgrading', 'Blacklisted')
+                AND state NOT IN ('Wanted', 'Scraping', 'Adding')
             """
             params = (datetime.now(), imdb_id, tmdb_id, season_number, episode_number)
         else:
             # Movie
             query = """
-                UPDATE media_items 
+                UPDATE media_items
                 SET state = 'Wanted',
                     filled_by_file = NULL,
                     filled_by_title = NULL,
@@ -1339,7 +1339,7 @@ def move_to_wanted():
                     upgrading = NULL
                 WHERE (imdb_id = ? OR tmdb_id = ?)
                 AND type = 'movie'
-                AND state IN ('Collected', 'Upgrading', 'Blacklisted')
+                AND state NOT IN ('Wanted', 'Scraping', 'Adding')
             """
             params = (datetime.now(), imdb_id, tmdb_id)
             
@@ -1349,7 +1349,7 @@ def move_to_wanted():
         if cursor.rowcount > 0:
             return jsonify({'success': True}), 200
         else:
-            return jsonify({'success': False, 'error': 'No matching items found or items not in Collected/Upgrading state'}), 404
+            return jsonify({'success': False, 'error': 'No matching items found or items already in Wanted/Scraping/Adding state'}), 404
             
     except Exception as e:
         logging.error(f"Error moving item to Wanted state: {str(e)}")

--- a/static/js/discover_details.js
+++ b/static/js/discover_details.js
@@ -710,8 +710,14 @@ function createEpisodeRow(episode, seasonNumber, showData) {
             }
         }
 
-        // Note: refresh and delete functionality would need to be implemented similar to library_show.js
-        // For now, just adding the buttons for visual parity
+        // Add event listener for refresh button (move to wanted)
+        const refreshBtn = row.querySelector('.refresh-btn');
+        if (refreshBtn) {
+            refreshBtn.addEventListener('click', handleRefreshClick);
+        }
+
+        // Note: delete functionality would need to be implemented similar to library_show.js
+        // For now, just adding the button for visual parity
 
     } else {
         // Episode not in database - show minimal info with search button
@@ -1138,4 +1144,39 @@ function escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
+}
+
+function handleRefreshClick(event) {
+    const btn = event.currentTarget;
+    const data = {
+        imdb_id: btn.dataset.imdbId,
+        tmdb_id: btn.dataset.tmdbId,
+        season_number: parseInt(btn.dataset.season),
+        episode_number: parseInt(btn.dataset.episode)
+    };
+
+    // Disable button while processing
+    btn.disabled = true;
+
+    fetch('/statistics/move_to_wanted', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data)
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            // Reload the page to reflect the updated state
+            window.location.reload();
+        } else {
+            throw new Error(data.error || 'Failed to move item to Wanted state');
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        alert(`Error moving item to Wanted state: ${error.message}`);
+        btn.disabled = false;
+    });
 }

--- a/static/js/scraper.js
+++ b/static/js/scraper.js
@@ -1145,7 +1145,7 @@ async function displayTorrentResults(data, title, year, version, mediaId, mediaT
                 const qualityBadgesHtml = qualityTags.map(tag => createQualityBadge(tag)).join('');
                 
                 // Use clean title from header, store filename for toggle
-                const ShowInfo = `${season ? `<span class="season-info">S${season.toString().padStart(2, '0')}` : ''}${(torrent.parsed_info.seasons).length > 1 ? ` - ${(torrent.parsed_info.seasons).length}</span>` : `</span>`} ${episode ? `<span class="ds-episode-info"> E${episode.toString().padStart(2, '0')}</span>`: ''}`;
+                const ShowInfo = `${season ? `<span class="season-info">S${season.toString().padStart(2, '0')}` : ''}${(torrent.parsed_info?.seasons?.length || 0) > 1 ? ` - ${torrent.parsed_info.seasons.length}</span>` : `</span>`} ${episode ? `<span class="ds-episode-info"> E${episode.toString().padStart(2, '0')}</span>`: ''}`;
                 const cleanTitle = `${title} (${year})${ShowInfo ? ` ${ShowInfo}` : ''}`;
                 const filename = torrent.title || torrent.original_title || 'N/A';
                 


### PR DESCRIPTION
- Add state change notifications for Wanted, Scraping, and Adding states
- Update notification system with emojis and messages for all queue states
- Fix move to Wanted to allow any state except Wanted/Scraping/Adding
- Add missing 'downloading' notification category to defaults
- Implement refresh button functionality in discover details page
- Fix undefined property access in scraper.js with optional chaining
- Remove bad Trakt cache entry causing repeated API failures