### PR TITLE
Bug fixes and improvements

### DIFF
--- a/cli_battery/app/direct_api.py
+++ b/cli_battery/app/direct_api.py
@@ -586,17 +586,18 @@ class DirectAPI:
 
                 # Stale or missing
                 logging.debug(f"get_show_metadata {imdb_id}: cache MISS (stale={item is not None})")
+                # Capture fallback before _refresh_show may expire item via session commit
+                fallback_md = _build_show_metadata_dict(item) if item else None
                 data = _refresh_show(imdb_id, session)
                 if data:
                     if imdb_id == LEGO_MASTERS_US_IMDB_ID and 'seasons' in data:
                         data['seasons'] = _apply_lego_masters_us_season_fix(data['seasons'])
                     return data, _get_metadata_source_name()
 
-                if item:
-                    md = _build_show_metadata_dict(item)
-                    if imdb_id == LEGO_MASTERS_US_IMDB_ID and 'seasons' in md:
-                        md['seasons'] = _apply_lego_masters_us_season_fix(md['seasons'])
-                    return md, 'battery'
+                if fallback_md:
+                    if imdb_id == LEGO_MASTERS_US_IMDB_ID and 'seasons' in fallback_md:
+                        fallback_md['seasons'] = _apply_lego_masters_us_season_fix(fallback_md['seasons'])
+                    return fallback_md, 'battery'
                 return None, None
         except Exception as e:
             logging.error(f"DirectAPI.get_show_metadata {imdb_id}: {e}", exc_info=True)
@@ -665,13 +666,15 @@ class DirectAPI:
                         except (json.JSONDecodeError, TypeError):
                             pass
 
+                # Capture md.value as plain string before _refresh_show may expire/detach the ORM object
+                md_value = md.value if (item and md) else None
                 data = _refresh_show(imdb_id, session)
                 if data and 'aliases' in data:
                     return data['aliases'], _get_metadata_source_name()
 
-                if item and md:
+                if md_value:
                     try:
-                        return json.loads(md.value), 'battery'
+                        return json.loads(md_value), 'battery'
                     except (json.JSONDecodeError, TypeError):
                         pass
                 return None, None

--- a/database/database_reading.py
+++ b/database/database_reading.py
@@ -111,9 +111,6 @@ def stream_all_media_items(state=None, media_type=None, imdb_id=None, tmdb_id=No
     """
     A generator that streams media items from the database one by one.
     This is memory-efficient and suitable for large datasets.
-
-    Args:
-        columns: Optional list of column names to select. If None, selects all columns (*).
     """
     conn = None
     try:
@@ -890,43 +887,6 @@ def get_item_count_by_state(state: str) -> int:
         if conn:
             conn.close()
 
-def get_item_counts_by_states(states: list) -> dict:
-    """Get counts for multiple states in a single DB connection.
-
-    Args:
-        states: List of state strings to count.
-
-    Returns:
-        Dict mapping state -> count.
-    """
-    conn = None
-    try:
-        conn = get_db_connection()
-
-        # Ensure the index exists (one-time, idempotent)
-        try:
-            conn.execute('CREATE INDEX IF NOT EXISTS idx_media_items_state ON media_items(state);')
-        except Exception:
-            pass
-
-        counts = {}
-        for state in states:
-            if state == 'Blacklisted':
-                query = 'SELECT COUNT(*) as count FROM media_items WHERE state = ? AND (ghostlisted IS NULL OR ghostlisted = 0)'
-            else:
-                query = 'SELECT COUNT(*) as count FROM media_items WHERE state = ?'
-            cursor = conn.execute(query, (state,))
-            result = cursor.fetchone()
-            counts[state] = result['count'] if result else 0
-        return counts
-    except Exception as e:
-        logging.error(f"Error getting item counts for states {states}: {e}")
-        return {state: 0 for state in states}
-    finally:
-        if conn:
-            conn.close()
-
-
 def check_item_exists_by_directory_name(item_directory_name: str) -> bool:
     """
     Check if any media item exists in the database where the item_directory_name
@@ -1573,6 +1533,45 @@ def get_items_with_all_blacklisted_versions() -> List[int]:
     finally:
         if conn:
             conn.close()
+
+def get_item_counts_by_states(states: list) -> dict:
+    """Fetch COUNT(*) for multiple states in a single DB connection.
+
+    Creates the state index if it doesn't already exist (idempotent), then
+    runs one COUNT query per state inside the same open connection, which
+    is much cheaper than opening/closing a connection for each state.
+
+    Args:
+        states: List of state strings to count (e.g. ['Wanted', 'Blacklisted']).
+
+    Returns:
+        Dict mapping each state string to its item count.
+    """
+    conn = None
+    try:
+        conn = get_db_connection()
+        try:
+            conn.execute('CREATE INDEX IF NOT EXISTS idx_media_items_state ON media_items(state);')
+        except Exception as e:
+            logging.debug(f"Index creation attempt (may already exist): {e}")
+
+        counts = {}
+        for state in states:
+            if state == 'Blacklisted':
+                query = 'SELECT COUNT(*) as count FROM media_items WHERE state = ? AND (ghostlisted IS NULL OR ghostlisted = 0)'
+            else:
+                query = 'SELECT COUNT(*) as count FROM media_items WHERE state = ?'
+            cursor = conn.execute(query, (state,))
+            result = cursor.fetchone()
+            counts[state] = result['count'] if result else 0
+        return counts
+    except Exception as e:
+        logging.error(f"Error in get_item_counts_by_states: {e}")
+        return {state: 0 for state in states}
+    finally:
+        if conn:
+            conn.close()
+
 
 # =============================================================================
 # Deletion Helper Functions (for DeletionManager)

--- a/database/migrations.py
+++ b/database/migrations.py
@@ -199,4 +199,37 @@ def add_database_page_indexes():
         logging.error(f"Error adding database page indexes: {str(e)}")
         conn.rollback()
     finally:
-        conn.close() 
+        conn.close()
+
+
+def add_library_covering_index():
+    """Add covering index for the library page GROUP BY query.
+
+    The library query does:
+      WHERE (ghostlisted=0 OR NULL) AND state NOT IN (...) AND type IN (...)
+      GROUP BY COALESCE(NULLIF(tmdb_id,''), NULLIF(imdb_id,''), title||year)
+      ORDER BY MAX(collected_at) DESC / title / year
+
+    Including all columns referenced in the GROUP BY expression and aggregates
+    (tmdb_id, imdb_id, title, year, id, collected_at) allows SQLite to satisfy
+    the entire GROUP BY from the index without touching main table rows (index-only scan).
+    """
+    from database import get_db_connection
+    conn = get_db_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_library_covering
+            ON media_items (
+                type, state, ghostlisted,
+                collected_at DESC,
+                tmdb_id, imdb_id, title, year, id
+            )
+        """)
+        conn.commit()
+        logging.info("Successfully added library covering index")
+    except Exception as e:
+        logging.error(f"Error adding library covering index: {str(e)}")
+        conn.rollback()
+    finally:
+        conn.close()

--- a/database/schema_management.py
+++ b/database/schema_management.py
@@ -602,13 +602,16 @@ def verify_database():
         logging.error(f"Error ensuring plex_removal_queue table: {e}")
     
     # Add statistics indexes
-    from .migrations import add_statistics_indexes, add_search_performance_indexes, add_statistics_composite_indexes, add_database_page_indexes
+    from .migrations import add_statistics_indexes, add_search_performance_indexes, add_statistics_composite_indexes, add_database_page_indexes, add_library_covering_index
     add_statistics_indexes()
     add_statistics_composite_indexes()
 
     # PHASE 1.3: Add search performance indexes
     add_search_performance_indexes()
     add_database_page_indexes()
+
+    # Library page covering index for GROUP BY query performance
+    add_library_covering_index()
 
     conn = get_db_connection()
     cursor = conn.cursor()

--- a/database/statistics.py
+++ b/database/statistics.py
@@ -124,6 +124,7 @@ def get_cached_download_stats():
                 }
             
             # Get usage stats with timeout protection
+            usage = None
             try:
                 logging.debug("Fetching usage stats...")
                 usage = provider.get_user_traffic()

--- a/database/wanted_items.py
+++ b/database/wanted_items.py
@@ -11,6 +11,56 @@ from utilities.settings import get_setting
 from content_checkers.trakt import fetch_items_from_trakt, load_imdb_trakt_cache, save_imdb_trakt_cache
 import re
 
+def _get_existing_item_id_collected(conn, imdb_id, tmdb_id, item_type, item):
+    """Get DB id of an existing Collected/Upgrading item matching the given identifiers."""
+    if item_type == 'movie':
+        for id_col, id_val in [('imdb_id', imdb_id), ('tmdb_id', tmdb_id)]:
+            if id_val:
+                row = conn.execute(
+                    f"SELECT id FROM media_items WHERE type='movie' AND {id_col}=? AND state IN ('Collected','Upgrading') LIMIT 1",
+                    (id_val,)
+                ).fetchone()
+                if row:
+                    return row['id']
+    else:
+        season = item.get('season_number')
+        episode = item.get('episode_number')
+        for id_col, id_val in [('imdb_id', imdb_id), ('tmdb_id', tmdb_id)]:
+            if id_val:
+                row = conn.execute(
+                    f"SELECT id FROM media_items WHERE type='episode' AND {id_col}=? AND season_number=? AND episode_number=? AND state IN ('Collected','Upgrading') LIMIT 1",
+                    (id_val, season, episode)
+                ).fetchone()
+                if row:
+                    return row['id']
+    return None
+
+
+def _get_existing_item_id_any_state(conn, imdb_id, tmdb_id, item_type, item):
+    """Get DB id of any existing item matching the given identifiers (any state)."""
+    if item_type == 'movie':
+        for id_col, id_val in [('imdb_id', imdb_id), ('tmdb_id', tmdb_id)]:
+            if id_val:
+                row = conn.execute(
+                    f"SELECT id FROM media_items WHERE type='movie' AND {id_col}=? LIMIT 1",
+                    (id_val,)
+                ).fetchone()
+                if row:
+                    return row['id']
+    else:
+        season = item.get('season_number')
+        episode = item.get('episode_number')
+        for id_col, id_val in [('imdb_id', imdb_id), ('tmdb_id', tmdb_id)]:
+            if id_val:
+                row = conn.execute(
+                    f"SELECT id FROM media_items WHERE type='episode' AND {id_col}=? AND season_number=? AND episode_number=? LIMIT 1",
+                    (id_val, season, episode)
+                ).fetchone()
+                if row:
+                    return row['id']
+    return None
+
+
 def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input):
     from metadata.metadata import get_show_airtime_by_imdb_id
     from utilities.settings import get_setting
@@ -266,6 +316,9 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input):
                         existing_episodes[key] = []
                     existing_episodes[key].append((strip_version(row['version']), row['state'], row['ghostlisted']))
 
+        pending_secondary_labels = []  # [(existing_id, source_name, source_detail)] — Collected items needing label from second source
+        pending_source_records = []   # [(existing_id, source_name, source_detail)] — not-yet-Collected items needing source recorded
+
         filtered_media_items_batch_after_existence_check = []
         for item in media_items_batch:
             imdb_id = item.get('imdb_id')
@@ -378,6 +431,12 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input):
 
             if is_collected_or_upgrading_in_db:
                 if not enable_granular_versions:
