### PR TITLE
Fix TVDB airtime timezone using network country code

### DIFF
--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -89,6 +89,24 @@ _NETWORK_TIMEZONE_MAP = {
     # Add more as needed
 }
 
+# Country code → default IANA timezone fallback
+# TVDB airsTime is in the show's local broadcast timezone
+_COUNTRY_TIMEZONE_MAP = {
+    'usa': 'America/New_York',
+    'can': 'America/New_York',
+    'gbr': 'Europe/London',
+    'aus': 'Australia/Sydney',
+    'jpn': 'Asia/Tokyo',
+    'kor': 'Asia/Seoul',
+    'deu': 'Europe/Berlin',
+    'fra': 'Europe/Paris',
+    'ita': 'Europe/Rome',
+    'esp': 'Europe/Madrid',
+    'bra': 'America/Sao_Paulo',
+    'ind': 'Asia/Kolkata',
+    'nzl': 'Pacific/Auckland',
+}
+
 
 def is_available() -> bool:
     """Check if TVDB API key is configured."""
@@ -432,20 +450,22 @@ def _map_status(tvdb_status: str | None) -> str | None:
     return _STATUS_MAP.get(tvdb_status, tvdb_status.lower())
 
 
-def _infer_timezone_from_network(network_name: str | None) -> str | None:
-    """Infer IANA timezone from network name when TVDB doesn't provide it."""
-    if not network_name:
-        return None
+def _infer_timezone_from_network(network_name: str | None, country: str | None = None) -> str | None:
+    """Infer IANA timezone from network name or country when TVDB doesn't provide it."""
+    if network_name:
+        # Direct match
+        if network_name in _NETWORK_TIMEZONE_MAP:
+            return _NETWORK_TIMEZONE_MAP[network_name]
 
-    # Direct match
-    if network_name in _NETWORK_TIMEZONE_MAP:
-        return _NETWORK_TIMEZONE_MAP[network_name]
+        # Partial match (case-insensitive)
+        network_lower = network_name.lower()
+        for net_key, tz in _NETWORK_TIMEZONE_MAP.items():
+            if net_key.lower() in network_lower:
+                return tz
 
-    # Partial match (case-insensitive)
-    network_lower = network_name.lower()
-    for net_key, tz in _NETWORK_TIMEZONE_MAP.items():
-        if net_key.lower() in network_lower:
-            return tz
+    # Fall back to country code
+    if country:
+        return _COUNTRY_TIMEZONE_MAP.get(country.lower())
 
     return None
 
@@ -490,13 +510,14 @@ def get_show_data(imdb_id: str) -> Optional[dict]:
     network = raw.get('originalNetwork')
     airs_timezone = network.get('timezone') if isinstance(network, dict) else None
 
-    # If TVDB doesn't provide timezone, try to infer from network name
+    # If TVDB doesn't provide timezone, try to infer from network name or country
     if not airs_timezone and airs_time:
         network_name = network.get('name') if isinstance(network, dict) else None
-        inferred_tz = _infer_timezone_from_network(network_name)
+        network_country = network.get('country') if isinstance(network, dict) else None
+        inferred_tz = _infer_timezone_from_network(network_name, network_country)
         if inferred_tz:
             airs_timezone = inferred_tz
-            logger.info(f"TVDB: Inferred timezone '{inferred_tz}' for network '{network_name}' (show {imdb_id})")
+            logger.info(f"TVDB: Inferred timezone '{inferred_tz}' for network '{network_name}' country '{network_country}' (show {imdb_id})")
         else:
             logger.debug(f"TVDB: No timezone for show {imdb_id} (network: {network_name}), will use TMDB/Trakt batch fetch")
 
@@ -572,9 +593,10 @@ def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
         if network_tz:
             airs['timezone'] = network_tz
         elif airs.get('time'):
-            # Try to infer timezone from network name
+            # Try to infer timezone from network name or country
             network_name = raw['originalNetwork'].get('name')
-            inferred_tz = _infer_timezone_from_network(network_name)
+            network_country = raw['originalNetwork'].get('country')
+            inferred_tz = _infer_timezone_from_network(network_name, network_country)
             if inferred_tz:
                 airs['timezone'] = inferred_tz
 
@@ -613,10 +635,11 @@ def _extract_seasons_from_extended(raw: dict) -> Optional[dict]:
     network = raw.get('originalNetwork')
     airs_timezone = network.get('timezone') if isinstance(network, dict) else None
 
-    # If TVDB doesn't provide timezone, try to infer from network name
+    # If TVDB doesn't provide timezone, try to infer from network name or country
     if not airs_timezone and airs_time:
         network_name = network.get('name') if isinstance(network, dict) else None
-        inferred_tz = _infer_timezone_from_network(network_name)
+        network_country = network.get('country') if isinstance(network, dict) else None
+        inferred_tz = _infer_timezone_from_network(network_name, network_country)
         if inferred_tz:
             airs_timezone = inferred_tz
 
@@ -694,10 +717,11 @@ def get_show_seasons_and_episodes(imdb_id: str, include_specials: bool = False) 
     network = raw.get('originalNetwork')
     airs_timezone = network.get('timezone') if isinstance(network, dict) else None
 
-    # If TVDB doesn't provide timezone, try to infer from network name
+    # If TVDB doesn't provide timezone, try to infer from network name or country
     if not airs_timezone and airs_time:
         network_name = network.get('name') if isinstance(network, dict) else None
-        inferred_tz = _infer_timezone_from_network(network_name)
+        network_country = network.get('country') if isinstance(network, dict) else None
+        inferred_tz = _infer_timezone_from_network(network_name, network_country)
         if inferred_tz:
             airs_timezone = inferred_tz
 


### PR DESCRIPTION
## Summary
- TVDB never populates `originalNetwork.timezone`, so `airsTime` (e.g. "22:00" for HBO) had no timezone context
- Without timezone, the code fell back to TMDB/Trakt batch fetch which only returns dates → midnight UTC → converting to local time shifted dates back a day
- Added `_COUNTRY_TIMEZONE_MAP` and pass `originalNetwork.country` to `_infer_timezone_from_network` as a fallback (covers US/UK/AU/JP/KR/EU networks)
- Example: HBO's "Knight of the Seven Kingdoms" S01E06 now correctly shows **Feb 22 20:00 MT** instead of Feb 21 17:00 MT

## What changed
- `cli_battery/app/tvdb_client.py` only — no other files touched
- Added `_COUNTRY_TIMEZONE_MAP` dict (country code → IANA timezone)
- Updated `_infer_timezone_from_network()` to accept optional `country` param as fallback
- Updated all 4 call sites to pass `network.get('country')`

## Test plan
- [x] Built and deployed test container, verified timezone inference logs: `Inferred timezone 'America/New_York' for network 'HBO' country 'usa'`
- [x] Verified Knight of the Seven Kingdoms episodes return correct UTC timestamps (e.g. `2026-02-23T03:00:00.000Z` for S01E06)
- [x] Spot-checked multiple shows: HBO, Apple TV+, FOX, BBC One — all infer correct timezones
- [x] No conflict with mash's recent `direct_api.py` DetachedInstanceError fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)