+                    new_source = item.get('content_source')
+                    new_detail = item.get('content_source_detail')
+                    if new_source and new_detail and new_detail.lower() != 'unknown':
+                        lookup_id = _get_existing_item_id_collected(conn, imdb_id, tmdb_id, item_type, item)
+                        if lookup_id:
+                            pending_secondary_labels.append((lookup_id, new_source, new_detail))
                     skip_stats['already_collected_or_upgrading'] += 1; items_skipped += 1; continue
 
             if item_type == 'movie':
@@ -409,7 +468,14 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input):
                         skip = True; skip_stats['existing_movie_imdb'] += 1
                         if media_id_vs not in version_summary['movies']:
                             version_summary['movies'][media_id_vs] = {'existing': existing_versions_set_vs, 'added': set(), 'title': normalized_title, 'states': existing_states_set_vs}
-                if skip: items_skipped += 1; continue
+                if skip:
+                    new_source = item.get('content_source')
+                    new_detail = item.get('content_source_detail')
+                    if new_source and new_detail and new_detail.lower() != 'unknown':
+                        lookup_id = _get_existing_item_id_any_state(conn, imdb_id, tmdb_id, item_type, item)
+                        if lookup_id:
+                            pending_source_records.append((lookup_id, new_source, new_detail))
+                    items_skipped += 1; continue
             else: # Episode
                 season_number_vs = item.get('season_number'); episode_number_vs = item.get('episode_number')
                 skip = False; media_id_vs = imdb_id or tmdb_id
@@ -446,8 +512,15 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input):
                         skip = True; skip_stats['existing_episode_imdb'] += 1
                         if episode_key_vs not in version_summary['episodes']:
                              version_summary['episodes'][episode_key_vs] = {'existing': existing_versions_set_vs, 'added': set(), 'title': normalized_title, 'states': existing_states_set_vs}
-                if skip: items_skipped += 1; continue
-            
+                if skip:
+                    new_source = item.get('content_source')
+                    new_detail = item.get('content_source_detail')
+                    if new_source and new_detail and new_detail.lower() != 'unknown':
+                        lookup_id = _get_existing_item_id_any_state(conn, imdb_id, tmdb_id, item_type, item)
+                        if lookup_id:
+                            pending_source_records.append((lookup_id, new_source, new_detail))
+                    items_skipped += 1; continue
+
             filtered_media_items_batch_after_existence_check.append(item)
 
         media_items_batch = filtered_media_items_batch_after_existence_check
@@ -706,13 +779,50 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input):
         if movies_to_insert or episodes_to_insert or updated_any_title:
             conn.commit()
 
+        # Apply labels for secondary sources on already-Collected items
+        if pending_secondary_labels:
+            try:
+                from utilities.plex_label_manager import (
+                    is_plex_labels_enabled_anywhere,
+                    determine_labels_for_item,
+                    add_label_to_item
+                )
+                if is_plex_labels_enabled_anywhere():
+                    for (existing_id, src, detail) in pending_secondary_labels:
+                        temp_item = {'content_source': src, 'content_source_detail': detail}
+                        labels = determine_labels_for_item(temp_item)
+                        for label in labels:
+                            try:
+                                add_label_to_item(existing_id, label, src, apply_to_plex=True)
+                                logging.info(f"Applied secondary source label '{label}' from {src} to item {existing_id}")
+                            except Exception as e:
+                                logging.warning(f"Failed to apply secondary source label '{label}' from {src} to item {existing_id}: {e}")
+            except Exception as e:
+                logging.warning(f"Failed to apply secondary source labels: {e}")
+
+        # Record secondary sources for not-yet-Collected items (for future label application when item reaches Collected)
+        if pending_source_records:
+            from utilities.plex_label_manager import parse_content_sources, serialize_content_sources
+            for (existing_id, src, detail) in pending_source_records:
+                try:
+                    row = conn.execute('SELECT content_sources FROM media_items WHERE id = ?', (existing_id,)).fetchone()
+                    sources = parse_content_sources(row['content_sources'] if row else None)
+                    if not any(s['source'] == src for s in sources):
+                        sources.append({'source': src, 'detail': detail, 'added_at': datetime.now().strftime('%Y-%m-%d %H:%M:%S')})
+                        conn.execute('UPDATE media_items SET content_sources = ? WHERE id = ?',
+                                     (serialize_content_sources(sources), existing_id))
+                        logging.debug(f"Recorded secondary source '{src}' on item {existing_id} for future label application")
+                except Exception as e:
+                    logging.warning(f"Failed to record secondary source for item {existing_id}: {e}")
+            conn.commit()
+
         # Send notifications for newly added items
         if (movies_to_insert or episodes_to_insert) and items_added > 0:
             try:
                 from routes.notifications import send_notifications
                 from routes.settings_routes import get_enabled_notifications_for_category
                 from routes.extensions import app
-                from database.database_reading import get_media_items_by_state
+                from database.database_reading import get_all_media_items
 
                 with app.app_context():
                     response = get_enabled_notifications_for_category('wanted')
@@ -738,7 +848,7 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input):
                                 inserted_identifiers.add((imdb_id, tmdb_id, title, year, version, 'episode', season_num, episode_num))
 
                             # Query for items in Wanted state that match our inserted items
-                            wanted_items = get_media_items_by_state('Wanted')
+                            wanted_items = get_all_media_items(state='Wanted')
 
                             for db_item in wanted_items:
                                 # Check if this item matches one we just inserted

--- a/debrid/real_debrid/client.py
+++ b/debrid/real_debrid/client.py
@@ -125,7 +125,10 @@ class RealDebridProvider(DebridProvider):
             if get_setting("Debrid Provider", "api_key") == "demo_key":
                 return {'days_remaining': None, 'expiration': None, 'premium': False}
 
-            user_info = make_request('GET', '/user', self.api_key) or {}
+            user_info = make_request('GET', '/user', self.api_key)
+            if not isinstance(user_info, dict):
+                logging.error(f"Unexpected response type from /user: {type(user_info)}")
+                user_info = {}
             premium = bool(user_info.get('premium', False))
             expiration = user_info.get('expiration') or user_info.get('premium_until')
 
@@ -295,6 +298,8 @@ class RealDebridProvider(DebridProvider):
                         # Search for existing torrent with this hash
                         torrents = make_request('GET', '/torrents', self.api_key) or []
                         for torrent in torrents:
+                            if not isinstance(torrent, dict):
+                                continue
                             if torrent.get('hash', '').lower() == hash_value.lower():
                                 torrent_id = torrent['id']
                                 break
@@ -499,16 +504,6 @@ class RealDebridProvider(DebridProvider):
                 # Don't URL decode - requests library handles encoding for POST form data
                 # If we decode first, it can corrupt the magnet link
 
-                # Check if torrent already exists
-                if hash_value:
-                    torrents = make_request('GET', '/torrents', self.api_key) or []
-                    for torrent in torrents:
-                        if torrent.get('hash', '').lower() == hash_value.lower():
-                            logging.info(f"Torrent already exists with ID {torrent['id']}")
-                            # Cache the filename for existing torrent
-                            self._cached_torrent_titles[hash_value] = torrent.get('filename', '')
-                            return torrent['id']
-
                 # Add magnet link
                 logging.debug(f"Adding magnet with hash {hash_value[:16] if hash_value else 'unknown'}...")
                 data = {'magnet': magnet_link}
@@ -517,7 +512,12 @@ class RealDebridProvider(DebridProvider):
                 logging.error("Neither magnet_link nor temp_file_path provided")
                 raise ValueError("Either magnet_link or temp_file_path must be provided")
 
-            if not result or 'id' not in result:
+            if result is None:
+                # RD returns 404 -> None for duplicate magnets; let caller (is_cached) handle lookup
+                logging.debug(f"add_torrent got None response for hash {hash_value} - likely duplicate")
+                return None
+
+            if not isinstance(result, dict) or 'id' not in result:
                 logging.error(f"Failed to add torrent - response: {result}")
                 raise TorrentAdditionError(f"Failed to add torrent - response: {result}")
                 
@@ -682,7 +682,10 @@ class RealDebridProvider(DebridProvider):
                 return 0, 0
 
             active_data = make_request('GET', '/torrents/activeCount', self.api_key)
-            
+            if not isinstance(active_data, dict):
+                logging.error(f"Unexpected response type from /torrents/activeCount: {type(active_data)}")
+                raise ProviderUnavailableError("Failed to get active downloads: unexpected response type")
+
             active_count = active_data.get('nb', 0)
             raw_max_downloads = active_data.get('limit', self.MAX_DOWNLOADS)
 

--- a/queues/checking_queue.py
+++ b/queues/checking_queue.py
@@ -326,7 +326,7 @@ class CheckingQueue:
             status_result = self.debrid_provider.get_torrent_info_with_status(torrent_id)
 
             if status_result.status == TorrentFetchStatus.OK:
-                return status_result.data.get('progress', 0) if status_result.data else 0
+                return status_result.data.get('progress', 0) if isinstance(status_result.data, dict) else 0
             elif status_result.status == TorrentFetchStatus.NOT_FOUND:
                 logging.info(f"Torrent {torrent_id} confirmed NOT FOUND (404) by provider.")
                 return PROGRESS_RESULT_MISSING
@@ -348,7 +348,9 @@ class CheckingQueue:
             elif status_result.status in [
                 TorrentFetchStatus.RATE_LIMITED,
                 TorrentFetchStatus.PROVIDER_HANDLED_ERROR, # Error logged by provider, treat as temp
-                TorrentFetchStatus.SERVER_ERROR, # Often temporary
+                TorrentFetchStatus.SERVER_ERROR, # Often temporary (5xx)
+                TorrentFetchStatus.CLIENT_ERROR, # Other 4xx errors, treat as temp
+                TorrentFetchStatus.UNKNOWN_ERROR, # Non-HTTP or unparseable errors, treat as temp
                 TorrentFetchStatus.REQUEST_ERROR # Network issues, often temporary
             ]:
                 logging.warning(

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -2459,20 +2459,6 @@ class ProgramRunner:
     def invalidate_content_sources_cache(self):
         self.content_sources = None
 
-    def sync_time(self):
-        try:
-            ntp_client = ntplib.NTPClient()
-            response = ntp_client.request('pool.ntp.org', version=3)
-            system_time = time.time()
-            ntp_time = response.tx_time
-            offset = ntp_time - system_time
-            
-            if abs(offset) > 1:  # If offset is more than 1 second
-                logging.warning(f"System time is off by {offset:.2f} seconds. Adjusting task timers.")
-                self.last_run_times = {task: ntp_time for task in self.task_intervals}
-        except:
-            logging.error("Failed to synchronize time with NTP server")
-
     def task_adjust_intervals_for_load(self): # Renamed
         """
         Task to dynamically adjust non-critical task intervals based on queue load.
@@ -2846,31 +2832,35 @@ class ProgramRunner:
                 logging.error(f"Error sending notifications: {str(e_send)}", exc_info=True)
 
     def task_sync_time(self):
-        # self.sync_time() # Call the original sync_time logic
-        try:
-            ntp_client = ntplib.NTPClient()
-            # Increased timeout for robustness
-            response = ntp_client.request('pool.ntp.org', version=3, timeout=10)
-            system_time = time.time()
-            ntp_time = response.tx_time
-            offset = ntp_time - system_time
+        """Check system clock against NTP and log any significant offset.
 
-            logging.info(f"Time sync check: System time offset from NTP = {offset:.3f} seconds.")
+        Tries multiple NTP servers in order so that a single unresponsive
+        server does not cause the task to always fail.
+        """
+        ntp_servers = [
+            'pool.ntp.org',
+            'time.cloudflare.com',
+            'time.google.com',
+        ]
+        ntp_client = ntplib.NTPClient()
+        last_error = None
 
-            # Adjusting task timers based on offset is complex with APScheduler.
-            # APScheduler uses the system clock. If the system clock is significantly off,
-            # tasks might run at the "wrong" wall-clock time but consistently relative
-            # to the system clock. Correcting the system clock itself is the best approach.
-            # This task now mainly serves to LOG the offset.
-            if abs(offset) > 60:  # Log a warning if offset is more than 1 minute
-                logging.warning(f"System time offset is significant ({offset:.2f} seconds). Consider synchronizing the system clock.")
-            # Removing the part that tried to adjust self.last_run_times
-            # self.last_run_times = {task: ntp_time for task in self.task_intervals}
-        except ntplib.NTPException as e:
-            logging.error(f"Failed to synchronize time with NTP server: {e}")
-        except Exception as e:
-             # Catch potential socket errors, etc.
-             logging.error(f"Unexpected error during time synchronization: {e}")
+        for server in ntp_servers:
+            try:
+                response = ntp_client.request(server, version=3, timeout=5)
+                offset = response.tx_time - time.time()
+                logging.info(f"Time sync check via {server}: offset = {offset:.3f}s")
+                if abs(offset) > 60:
+                    logging.warning(f"System time offset is significant ({offset:.2f}s). Consider synchronising the system clock.")
+                return  # success — no need to try further servers
+            except ntplib.NTPException as e:
+                last_error = e
+                logging.debug(f"NTP error from {server}: {e}")
+            except Exception as e:
+                last_error = e
+                logging.debug(f"Could not reach NTP server {server}: {e}")
+
+        logging.error(f"Failed to synchronize time: all NTP servers unreachable. Last error: {last_error}")
 
     def task_backup_database(self):
         """
@@ -3647,12 +3637,47 @@ class ProgramRunner:
                     self.plex_scan_tick_counts[cache_key] = current_tick
                     # Trigger scan only if library checks are ENABLED
                     if not get_setting('Plex', 'disable_plex_library_checks', default=False):
-                         if current_tick <= 5:
+                         if current_tick <= 3:
                              should_trigger_scan = True
                              updated_items += 1 # Count item here when scan is intended
                              logging.info(f"File '{current_filename}' found (tick {current_tick}). Identifying relevant Plex sections to scan.")
                          else:
-                             logging.debug(f"File '{current_filename}' found (tick {current_tick}). Skipping Plex scan trigger (only triggers for first 5 ticks).")
+                             logging.info(f"File '{current_filename}' found (tick {current_tick}). Plex scan ticks exhausted — marking item {item_id} as Collected directly (file confirmed on disk, recentlyAdded did not resolve it).")
+                             # Fallback: recentlyAdded scan failed to resolve this item (e.g. file was already
+                             # in Plex before it entered Checking). File is confirmed on disk, so mark Collected.
+                             _conn_fb = None
+                             try:
+                                 _conn_fb = get_db_connection()
+                                 _cur_fb = _conn_fb.cursor()
+                                 _now_fb = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                                 _cur_fb.execute(
+                                     'UPDATE media_items SET state = "Collected", collected_at = ? WHERE id = ? AND state = "Checking" AND (ghostlisted IS NULL OR ghostlisted = 0)',
+                                     (_now_fb, item_id)
+                                 )
+                                 if _cur_fb.rowcount > 0:
+                                     _conn_fb.commit()
+                                     logging.info(f"Fallback: marked item {item_id} ({item_dict['title'] if item_dict['title'] else 'N/A'}) as Collected after {current_tick} ticks with file on disk.")
+                                     _fb_details = get_media_item_by_id(item_id)
+                                     if _fb_details:
+                                         handle_state_change(dict(_fb_details))
+                                         from database.database_writing import add_to_collected_notifications
+                                         _notif = dict(_fb_details)
+                                         _notif['is_upgrade'] = False
+                                         _notif['new_state'] = "Collected"
+                                         add_to_collected_notifications(_notif)
+                                     # Reset tick count so it doesn't keep trying on the now-Collected item
+                                     if cache_key in self.plex_scan_tick_counts:
+                                         del self.plex_scan_tick_counts[cache_key]
+                                 else:
+                                     logging.debug(f"Fallback: item {item_id} state already changed, skipping Collected update.")
+                             except sqlite3.Error as _fb_db_err:
+                                 logging.error(f"Fallback: DB error marking item {item_id} as Collected: {_fb_db_err}")
+                                 if _conn_fb: _conn_fb.rollback()
+                             except Exception as _fb_err:
+                                 logging.error(f"Fallback: unexpected error for item {item_id}: {_fb_err}", exc_info=True)
+                                 if _conn_fb: _conn_fb.rollback()
+                             finally:
+                                 if _conn_fb: _conn_fb.close()
                     else:
                          # If library checks are disabled, we don't trigger scans based on ticks here
                          # We just mark as collected
@@ -3865,12 +3890,45 @@ class ProgramRunner:
                     self.file_location_cache[cache_key] = 'exists'
                     current_tick = self.plex_scan_tick_counts.get(cache_key, 0) + 1
                     self.plex_scan_tick_counts[cache_key] = current_tick
-                    if current_tick <= 5:
+                    if current_tick <= 3:
                         should_trigger_scan = True
                         updated_items += 1 # Count item here when scan is intended
                         logging.info(f"File '{current_filename}' found (tick {current_tick}). Identifying relevant Plex sections to scan.")
                     else:
-                        logging.debug(f"File '{current_filename}' found (tick {current_tick}). Skipping Plex scan trigger (only triggers for first 5 ticks).")
+                        logging.info(f"File '{current_filename}' found (tick {current_tick}). Plex scan ticks exhausted — marking item {item_id} as Collected directly (file confirmed on disk, recentlyAdded did not resolve it).")
+                        _conn_fb = None
+                        try:
+                            _conn_fb = get_db_connection()
+                            _cur_fb = _conn_fb.cursor()
+                            _now_fb = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                            _cur_fb.execute(
+                                'UPDATE media_items SET state = "Collected", collected_at = ? WHERE id = ? AND state = "Checking" AND (ghostlisted IS NULL OR ghostlisted = 0)',
+                                (_now_fb, item_id)
+                            )
+                            if _cur_fb.rowcount > 0:
+                                _conn_fb.commit()
+                                logging.info(f"Fallback: marked item {item_id} ({item_dict['title'] if item_dict['title'] else 'N/A'}) as Collected after {current_tick} ticks with file on disk.")
+                                _fb_details = get_media_item_by_id(item_id)
+                                if _fb_details:
+                                    handle_state_change(dict(_fb_details))
+                                    from database.database_writing import add_to_collected_notifications
+                                    _notif = dict(_fb_details)
+                                    _notif['is_upgrade'] = False
+                                    _notif['new_state'] = "Collected"
+                                    add_to_collected_notifications(_notif)
+                                if cache_key in self.plex_scan_tick_counts:
+                                    del self.plex_scan_tick_counts[cache_key]
+                            else:
+                                logging.debug(f"Fallback: item {item_id} state already changed, skipping Collected update.")
+                        except sqlite3.Error as _fb_db_err:
+                            logging.error(f"Fallback: DB error marking item {item_id} as Collected: {_fb_db_err}")
+                            if _conn_fb: _conn_fb.rollback()
+                        except Exception as _fb_err:
+                            logging.error(f"Fallback: unexpected error for item {item_id}: {_fb_err}", exc_info=True)
+                            if _conn_fb: _conn_fb.rollback()
+                        finally:
+                            if _conn_fb: _conn_fb.close()
+                        continue
                 else:
                     # File not found
                     not_found_items += 1

--- a/routes/content_requestor_routes.py
+++ b/routes/content_requestor_routes.py
@@ -1,5 +1,7 @@
 from flask import Blueprint, jsonify, request, render_template
+from flask_login import current_user
 from .models import user_required, onboarding_required
+from .utils import is_user_system_enabled
 from utilities.web_scraper import search_trakt, parse_search_term, get_available_versions
 from cli_battery.app.direct_api import DirectAPI
 from queues.config_manager import load_config
@@ -184,10 +186,16 @@ def request_content():
             # Return a more specific message indicating the item might already exist or was filtered
             return jsonify({'error': 'Content already requested or already exists in library.'}), 400
             
-        # Add content source to all items
+        # Add content source to all items.
+        # When user system is enabled, record the requesting user's username as the detail
+        # so each user's requests get their own Plex label. Falls back to 'CD-Discover'.
+        if is_user_system_enabled() and current_user.is_authenticated:
+            source_detail = current_user.username
+        else:
+            source_detail = 'CD-Discover'
         for item in all_items:
-            item['content_source'] = 'content_requestor'
-            item['content_source_detail'] = 'CD-Discover'
+            item['content_source'] = 'content_requester'
+            item['content_source_detail'] = source_detail
             
         # Pass versions dictionary to add_wanted_items
         add_wanted_items(all_items, versions)

--- a/routes/discover_routes.py
+++ b/routes/discover_routes.py
@@ -1508,7 +1508,7 @@ def save_adaptive_list():
             'list_length_limit': 0,
             'plex_labels': {
                 'enabled': False,
-                'label_mode': 'source',
+                'label_mode': 'list_name',
                 'fixed_label': ''
             }
         }

--- a/routes/library_routes.py
+++ b/routes/library_routes.py
@@ -674,9 +674,9 @@ def get_library_data():
         else:
             query += " ORDER BY title COLLATE NOCASE ASC"
 
-        # Pagination
+        # Pagination — fetch one extra row to detect has_more without a separate COUNT query
         query += " LIMIT ? OFFSET ?"
-        params.extend([limit, offset])
+        params.extend([limit + 1, offset])
 
         # Execute query
         query_exec_start = time.time()
@@ -684,14 +684,13 @@ def get_library_data():
         items = [dict(row) for row in cursor.fetchall()]
         query_exec_time = time.time() - query_exec_start
 
-        # Get total count
-        count_start = time.time()
-        count_cursor = conn.execute(count_query, count_params)
-        total_count = count_cursor.fetchone()[0]
-        count_time = time.time() - count_start
-
-        # Check if there are more items
-        has_more = (offset + len(items)) < total_count
+        # Determine has_more and total using the n+1 trick (no separate COUNT query)
+        has_more = len(items) > limit
+        if has_more:
+            items = items[:limit]  # Drop the sentinel row
+            total_count = None     # Total unknown while more pages exist
+        else:
+            total_count = offset + len(items)  # Exact total on the last page
 
         # Batch-fetch episode counts for all shows in one query (PERFORMANCE OPTIMIZATION)
         episode_start = time.time()
@@ -792,7 +791,7 @@ def get_library_data():
 
         total_time = time.time() - start_time
         logging.info(f"Returning {len(formatted_items)} items (has_more={has_more}, total={total_count})")
-        logging.info(f"Performance: total={total_time:.3f}s, db_connect={db_connect_time:.3f}s, query={query_exec_time:.3f}s, count={count_time:.3f}s, episodes={episode_time:.3f}s, upcoming_release={upcoming_release_time:.3f}s, poster_cache_load={poster_cache_load_time:.3f}s, format={format_time:.3f}s")
+        logging.info(f"Performance: total={total_time:.3f}s, db_connect={db_connect_time:.3f}s, query={query_exec_time:.3f}s, episodes={episode_time:.3f}s, upcoming_release={upcoming_release_time:.3f}s, poster_cache_load={poster_cache_load_time:.3f}s, format={format_time:.3f}s")
 
         return jsonify({
             'success': True,

--- a/routes/poster_cache.py
+++ b/routes/poster_cache.py
@@ -1,8 +1,9 @@
 import os
 import pickle
+import threading
+import time as _time
 from datetime import datetime, timedelta
 import logging
-import time
 import uuid
 
 # Get db_content directory from environment variable with fallback
@@ -14,172 +15,182 @@ CACHE_EXPIRY_DAYS = 7  # Cache expires after 7 days
 
 UNAVAILABLE_POSTER = "/static/images/placeholder.png"
 
-def is_cache_healthy():
-    """Check if the cache file is valid and can be loaded"""
-    if not os.path.exists(CACHE_FILE):
-        return False
-        
-    try:
-        with open(CACHE_FILE, 'rb') as f:
-            # Try to read and unpickle the first few bytes
-            pickle.load(f)
-        return True
-    except PermissionError as e:
-        # Transient access issues (e.g., AV scanning or another process replacing the file)
-        logging.warning(f"Cache file temporarily unavailable due to permission error: {e}")
-        return False
-    except (EOFError, pickle.UnpicklingError, UnicodeDecodeError, FileNotFoundError) as e:
-        logging.error(f"Cache file is corrupted: {e}")
-        try:
-            # If corrupted, attempt to remove the file
-            os.remove(CACHE_FILE)
-            logging.info("Removed corrupted cache file")
-        except Exception as e:
-            logging.error(f"Failed to remove corrupted cache file: {e}")
-        return False
+# ---------------------------------------------------------------------------
+# In-memory cache — loaded once from disk, kept in RAM, saved periodically.
+# All reads/writes go through the module-level dict; disk I/O is batched.
+# ---------------------------------------------------------------------------
+_cache: dict = {}
+_cache_lock = threading.Lock()
+_cache_dirty = False          # True when in-memory cache differs from disk
+_cache_loaded = False         # True after first load from disk
+_save_interval_seconds = 60   # Flush to disk at most every 60 s
 
-def load_cache():
-    """Load the cache, performing a health check first"""
-    if not is_cache_healthy():
-        logging.info("Creating new cache due to health check failure")
+
+def _load_from_disk() -> dict:
+    """Load the pickle file from disk, returning an empty dict on any error."""
+    if not os.path.exists(CACHE_FILE):
         return {}
-        
     try:
         with open(CACHE_FILE, 'rb') as f:
             return pickle.load(f)
+    except (EOFError, pickle.UnpicklingError, UnicodeDecodeError, FileNotFoundError):
+        logging.error("poster_cache: cache file corrupted, starting fresh")
+        try:
+            os.remove(CACHE_FILE)
+        except Exception:
+            pass
+        return {}
     except Exception as e:
-        logging.warning(f"Error loading cache: {e}. Creating a new cache.")
+        logging.warning(f"poster_cache: could not load cache from disk: {e}")
         return {}
 
-def save_cache(cache):
-    """Save the cache to disk with validation and atomic writing"""
-    if not isinstance(cache, dict):
-        logging.error("Invalid cache format: cache must be a dictionary")
-        return False
-        
+
+def _ensure_loaded():
+    """Load the cache from disk the first time it is accessed."""
+    global _cache, _cache_loaded
+    if _cache_loaded:
+        return
+    with _cache_lock:
+        if not _cache_loaded:   # double-checked locking
+            _cache = _load_from_disk()
+            _cache_loaded = True
+            logging.info(f"poster_cache: loaded {len(_cache)} entries from disk")
+            _start_background_saver()
+
+
+def _save_to_disk(cache_snapshot: dict) -> bool:
+    """Atomically write a snapshot of the cache to disk."""
     cache_dir = os.path.dirname(CACHE_FILE)
     try:
         os.makedirs(cache_dir, exist_ok=True)
     except Exception as e:
-        logging.error(f"Failed to create cache directory '{cache_dir}': {e}")
+        logging.error(f"poster_cache: cannot create cache dir: {e}")
         return False
 
-    # Retry loop to mitigate transient PermissionError on Windows (e.g., AV/defender locking)
-    max_attempts = 5
-    backoff_seconds = 0.1
-    last_error = None
-
-    for attempt in range(1, max_attempts + 1):
-        # Unique temp file to avoid collisions between concurrent writers
-        temp_file = os.path.join(
-            cache_dir,
-            f"{os.path.basename(CACHE_FILE)}.{os.getpid()}.{int(time.time()*1000)}.{uuid.uuid4().hex}.tmp"
-        )
+    temp_file = os.path.join(
+        cache_dir,
+        f"{os.path.basename(CACHE_FILE)}.{os.getpid()}.{int(_time.time()*1000)}.{uuid.uuid4().hex}.tmp"
+    )
+    try:
+        with open(temp_file, 'wb') as f:
+            pickle.dump(cache_snapshot, f)
+        # Validate
+        with open(temp_file, 'rb') as f:
+            pickle.load(f)
+        os.replace(temp_file, CACHE_FILE)
+        return True
+    except Exception as e:
+        logging.error(f"poster_cache: failed to save cache to disk: {e}")
         try:
-            # Write to temporary file first
-            with open(temp_file, 'wb') as f:
-                pickle.dump(cache, f)
+            os.remove(temp_file)
+        except Exception:
+            pass
+        return False
 
-            # Validate the temporary file can be read back
-            try:
-                with open(temp_file, 'rb') as f:
-                    pickle.load(f)
-            except Exception as e:
-                logging.error(f"Validation of temporary cache file failed: {e}")
-                try:
-                    os.remove(temp_file)
-                except Exception:
-                    pass
-                last_error = e
-                time.sleep(backoff_seconds)
-                backoff_seconds = min(backoff_seconds * 2, 2.0)
-                continue
 
-            # Atomically replace the real cache file
-            try:
-                os.replace(temp_file, CACHE_FILE)
-            except PermissionError as e:
-                last_error = e
-                logging.warning(f"Permission error replacing cache file (attempt {attempt}/{max_attempts}): {e}")
-                try:
-                    os.remove(temp_file)
-                except Exception:
-                    pass
-                time.sleep(backoff_seconds)
-                backoff_seconds = min(backoff_seconds * 2, 2.0)
-                continue
+def _background_saver():
+    """Daemon thread: flushes the in-memory cache to disk every 60 seconds."""
+    global _cache_dirty
+    while True:
+        _time.sleep(_save_interval_seconds)
+        if _cache_dirty:
+            with _cache_lock:
+                if _cache_dirty:
+                    snapshot = dict(_cache)
+                    _cache_dirty = False
+            _save_to_disk(snapshot)
+            logging.debug("poster_cache: flushed to disk")
 
-            return True
 
-        except PermissionError as e:
-            last_error = e
-            logging.warning(f"Permission error writing temp cache file '{temp_file}' (attempt {attempt}/{max_attempts}): {e}")
-            try:
-                if os.path.exists(temp_file):
-                    os.remove(temp_file)
-            except Exception:
-                pass
-            time.sleep(backoff_seconds)
-            backoff_seconds = min(backoff_seconds * 2, 2.0)
-        except Exception as e:
-            last_error = e
-            logging.error(f"Error saving cache (attempt {attempt}/{max_attempts}): {e}")
-            try:
-                if os.path.exists(temp_file):
-                    os.remove(temp_file)
-            except Exception:
-                pass
-            time.sleep(backoff_seconds)
-            backoff_seconds = min(backoff_seconds * 2, 2.0)
+def _start_background_saver():
+    t = threading.Thread(target=_background_saver, daemon=True, name="poster-cache-saver")
+    t.start()
 
-    logging.error(f"Failed to save cache after {max_attempts} attempts: {last_error}")
-    return False
+
+# ---------------------------------------------------------------------------
+# Public API — same signatures as before, now backed by the in-memory dict
+# ---------------------------------------------------------------------------
+
+def is_cache_healthy():
+    """Returns True if the in-memory cache is populated (always True after load)."""
+    _ensure_loaded()
+    return True
+
+
+def load_cache() -> dict:
+    """Return the live in-memory cache dict (read-only snapshot not needed for callers)."""
+    _ensure_loaded()
+    return _cache
+
+
+def save_cache(cache: dict):
+    """Replace the in-memory cache and mark it dirty for background flush.
+
+    Kept for backwards compatibility — callers that previously called save_cache()
+    after modifying a local copy will still work correctly.
+    """
+    global _cache, _cache_dirty
+    if not isinstance(cache, dict):
+        logging.error("poster_cache: save_cache received non-dict; ignoring")
+        return False
+    with _cache_lock:
+        _cache = cache
+        _cache_dirty = True
+    return True
+
 
 def normalize_media_type(media_type):
     """Normalize media type to either 'tv' or 'movie'"""
     return 'tv' if media_type.lower() in ['tv', 'show', 'series'] else 'movie'
 
+
 def get_cached_poster_url(tmdb_id, media_type):
     if not tmdb_id:
         return UNAVAILABLE_POSTER
-        
-    cache = load_cache()
+    _ensure_loaded()
     normalized_type = normalize_media_type(media_type)
     cache_key = f"{tmdb_id}_{normalized_type}"
-    cache_item = cache.get(cache_key)
-    
+    with _cache_lock:
+        cache_item = _cache.get(cache_key)
     if cache_item:
         url, timestamp = cache_item
         if datetime.now() - timestamp < timedelta(days=CACHE_EXPIRY_DAYS):
             return url
-            
     return None
 
+
 def cache_poster_url(tmdb_id, media_type, url):
+    global _cache_dirty
     if not tmdb_id:
         return
-        
-    cache = load_cache()
+    _ensure_loaded()
     normalized_type = normalize_media_type(media_type)
     cache_key = f"{tmdb_id}_{normalized_type}"
-    cache[cache_key] = (url, datetime.now())
-    save_cache(cache)
+    with _cache_lock:
+        _cache[cache_key] = (url, datetime.now())
+        _cache_dirty = True
+
 
 def clean_expired_cache():
-    cache = load_cache()
+    global _cache_dirty
+    _ensure_loaded()
     current_time = datetime.now()
-    expired_keys = [
-        key for key, (_, timestamp) in cache.items()
-        if current_time - timestamp > timedelta(days=CACHE_EXPIRY_DAYS)
-    ]
-    for key in expired_keys:
-        del cache[key]
-    save_cache(cache)
+    with _cache_lock:
+        expired_keys = [
+            key for key, (_, timestamp) in _cache.items()
+            if current_time - timestamp > timedelta(days=CACHE_EXPIRY_DAYS)
+        ]
+        for key in expired_keys:
+            del _cache[key]
+        if expired_keys:
+            _cache_dirty = True
+
 
 def get_cached_media_meta(tmdb_id, media_type):
-    cache = load_cache()
+    _ensure_loaded()
     cache_key = f"{tmdb_id}_{media_type}_meta"
-    cache_item = cache.get(cache_key)
+    with _cache_lock:
+        cache_item = _cache.get(cache_key)
     if cache_item:
         media_meta, timestamp = cache_item
         if datetime.now() - timestamp < timedelta(days=CACHE_EXPIRY_DAYS):
@@ -190,24 +201,29 @@ def get_cached_media_meta(tmdb_id, media_type):
         logging.info(f"Cache miss for media meta {cache_key}")
     return None
 
+
 def cache_media_meta(tmdb_id, media_type, media_meta):
-    cache = load_cache()
+    global _cache_dirty
+    _ensure_loaded()
     cache_key = f"{tmdb_id}_{media_type}_meta"
-    cache[cache_key] = (media_meta, datetime.now())
-    save_cache(cache)
+    with _cache_lock:
+        _cache[cache_key] = (media_meta, datetime.now())
+        _cache_dirty = True
     logging.info(f"Cached media meta for {cache_key}")
+
 
 def cache_unavailable_poster(tmdb_id, media_type):
     cache_poster_url(tmdb_id, media_type, UNAVAILABLE_POSTER)
 
+
 def get_cached_trending_response():
     """Get cached trending response if available and not expired"""
-    cache = load_cache()
+    _ensure_loaded()
     cache_key = "all_trending_response"
-    cache_item = cache.get(cache_key)
+    with _cache_lock:
+        cache_item = _cache.get(cache_key)
     if cache_item:
         response_data, timestamp = cache_item
-        # Cache trending for 15 minutes (not 7 days)
         if datetime.now() - timestamp < timedelta(minutes=15):
             logging.info("Using cached trending response")
             return response_data
@@ -215,24 +231,30 @@ def get_cached_trending_response():
             logging.info("Cached trending response expired")
     return None
 
+
 def cache_trending_response(response_data):
     """Cache the entire trending response for 15 minutes"""
-    cache = load_cache()
+    global _cache_dirty
+    _ensure_loaded()
     cache_key = "all_trending_response"
-    cache[cache_key] = (response_data, datetime.now())
-    save_cache(cache)
+    with _cache_lock:
+        _cache[cache_key] = (response_data, datetime.now())
+        _cache_dirty = True
     logging.info("Cached trending response for 15 minutes")
+
 
 def clear_all_cache():
     """Clear the entire poster and artwork cache"""
+    global _cache, _cache_dirty
     try:
+        with _cache_lock:
+            _cache = {}
+            _cache_dirty = True
+        # Also remove the file immediately so it doesn't reload on restart
         if os.path.exists(CACHE_FILE):
             os.remove(CACHE_FILE)
             logging.info("Successfully cleared all poster/artwork cache")
-            return True
-        else:
-            logging.info("Cache file does not exist, nothing to clear")
-            return True
+        return True
     except Exception as e:
         logging.error(f"Error clearing cache: {e}")
         return False

--- a/routes/queues_routes.py
+++ b/routes/queues_routes.py
@@ -258,15 +258,6 @@ def get_rate_limiting_stats() -> Dict:
 queues_bp = Blueprint('queues', __name__)
 queue_manager = QueueManager()
 
-# Columns needed for queue display - avoids SELECT * on 79-column table
-QUEUE_DISPLAY_COLUMNS = [
-    'id', 'imdb_id', 'tmdb_id', 'title', 'year', 'type', 'state', 'version',
-    'season_number', 'episode_number', 'release_date', 'physical_release_date',
-    'airtime', 'content_source', 'filled_by_file', 'filled_by_torrent_id',
-    'wake_count', 'collected_at', 'last_updated', 'final_check_add_timestamp',
-    'force_priority', 'ghostlisted'
-]
-
 # Cache settings to avoid repeated database/file reads
 _settings_cache = {}
 _cache_timestamp = 0
@@ -278,6 +269,15 @@ _items_per_hour_cache = {
     'timestamp': 0
 }
 ITEMS_PER_HOUR_CACHE_DURATION = 300  # 5 minutes
+
+# Columns fetched from DB for queue display — avoids SELECT * on a wide table
+QUEUE_DISPLAY_COLUMNS = [
+    'id', 'imdb_id', 'tmdb_id', 'title', 'year', 'type', 'state', 'version',
+    'season_number', 'episode_number', 'release_date', 'physical_release_date',
+    'airtime', 'content_source', 'filled_by_file', 'filled_by_torrent_id',
+    'wake_count', 'collected_at', 'last_updated', 'final_check_add_timestamp',
+    'force_priority', 'ghostlisted'
+]
 
 def consolidate_items(items, limit=None):
     # Add timing for performance monitoring
@@ -447,7 +447,6 @@ def index():
                 if not isinstance(item, dict):
                     logging.warning(f"[QUEUE_ROUTES] Skipping non-dict item in {queue_name}: {type(item)}")
                     continue
-                # Only fetch wake_count if not already populated by SleepingQueue.update()
                 if 'wake_count' not in item or item['wake_count'] is None:
                     item['wake_count'] = queue_manager.get_wake_count(item['id'])
         elif queue_name == 'Pending Uncached':
@@ -853,39 +852,17 @@ def process_item_for_response(item, queue_name, currently_processing_upgrade_id=
             'error': str(e)
         }
 
-_scrape_time_cache = {}
-_scrape_time_cache_ts = 0
-SCRAPE_TIME_CACHE_DURATION = 30  # Invalidate cache every 30 seconds
-
-def compute_scrape_time_cached(item):
-    """Optimized scrape time calculation with actual caching by item fields."""
-    global _scrape_time_cache, _scrape_time_cache_ts
-    now_ts = time.time()
-
-    # Periodically invalidate the entire cache (settings may change)
-    if now_ts - _scrape_time_cache_ts > SCRAPE_TIME_CACHE_DURATION:
-        _scrape_time_cache = {}
-        _scrape_time_cache_ts = now_ts
-
-    cache_key = (
-        item.get('release_date'),
-        item.get('airtime'),
-        item.get('version'),
-        item.get('type'),
-        item.get('physical_release_date'),
-    )
-    if cache_key in _scrape_time_cache:
-        return _scrape_time_cache[cache_key]
-
-    result = _compute_scrape_time(item)
-    _scrape_time_cache[cache_key] = result
-    return result
+# Module-level cache for scrape time computation results.
+# Invalidated as a whole every SCRAPE_TIME_CACHE_DURATION seconds so that
+# setting changes (offsets, alt strategy, etc.) are picked up promptly.
+_scrape_time_cache: dict = {}
+_scrape_time_cache_ts: float = 0.0
+SCRAPE_TIME_CACHE_DURATION = 30  # seconds
 
 
 def _compute_scrape_time(item):
-    """Core scrape time calculation logic."""
+    """Core scrape time computation (no caching). Called by compute_scrape_time_cached."""
     try:
-        # Use cached settings
         use_alt = get_cached_setting('Debug', 'use_alternate_scrape_time_strategy', False)
         anchor_str = get_cached_setting('Debug', 'alternate_scrape_time_24h', '00:00')
 
@@ -912,25 +889,21 @@ def _compute_scrape_time(item):
             except Exception:
                 anchor_time = datetime.strptime('00:00', '%H:%M').time()
 
-            # Calculate the anchor datetime for today and tomorrow
             today_anchor = now.replace(hour=anchor_time.hour, minute=anchor_time.minute, second=0, microsecond=0)
             if now < today_anchor:
                 next_anchor = today_anchor
             else:
                 next_anchor = today_anchor + timedelta(days=1)
 
-            # Item's anchor datetime
             item_release_date = datetime.strptime(effective_release_date_str, '%Y-%m-%d').date()
             item_anchor_dt = datetime.combine(item_release_date, anchor_time)
 
-            # If item's anchor is in the future, show that
             if item_anchor_dt > now:
                 return item_anchor_dt.strftime('%Y-%m-%d %I:%M %p') + ' (Alt Scrape Time)'
             else:
                 return next_anchor.strftime('%Y-%m-%d %I:%M %p') + ' (Alt Scrape Time)'
 
         elif effective_release_date_str:
-            # Parse effective date
             release_date = datetime.strptime(effective_release_date_str, '%Y-%m-%d').date()
             if airtime_str:
                 try:
@@ -945,7 +918,6 @@ def _compute_scrape_time(item):
 
             release_datetime = datetime.combine(release_date, airtime)
 
-            # If a movie has no specific airtime, shift the base release time to the start of the next day.
             if item_type == 'movie' and not airtime_str:
                 release_datetime += timedelta(days=1)
 
@@ -973,6 +945,36 @@ def _compute_scrape_time(item):
         return "Error Calculating"
 
     return "Unknown"
+
+
+def compute_scrape_time_cached(item):
+    """Optimized scrape time calculation with per-key caching.
+
+    Cache is keyed by the 5-tuple of fields that affect the result and is
+    fully invalidated every SCRAPE_TIME_CACHE_DURATION seconds so that
+    settings changes are reflected without a restart.
+    """
+    global _scrape_time_cache, _scrape_time_cache_ts
+
+    current_ts = time.time()
+    if current_ts - _scrape_time_cache_ts > SCRAPE_TIME_CACHE_DURATION:
+        _scrape_time_cache.clear()
+        _scrape_time_cache_ts = current_ts
+
+    cache_key = (
+        item.get('release_date'),
+        item.get('airtime'),
+        item.get('version'),
+        item.get('type'),
+        item.get('physical_release_date'),
+    )
+
+    if cache_key in _scrape_time_cache:
+        return _scrape_time_cache[cache_key]
+
+    result = _compute_scrape_time(item)
+    _scrape_time_cache[cache_key] = result
+    return result
 
 @queues_bp.route('/api/rate-limiting-stats')
 @user_required
@@ -1127,22 +1129,25 @@ def queue_stream():
                     in_memory_time = time.time() - in_memory_start
                     logging.debug(f"[QUEUE_STREAM] In-memory queue processing took {in_memory_time:.3f}s")
 
-                    # Batch all DB count queries into a single connection
-                    all_db_states = list(COUNT_ONLY_QUEUES) + list(DB_FETCH_QUEUES)
+                    # Batch all state COUNT queries into a single DB connection
                     count_batch_start = time.time()
+                    all_db_states = list(COUNT_ONLY_QUEUES) + list(DB_FETCH_QUEUES)
                     try:
                         db_counts = get_item_counts_by_states(all_db_states)
-                    except Exception as db_err:
-                        logging.error(f"Error fetching batch counts: {db_err}")
+                    except Exception as count_err:
+                        logging.error(f"[QUEUE_STREAM] Batch count query failed: {count_err}")
                         db_counts = {s: 0 for s in all_db_states}
                     count_batch_time = time.time() - count_batch_start
-                    if count_batch_time > 0.1:
-                        logging.debug(f"[QUEUE_STREAM] Batch get_item_counts_by_states took {count_batch_time:.3f}s")
+                    logging.debug(f"[QUEUE_STREAM] Batch count query took {count_batch_time:.3f}s")
 
-                    # Process count-only queues (Blacklisted and Unreleased)
+                    # Process count-only queues (Blacklisted, Unreleased, Collected)
+                    count_only_start = time.time()
                     for queue_name in COUNT_ONLY_QUEUES:
                         queue_counts[queue_name] = db_counts.get(queue_name, 0)
                         final_contents[queue_name] = []
+
+                    count_only_time = time.time() - count_only_start
+                    logging.debug(f"[QUEUE_STREAM] Count-only queue processing took {count_only_time:.3f}s")
 
                     # Process database-backed queues (only Wanted and Final_Check now)
                     db_start = time.time()
@@ -1345,17 +1350,21 @@ def _format_remaining_time(hours_float: float) -> str:
 # ---------------------------------------------------------------------------
 # Helper: count Wanted items whose *computed* scrape time has passed
 # ---------------------------------------------------------------------------
-_ready_wanted_cache = {'value': 0, 'timestamp': 0}
-READY_WANTED_CACHE_DURATION = 60  # 60 seconds - this count changes slowly
+_ready_wanted_cache: dict = {'value': 0, 'timestamp': 0}
+READY_WANTED_CACHE_DURATION = 60  # seconds
+
 
 def get_ready_wanted_items_count() -> int:
-    """Return number of Wanted-queue entries that are ready to be scraped."""
+    """Return number of Wanted-queue entries that are ready to be scraped.
+
+    Result is cached for READY_WANTED_CACHE_DURATION seconds to avoid
+    iterating all Wanted items on every SSE cycle (every 2.5–5 s).
+    """
     global _ready_wanted_cache
     current_ts = time.time()
 
-    # Return cached value if still fresh
-    if (current_ts - _ready_wanted_cache['timestamp'] < READY_WANTED_CACHE_DURATION
-            and _ready_wanted_cache['timestamp'] > 0):
+    if (_ready_wanted_cache['timestamp'] > 0 and
+            current_ts - _ready_wanted_cache['timestamp'] < READY_WANTED_CACHE_DURATION):
         return _ready_wanted_cache['value']
 
     try:

--- a/routes/scraper_routes.py
+++ b/routes/scraper_routes.py
@@ -24,6 +24,7 @@ import hashlib
 from datetime import datetime, timezone, timedelta
 from database.torrent_tracking import record_torrent_addition, get_torrent_history, update_torrent_tracking
 from flask_login import current_user
+from .utils import is_user_system_enabled
 import asyncio
 from utilities.phalanx_db_cache_manager import PhalanxDBClassManager
 import re
@@ -545,8 +546,8 @@ def add_torrent_to_debrid():
                     'genres': json.dumps(genres),  # JSON encode the genres list
                     'current_score': current_score,
                     'real_debrid_original_title': torrent_info.get('original_filename'),
-                    'content_source': 'content_requestor',
-                    'content_source_detail': 'CD-Discover',
+                    'content_source': 'content_requester',
+                    'content_source_detail': current_user.username if (is_user_system_enabled() and current_user.is_authenticated) else 'CD-Discover',
                     'selected_folder': selected_folder,  # User-selected folder from dropdown
                     'selected_folder_is_custom': selected_folder_is_custom  # Flag for custom vs standard folders
                 }
@@ -602,7 +603,7 @@ def add_torrent_to_debrid():
                                 episode_item['episode_number'] = episode_num
                                 episode_item['current_score'] = current_score # Use the score passed for the pack
                                 episode_item['type'] = 'episode' # Ensure type is set for matching
-                                # Note: content_source inherited from item which already has 'content_requestor'
+                                # Note: content_source inherited from item which already has 'content_requester'
                                 
                                 # Get episode-specific release date and title
                                 first_aired = episode_data.get('first_aired')
@@ -1852,51 +1853,52 @@ def get_tv_details(tmdb_id):
 @scraper_bp.route('/tmdb_image/<path:image_path>')
 def tmdb_image_proxy(image_path):
     import requests
-    from flask import Response, make_response, request
-    from datetime import datetime, timedelta
+    from flask import Response, make_response
 
-    # Log if this is a fresh request or from browser cache
-    if_none_match = request.headers.get('If-None-Match')
-    if_modified_since = request.headers.get('If-Modified-Since')
-    
-    if if_none_match or if_modified_since:
-        logging.info(f"Browser requesting image with cache validation: {image_path}")
-    else:
-        logging.info(f"Fresh image request from browser: {image_path}")
+    # Sanitize path to prevent directory traversal
+    safe_path = image_path.replace('..', '').lstrip('/')
 
-    # Construct TMDB URL
-    tmdb_url = f'https://image.tmdb.org/t/p/{image_path}'
-    
+    # Check server-side disk cache first — serves any user/browser without re-fetching from TMDB
+    db_content_dir = os.environ.get('USER_DB_CONTENT', '/user/db_content')
+    cache_file = os.path.join(db_content_dir, 'image_cache', safe_path)
+
+    if os.path.exists(cache_file):
+        try:
+            with open(cache_file, 'rb') as f:
+                image_data = f.read()
+            ext = os.path.splitext(cache_file)[1].lower()
+            content_type = 'image/png' if ext == '.png' else 'image/jpeg'
+            resp = Response(image_data, content_type=content_type)
+            resp.headers['Cache-Control'] = 'public, max-age=604800'
+            return resp
+        except Exception as e:
+            logging.warning(f"Image cache read error for {safe_path}: {e}")
+            # Fall through to TMDB fetch
+
+    # Cache miss — fetch from TMDB CDN
+    tmdb_url = f'https://image.tmdb.org/t/p/{safe_path}'
+
     try:
-        # Get the image from TMDB
-        response = requests.get(tmdb_url, stream=True)
+        response = requests.get(tmdb_url, timeout=10)
         response.raise_for_status()
-        
-        # Create Flask response with the image content
-        proxy_response = Response(
-            response.iter_content(chunk_size=8192),
-            content_type=response.headers['Content-Type']
-        )
 
-        # Set cache control headers - only cache if web caching is enabled in settings
-        config = load_config()
-        enable_caching = config.get('UI Settings', {}).get('enable_caching', False)
+        image_data = response.content
+        content_type = response.headers.get('Content-Type', 'image/jpeg')
 
-        if enable_caching:
-            proxy_response.headers['Cache-Control'] = 'public, max-age=604800'  # 7 days in seconds
-            proxy_response.headers['Expires'] = (datetime.utcnow() + timedelta(days=7)).strftime('%a, %d %b %Y %H:%M:%S GMT')
-            # Add ETag for cache validation
-            proxy_response.headers['ETag'] = response.headers.get('ETag', '')
-        else:
-            proxy_response.headers['Cache-Control'] = 'no-cache'
-        
-        # Log successful image fetch
-        logging.info(f"Successfully fetched and cached image from TMDB: {image_path}")
-        
+        # Save to disk cache for future requests
+        try:
+            os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+            with open(cache_file, 'wb') as f:
+                f.write(image_data)
+        except Exception as e:
+            logging.warning(f"Could not write image cache for {safe_path}: {e}")
+
+        proxy_response = Response(image_data, content_type=content_type)
+        proxy_response.headers['Cache-Control'] = 'public, max-age=604800'
         return proxy_response
-        
+
     except requests.RequestException as e:
-        logging.error(f"Error proxying TMDB image: {e}")
+        logging.error(f"Error proxying TMDB image {safe_path}: {e}")
         return make_response('Image not found', 404)
 
 @scraper_bp.route('/check_cache_status', methods=['POST'])

--- a/routes/settings_routes.py
+++ b/routes/settings_routes.py
@@ -3046,11 +3046,11 @@ def get_enabled_content_sources_route():
     try:
         enabled_sources = get_enabled_content_sources()
         
-        # Manually add content_requestor and overseerr_webhook to the list for UI purposes
+        # Manually add content_requester and overseerr_webhook to the list for UI purposes
         enabled_sources.append({
-            'id': 'content_requestor',
+            'id': 'content_requester',
             'type': 'Internal', # Assign a placeholder type
-            'display_name': 'Content Requestor'
+            'display_name': 'Content Requester'
         })
 
         enabled_sources.append({
@@ -3072,8 +3072,8 @@ def save_content_source_order():
         if not isinstance(source_order_from_request, list):
              return jsonify({'success': False, 'error': 'Invalid order format provided'}), 400
 
-        # Filter out 'content_requestor' as it's not a real content source to be saved
-        filtered_source_order = [source_id for source_id in source_order_from_request if source_id != 'content_requestor']
+        # Filter out 'content_requester' as it's not a real content source to be saved
+        filtered_source_order = [source_id for source_id in source_order_from_request if source_id not in ('content_requester', 'content_requestor')]
         
         if not filtered_source_order:
             logging.info("Content source priority order is empty after filtering.")

--- a/static/js/discover.js
+++ b/static/js/discover.js
@@ -17,7 +17,7 @@ window.discoverState = {
     hasMore: true,
     isLoading: false,
     autoLoadCount: 0, // Track consecutive auto-loads to prevent infinite loops
-    maxAutoLoads: 3,  // Maximum pages to auto-load before requiring user scroll
+    maxAutoLoads: 1,  // Maximum pages to auto-load before requiring user scroll
     liveFilterEnabled: true, // Enable live filtering when filter values change
     genres: {
         movie: [],
@@ -4053,7 +4053,7 @@ function createResultItemHTML(item) {
     const year = (item.release_date || item.first_air_date || '').substring(0, 4) || '';
     const releaseDate = item.release_date || item.first_air_date || '';
     const formattedDate = releaseDate ? formatReleaseDate(releaseDate) : '';
-    const posterUrl = item.poster_path ? `https://image.tmdb.org/t/p/w500${item.poster_path}` : '/static/images/placeholder.png';
+    const posterUrl = item.poster_path ? `https://image.tmdb.org/t/p/w342${item.poster_path}` : '/static/images/placeholder.png';
     const overview = item.overview || 'No overview available.';
     const rating = item.vote_average ? item.vote_average.toFixed(1) : '';
 

--- a/static/js/library.js
+++ b/static/js/library.js
@@ -492,7 +492,10 @@ async function fetchItems(isReset = false) {
         if (data.success) {
             // Update state
             libraryState.hasMore = data.has_more;
-            libraryState.totalCount = data.total;
+            // total is null when more pages exist (n+1 trick), exact on the last page
+            if (data.total !== null && data.total !== undefined) {
+                libraryState.totalCount = data.total;
+            }
 
             // Render items
             if (data.items && data.items.length > 0) {
@@ -689,8 +692,8 @@ function createGridCard(item) {
         const plexPath = item.poster_path.substring(5); // Remove 'plex:' prefix
         posterUrl = `/library/plex_image${plexPath}`;
     } else if (item.poster_path && item.poster_path.startsWith('/')) {
-        // TMDB image - use TMDB proxy endpoint
-        posterUrl = `/scraper/tmdb_image/w300${item.poster_path}`;
+        // TMDB image - use TMDB proxy endpoint (w185 matches 160px card width)
+        posterUrl = `/scraper/tmdb_image/w185${item.poster_path}`;
     } else if (item.poster_path) {
         // Full URL or other format - use as-is
         posterUrl = item.poster_path;
@@ -1033,50 +1036,75 @@ function formatFileSize(bytes) {
     return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + units[i];
 }
 
-// Fetch missing poster from TMDB on-demand using TMDB ID
-async function fetchMissingPoster(tmdbId, mediaType, card) {
-    try {
-        const response = await fetch(`/library/fetch_poster/${tmdbId}/${mediaType}`);
-        const data = await response.json();
-
-        if (data.success && data.poster_path) {
-            // Update the poster image - handle both grid view (.media-poster img) and list view (.list-col-poster img)
-            // Also handle case where 'card' is already the img element itself
-            const img = card.tagName === 'IMG' ? card :
-                        (card.querySelector('.media-poster img') ||
-                         card.querySelector('.list-col-poster img'));
-            if (img) {
-                img.src = `/scraper/tmdb_image/w300${data.poster_path}`;
-                img.classList.remove('placeholder');
-            }
+// Concurrency-limited queue for on-demand poster fetches (prevents flooding TMDB API)
+const _posterFetchQueue = {
+    queue: [],
+    running: 0,
+    maxConcurrent: 5,
+    add(fn) {
+        this.queue.push(fn);
+        this._run();
+    },
+    _run() {
+        while (this.running < this.maxConcurrent && this.queue.length > 0) {
+            const fn = this.queue.shift();
+            this.running++;
+            fn().finally(() => {
+                this.running--;
+                this._run();
+            });
         }
-    } catch (error) {
-        console.debug(`Could not fetch poster for ${tmdbId}:`, error);
-        // Silent fail - placeholder already shown
     }
+};
+
+// Fetch missing poster from TMDB on-demand using TMDB ID
+function fetchMissingPoster(tmdbId, mediaType, card) {
+    _posterFetchQueue.add(async () => {
+        try {
+            const response = await fetch(`/library/fetch_poster/${tmdbId}/${mediaType}`);
+            const data = await response.json();
+
+            if (data.success && data.poster_path) {
+                // Update the poster image - handle both grid view (.media-poster img) and list view (.list-col-poster img)
+                // Also handle case where 'card' is already the img element itself
+                const img = card.tagName === 'IMG' ? card :
+                            (card.querySelector('.media-poster img') ||
+                             card.querySelector('.list-col-poster img'));
+                if (img) {
+                    img.src = `/scraper/tmdb_image/w185${data.poster_path}`;
+                    img.classList.remove('placeholder');
+                }
+            }
+        } catch (error) {
+            console.debug(`Could not fetch poster for ${tmdbId}:`, error);
+            // Silent fail - placeholder already shown
+        }
+    });
 }
 
 // Fetch missing poster from TMDB on-demand using IMDB ID (fallback when no TMDB ID)
-async function fetchMissingPosterByImdb(imdbId, mediaType, card) {
-    try {
-        const response = await fetch(`/library/fetch_poster_imdb/${imdbId}/${mediaType}`);
-        const data = await response.json();
+function fetchMissingPosterByImdb(imdbId, mediaType, card) {
+    _posterFetchQueue.add(async () => {
+        try {
+            const response = await fetch(`/library/fetch_poster_imdb/${imdbId}/${mediaType}`);
+            const data = await response.json();
 
-        if (data.success && data.poster_path) {
-            // Update the poster image - handle both grid view (.media-poster img) and list view (.list-col-poster img)
-            // Also handle case where 'card' is already the img element itself
-            const img = card.tagName === 'IMG' ? card :
-                        (card.querySelector('.media-poster img') ||
-                         card.querySelector('.list-col-poster img'));
-            if (img) {
-                img.src = `/scraper/tmdb_image/w300${data.poster_path}`;
-                img.classList.remove('placeholder');
+            if (data.success && data.poster_path) {
+                // Update the poster image - handle both grid view (.media-poster img) and list view (.list-col-poster img)
+                // Also handle case where 'card' is already the img element itself
+                const img = card.tagName === 'IMG' ? card :
+                            (card.querySelector('.media-poster img') ||
+                             card.querySelector('.list-col-poster img'));
+                if (img) {
+                    img.src = `/scraper/tmdb_image/w185${data.poster_path}`;
+                    img.classList.remove('placeholder');
+                }
             }
+        } catch (error) {
+            console.debug(`Could not fetch poster for IMDB ${imdbId}:`, error);
+            // Silent fail - placeholder already shown
         }
-    } catch (error) {
-        console.debug(`Could not fetch poster for IMDB ${imdbId}:`, error);
-        // Silent fail - placeholder already shown
-    }
+    });
 }
 
 function handleCardClick(item) {
@@ -1176,10 +1204,16 @@ function showSuccess(message) {
 
 function updateResultsInfo() {
     const displayedCount = libraryState.offset;
-    const totalText = libraryState.totalCount > 0
-        ? `Showing ${displayedCount} of ${libraryState.totalCount} items`
-        : 'Loading...';
-
+    let totalText;
+    if (libraryState.totalCount > 0) {
+        // Exact total known (last page reached)
+        totalText = `Showing ${displayedCount} of ${libraryState.totalCount} items`;
+    } else if (displayedCount > 0) {
+        // Still loading more pages — total not yet known
+        totalText = `Showing ${displayedCount} items`;
+    } else {
+        totalText = 'Loading...';
+    }
     resultsInfo.textContent = totalText;
 }
 

--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -172,8 +172,8 @@ const Loading = {
 
     show: function(message, details, hideCloseButton, hideProgress) {
         this.init();
-        if (message && this.messageElement) {
-            this.messageElement.textContent = message;
+        if (this.messageElement) {
+            this.messageElement.textContent = message || 'Processing command in background...';
         }
         if (details && this.detailsElement) {
             this.detailsElement.textContent = details;

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1183,6 +1183,39 @@ def check_local_file_for_item(item: Dict[str, Any], is_webhook: bool = False, ex
                      found_file = True
                      logging.info(f"Found file directly under original_files_path: {source_file}")
 
+            # 8. Check filename-as-folder pattern (single-file torrent on Real-Debrid).
+            # RD presents single-file torrents as: original_path/{file.mkv}/{file.mkv}
+            # None of the title-based attempts above catch this because the folder name
+            # includes the file extension, while stored titles typically do not.
+            if not found_file:
+                potential_folder = os.path.join(original_path, current_filename)
+                potential_path = os.path.join(potential_folder, current_filename)
+                logging.debug(f"Attempt 8: Checking filename-as-folder (RD single-file pattern): {potential_path}")
+                if os.path.exists(potential_path):
+                    source_file = potential_path
+                    source_folder = potential_folder
+                    found_file = True
+                    logging.info(f"Found file using filename-as-folder pattern: {source_file}")
+
+            # 9. Extended search: scan original_path subdirectories for the file.
+            # Only runs when extended_search=True (activated after 900s in checking queue)
+            # and all named-folder attempts have failed.
+            if not found_file and extended_search:
+                logging.info(f"Extended search: scanning '{original_path}' for '{current_filename}'")
+                try:
+                    for folder_name in os.listdir(original_path):
+                        candidate_folder = os.path.join(original_path, folder_name)
+                        if not os.path.isdir(candidate_folder):
+                            continue
+                        candidate_path = os.path.join(candidate_folder, current_filename)
+                        if os.path.exists(candidate_path):
+                            source_file = candidate_path
+                            source_folder = candidate_folder
+                            found_file = True
+                            logging.info(f"Extended search found file in folder '{folder_name}': {source_file}")
+                            break
+                except Exception as ext_err:
+                    logging.warning(f"Extended search failed: {ext_err}")
 
             # --- Handling not found after all checks ---
             if not found_file:

--- a/utilities/plex_functions.py
+++ b/utilities/plex_functions.py
@@ -1473,7 +1473,7 @@ def remove_show_from_plex(show_title: str, imdb_id: str = None, tmdb_id: str = N
             result['error'] = "Plex URL or token is empty"
             return result
 
-        plex = plexapi.server.PlexServer(plex_url, plex_token)
+        plex = plexapi.server.PlexServer(plex_url, plex_token, timeout=30)
         sections = plex.library.sections()
 
         logger.info(f"[PLEX_SHOW_DELETE] Searching for show: {show_title} (imdb={imdb_id}, tmdb={tmdb_id})")
@@ -1580,7 +1580,7 @@ def remove_season_from_plex(show_title: str, season_number: int, imdb_id: str = 
             result['error'] = "Plex URL or token is empty"
             return result
 
-        plex = plexapi.server.PlexServer(plex_url, plex_token)
+        plex = plexapi.server.PlexServer(plex_url, plex_token, timeout=30)
         sections = plex.library.sections()
 
         logger.info(f"[PLEX_SEASON_DELETE] Searching for show: {show_title} S{season_number:02d} (imdb={imdb_id}, tmdb={tmdb_id})")
@@ -1691,7 +1691,7 @@ def remove_movie_from_plex(movie_title: str, imdb_id: str = None, tmdb_id: str =
             result['error'] = "Plex URL or token is empty"
             return result
 
-        plex = plexapi.server.PlexServer(plex_url, plex_token)
+        plex = plexapi.server.PlexServer(plex_url, plex_token, timeout=30)
         sections = plex.library.sections()
 
         logger.info(f"[PLEX_MOVIE_DELETE] Searching for movie: {movie_title} (imdb={imdb_id}, tmdb={tmdb_id})")
@@ -1780,8 +1780,8 @@ def remove_file_from_plex(item_title, item_path, episode_title=None):
             logger.error("No Plex URL or token found in settings")
             return False
             
-        plex = plexapi.server.PlexServer(plex_url, plex_token)
-        
+        plex = plexapi.server.PlexServer(plex_url, plex_token, timeout=30)
+
         logger.info(f"Searching for item with title: {item_title}, episode title: {episode_title}, and file name: {item_path}")
         
         sections = plex.library.sections()
@@ -1799,10 +1799,22 @@ def remove_file_from_plex(item_title, item_path, episode_title=None):
                     try:
                         if section.type == 'show':
                             shows = section.search(title=item_title)
-                            
+
                             for show in shows:
-                                episodes = show.episodes()
-                                
+                                # If episode_title is known, filter to matching episodes only
+                                # (much faster for large shows — avoids fetching all episodes).
+                                # Falls back to all episodes if the filtered result is empty,
+                                # preserving backward compatibility.
+                                if episode_title:
+                                    try:
+                                        episodes = show.episodes(title=episode_title)
+                                        if not episodes:
+                                            episodes = show.episodes()
+                                    except Exception:
+                                        episodes = show.episodes()
+                                else:
+                                    episodes = show.episodes()
+
                                 for episode in episodes:
                                     if hasattr(episode, 'media'):
                                         for media in episode.media:
@@ -1917,7 +1929,7 @@ def scan_and_empty_plex_trash(paths: list = None, section_type: str = None) -> d
             result['success'] = False
             return result
 
-        plex = plexapi.server.PlexServer(plex_url, plex_token)
+        plex = plexapi.server.PlexServer(plex_url, plex_token, timeout=30)
         sections = plex.library.sections()
 
         # Track which sections were actually scanned

--- a/utilities/plex_label_manager.py
+++ b/utilities/plex_label_manager.py
@@ -258,7 +258,7 @@ def serialize_content_sources(sources_list: List[Dict[str, Any]]) -> str:
     return json.dumps(sources_list)
 
 
-@retry_on_db_lock(max_attempts=10, initial_wait=0.5, backoff_factor=2)
+@retry_on_db_lock(max_attempts=10, initial_wait=0.5, backoff_factor=2, long_execution_threshold_seconds=5.0)
 def add_label_to_item(item_id: int, label: str, source_name: str, apply_to_plex: bool = True) -> bool:
     """
     Add a label to an item with source tracking
@@ -281,11 +281,14 @@ def add_label_to_item(item_id: int, label: str, source_name: str, apply_to_plex:
         logging.warning(f"Cannot add empty label to item {item_id}")
         return False
 
+    # Phase 1: DB work — read, compute, write, close.
+    # The connection is released BEFORE the Plex API call to avoid holding it
+    # open during a potentially slow HTTP request (100ms–2s), which caused
+    # lock contention under concurrent load.
     conn = get_db_connection()
-    # Set a timeout for database locks (30 seconds)
-    # The retry decorator will handle retries if this timeout is still exceeded
     conn.execute("PRAGMA busy_timeout = 30000")
     cursor = conn.cursor()
+    item_title = 'unknown'
 
     try:
         # Get current item data
@@ -299,8 +302,6 @@ def add_label_to_item(item_id: int, label: str, source_name: str, apply_to_plex:
         item_title = row['title']
         plex_labels = parse_plex_labels(row['plex_labels'])
         content_sources = parse_content_sources(row['content_sources'])
-
-        added_to_plex = False
 
         if label not in plex_labels:
             # First source adding this label
@@ -318,35 +319,20 @@ def add_label_to_item(item_id: int, label: str, source_name: str, apply_to_plex:
             else:
                 logging.debug(f"Label '{label}' already tracked by {source_name} on '{item_title}'")
 
-        # Always attempt to sync to Plex when apply_to_plex=True
-        # This ensures labels are synced even if they were previously added to DB but failed to sync
-        if apply_to_plex:
-            success = apply_label_to_plex(item_id, label)
-            if success:
-                added_to_plex = True
-                logging.debug(f"Synced label '{label}' to Plex for '{item_title}'")
-            else:
-                logging.debug(f"Label '{label}' not synced to Plex for '{item_title}' (may already exist or item not in Plex)")
-        else:
-            logging.debug(f"Dry-run: Would sync label '{label}' to Plex for '{item_title}'")
-
         # Update content_sources list if source not already tracked
         if source_name not in [src['source'] for src in content_sources]:
             content_sources.append({'source': source_name, 'added_at': time.strftime('%Y-%m-%d %H:%M:%S')})
             logging.debug(f"Added source '{source_name}' to content_sources for item {item_id}")
 
-        # Serialize data for database
+        # Serialize and write to DB.
+        # plex_labels_last_synced reset to NULL so periodic sync catches any missed Plex apply.
         serialized_labels = serialize_plex_labels(plex_labels)
         serialized_sources = serialize_content_sources(content_sources)
-
-        # Update database with both plex_labels and content_sources
         cursor.execute(
-            'UPDATE media_items SET plex_labels = ?, content_sources = ? WHERE id = ?',
+            'UPDATE media_items SET plex_labels = ?, content_sources = ?, plex_labels_last_synced = NULL WHERE id = ?',
             (serialized_labels, serialized_sources, item_id)
         )
         conn.commit()
-
-        return added_to_plex
 
     except sqlite3.OperationalError as e:
         # Let database lock errors propagate to the retry decorator
@@ -366,7 +352,22 @@ def add_label_to_item(item_id: int, label: str, source_name: str, apply_to_plex:
         return False
     finally:
         cursor.close()
-        conn.close()
+        conn.close()  # Release DB connection before Plex API call
+
+    # Phase 2: Plex API call — no DB connection held during HTTP I/O.
+    # apply_label_to_plex manages its own connection for plex_labels_last_synced.
+    added_to_plex = False
+    if apply_to_plex:
+        success = apply_label_to_plex(item_id, label)
+        if success:
+            added_to_plex = True
+            logging.debug(f"Synced label '{label}' to Plex for '{item_title}'")
+        else:
+            logging.debug(f"Label '{label}' not synced to Plex for '{item_title}' (may already exist or item not in Plex)")
+    else:
+        logging.debug(f"Dry-run: Would sync label '{label}' to Plex for '{item_title}'")
+
+    return added_to_plex
 
 
 def remove_label_from_item(item_id: int, label: str, source_name: str, remove_from_plex: bool = True) -> bool:
@@ -912,6 +913,35 @@ def apply_labels_for_item(item: Dict[str, Any]) -> int:
     else:
         logging.warning(f"No labels were applied to '{item_title}' even though {len(labels)} were determined")
 
+    # Secondary sources: apply labels for any additional sources recorded in content_sources
+    # These are sources that discovered this item before it was Collected (via pending_source_records path)
+    try:
+        sec_conn = get_db_connection()
+        row = sec_conn.execute('SELECT content_sources FROM media_items WHERE id = ?', (item_id,)).fetchone()
+        sec_conn.close()
+        additional_sources = parse_content_sources(row['content_sources'] if row else None)
+
+        for src_entry in additional_sources:
+            src_name = src_entry.get('source')
+            src_detail = src_entry.get('detail')
+
+            # Skip: no detail (legacy entry), same as primary source (already handled), or unknown
+            if not src_detail or src_name == content_source or src_detail.lower() == 'unknown':
+                continue
+
+            temp_item = {'content_source': src_name, 'content_source_detail': src_detail}
+            secondary_labels = determine_labels_for_item(temp_item)
+            for label in secondary_labels:
+                try:
+                    success = add_label_to_item(item_id, label, src_name, apply_to_plex=True)
+                    if success:
+                        labels_applied += 1
+                        logging.info(f"Applied secondary source label '{label}' from {src_name} to '{item_title}'")
+                except Exception as e:
+                    logging.error(f"Error applying secondary label '{label}' from {src_name} to item {item_id}: {e}")
+    except Exception as e:
+        logging.warning(f"Error processing secondary sources for item {item_id}: {e}")
+
     return labels_applied
 
 
@@ -1001,7 +1031,7 @@ def get_collected_items_with_pending_labels(movie_limit: int = 50, show_limit: i
                 AND plex_labels IS NOT NULL
                 AND plex_labels != 'null'
                 AND plex_labels != '{}'
-                AND (plex_labels_last_synced IS NULL OR plex_labels_last_synced < last_updated)
+                AND plex_labels_last_synced IS NULL
                 ORDER BY last_updated DESC
                 LIMIT ?
             )
@@ -1016,7 +1046,7 @@ def get_collected_items_with_pending_labels(movie_limit: int = 50, show_limit: i
                 AND plex_labels IS NOT NULL
                 AND plex_labels != 'null'
                 AND plex_labels != '{}'
-                AND (plex_labels_last_synced IS NULL OR plex_labels_last_synced < last_updated)
+                AND plex_labels_last_synced IS NULL
                 GROUP BY title, tmdb_id
                 ORDER BY last_updated DESC
                 LIMIT ?
@@ -1213,9 +1243,15 @@ def backfill_content_source_detail() -> Dict[str, Any]:
             if idx % 100 == 0:
                 logging.info(f"Processing remaining item {idx}/{len(items)}")
 
-            # Special handling for internal CLI Debrid sources
+            # Special handling for internal CLI Debrid sources.
+            # If the item already has a non-null, non-unknown detail (e.g., a username set when
+            # user auth was enabled), preserve it — only fall back to 'CD-Discover' when blank.
             if content_source in ['content_requestor', 'content_requester']:
-                detail_value = 'CD-Discover'
+                existing_detail = item.get('content_source_detail')
+                if existing_detail and existing_detail.lower() != 'unknown':
+                    detail_value = existing_detail
+                else:
+                    detail_value = 'CD-Discover'
             elif content_source == 'Collected_1':
                 detail_value = 'CD-Library'
             # Check if this content source exists in config

--- a/utilities/plex_removal_cache.py
+++ b/utilities/plex_removal_cache.py
@@ -131,9 +131,12 @@ def process_removal_cache(min_age_hours: int = 6) -> None:
     # min_age_seconds = 0 # For testing, set to 0 to process all items immediately
     
     # Build a new cache dictionary with only the entries that need to be kept for the next run.
-    next_run_cache = {} 
+    next_run_cache = {}
     # Define states that indicate an item is actively managed and should not be removed by cache
     active_db_states = ['Collected', 'Upgrading', 'Checking']
+
+    # Collect paths that need a Plex scan+trash after processing all items (batched for efficiency)
+    pending_scan_paths = set()
 
     for key, entries in cache.items():
         remaining_entries_for_key = []
@@ -185,17 +188,12 @@ def process_removal_cache(min_age_hours: int = 6) -> None:
                             logging.info(f"Successfully processed Plex removal for {item_title} ({item_path}).")
                             entry_should_be_kept_in_cache = False # Successfully processed, so don't keep this entry.
                         else:
-                            # Direct removal failed (possibly 400 error) - try scan & empty trash as fallback
-                            logging.warning(f"Direct Plex removal failed for {item_title}. Trying scan & empty trash...")
-                            try:
-                                # Determine section type: if episode_title exists, it's a show; otherwise, movie
-                                section_type = 'show' if episode_title else 'movie'
-                                scan_paths = [os.path.dirname(item_path)] if item_path else None
-                                scan_and_empty_plex_trash(paths=scan_paths, section_type=section_type)
-                                logging.info(f"Triggered library scan and trash empty for {item_title} (section_type={section_type}).")
-                                entry_should_be_kept_in_cache = False # Processed via fallback, don't keep.
-                            except Exception as scan_err:
-                                logging.warning(f"Scan & empty trash also failed for {item_title}: {scan_err}. Keeping in cache.")
+                            # Direct removal failed — queue the parent path for a batched scan+trash
+                            # at the end of this run (one Plex API call instead of one per item).
+                            logging.warning(f"Direct Plex removal failed for {item_title}. Queuing for batch scan & empty trash.")
+                            if item_path:
+                                pending_scan_paths.add(os.path.dirname(item_path))
+                            entry_should_be_kept_in_cache = False  # Processed via fallback, don't keep.
                     except Exception as e:
                         logging.error(f"Error during Plex removal for {item_title} ({item_path}): {str(e)}. Keeping in cache.")
                         # entry_should_be_kept_in_cache remains True if Plex removal fails.
@@ -210,6 +208,14 @@ def process_removal_cache(min_age_hours: int = 6) -> None:
         if remaining_entries_for_key:
             next_run_cache[key] = remaining_entries_for_key
             
+    # Perform one batched scan+trash for all paths that needed it this run
+    if pending_scan_paths:
+        try:
+            logging.info(f"Running batched Plex scan & empty trash for {len(pending_scan_paths)} path(s).")
+            scan_and_empty_plex_trash(paths=list(pending_scan_paths), section_type=None)
+        except Exception as scan_err:
+            logging.warning(f"Batched scan & empty trash failed: {scan_err}. Items still removed from cache.")
+
     _save_cache(next_run_cache)
     if not next_run_cache and cache: # Cache was not empty before, but is now
         logging.info("Finished processing Plex removal cache. All items processed.")


### PR DESCRIPTION
- Plex Checking fallback: mark as Collected after 3 scan ticks when file confirmed on disk (fixes stuck items when recentlyAdded misses pre-existing files)
- plex_label_manager: release DB connection before Plex API call to reduce lock contention
- plex_label_manager: reset plex_labels_last_synced=NULL on label write so periodic sync catches missed applies
- plex_label_manager: simplify pending-sync query to IS NULL only
- plex_label_manager: apply secondary-source labels from content_sources when item reaches Collected
- wanted_items: apply Plex labels for second source on already-Collected items; record source for not-yet-Collected items
- local_library_scan: add filename-as-folder pattern (Attempt 8) and extended directory scan (Attempt 9) for RD single-file torrents
- plex_functions: add timeout=30 to all PlexServer calls; filter episodes by title before full fetch
- plex_removal_cache: batch scan+trash calls instead of one per item
- checking_queue: treat CLIENT_ERROR and UNKNOWN_ERROR as transient torrent fetch failures
- database_reading: add columns param to stream_all_media_items; add get_item_counts_by_states
- content_requestor: use requesting user's username as content_source_detail for per-user Plex labels
- NTP sync: try multiple servers with fallback instead of single pool.ntp.org
- library.js: concurrency-limited poster fetch queue; reduce poster size to w185
- discover.js: reduce max auto-loads to 1; reduce poster size to w342
- loading.js: show fallback message when message param is undefined