### PR TITLE
Fixes and Improvements

### DIFF
--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -496,6 +496,33 @@ def get_show_data(imdb_id: str) -> Optional[dict]:
         from . import trakt_client
         return trakt_client.get_show_data(imdb_id)
 
+    # Validate that the TVDB show's IMDb ID matches what we requested.
+    # A stale cache entry could map the wrong TVDB ID to this IMDb ID.
+    remote_ids_raw = raw.get('remoteIds', [])
+    tvdb_imdb_id = None
+    if isinstance(remote_ids_raw, list):
+        for rid in remote_ids_raw:
+            if isinstance(rid, dict):
+                source_name = (rid.get('sourceName', '') or '').lower()
+                rid_val = rid.get('id', '')
+                if 'imdb' in source_name and rid_val and rid_val.startswith('tt'):
+                    tvdb_imdb_id = rid_val
+                    break
+    if tvdb_imdb_id and tvdb_imdb_id != imdb_id:
+        logger.warning(
+            f"TVDB IMDb mismatch for show: requested {imdb_id}, TVDB series {tvdb_id} has {tvdb_imdb_id}. "
+            f"Invalidating stale cache entry and falling back to Trakt."
+        )
+        try:
+            with managed_session() as session:
+                stale = session.query(TVDBToIMDBMapping).filter_by(imdb_id=imdb_id, tvdb_id=str(tvdb_id)).first()
+                if stale:
+                    session.delete(stale)
+        except Exception as e:
+            logger.debug(f"Could not remove stale TVDB mapping for {imdb_id}: {e}")
+        from . import trakt_client
+        return trakt_client.get_show_data(imdb_id)
+
     # Build Trakt-compatible show dict
     show_data = _build_show_dict(raw, imdb_id, tvdb_id)
 
@@ -846,6 +873,33 @@ def get_movie_data(imdb_id: str) -> Optional[dict]:
     raw = resp.json().get('data', {})
     if not raw:
         logger.warning(f"TVDB returned empty data for movie {imdb_id} (TVDB ID: {tvdb_id}), trying Trakt fallback")
+        from . import trakt_client
+        return trakt_client.get_movie_data(imdb_id)
+
+    # Validate that the TVDB movie's IMDb ID matches what we requested.
+    # A stale cache entry could map the wrong TVDB ID to this IMDb ID.
+    remote_ids_raw = raw.get('remoteIds', [])
+    tvdb_imdb_id = None
+    if isinstance(remote_ids_raw, list):
+        for rid in remote_ids_raw:
+            if isinstance(rid, dict):
+                source_name = (rid.get('sourceName', '') or '').lower()
+                rid_val = rid.get('id', '')
+                if 'imdb' in source_name and rid_val and rid_val.startswith('tt'):
+                    tvdb_imdb_id = rid_val
+                    break
+    if tvdb_imdb_id and tvdb_imdb_id != imdb_id:
+        logger.warning(
+            f"TVDB IMDb mismatch for movie: requested {imdb_id}, TVDB movie {tvdb_id} has {tvdb_imdb_id}. "
+            f"Invalidating stale cache entry and falling back to Trakt."
+        )
+        try:
+            with managed_session() as session:
+                stale = session.query(TVDBToIMDBMapping).filter_by(imdb_id=imdb_id, tvdb_id=str(tvdb_id)).first()
+                if stale:
+                    session.delete(stale)
+        except Exception as e:
+            logger.debug(f"Could not remove stale TVDB mapping for {imdb_id}: {e}")
         from . import trakt_client
         return trakt_client.get_movie_data(imdb_id)
 

--- a/content_checkers/plex_rss_watchlist.py
+++ b/content_checkers/plex_rss_watchlist.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import feedparser
 from typing import List, Dict, Any, Tuple, Union
 from utilities.settings import get_setting
-from database.database_reading import get_media_item_presence
+from database.database_reading import get_media_item_presence, get_media_item_presence_overall
 from cli_battery.app import trakt_client
 from cli_battery.app.database import DatabaseManager
 
@@ -144,8 +144,8 @@ def get_wanted_from_plex_rss(rss_url: str, versions: Dict[str, bool]) -> List[Tu
                     media_type = 'tv'
 
                 # Check if the item is already collected
-                item_state = get_media_item_presence(imdb_id=imdb_id)
-                if item_state == "Collected" and should_remove:
+                item_state = get_media_item_presence_overall(imdb_id=imdb_id)
+                if item_state in ("Collected", "Partial") and should_remove:
                     if media_type == 'tv':
                         if keep_series:
                             logging.debug(f"Keeping collected TV series from RSS: {imdb_id} ('{entry_title}') - keep_series is enabled")

--- a/content_checkers/plex_watchlist.py
+++ b/content_checkers/plex_watchlist.py
@@ -64,7 +64,7 @@ patch_logger.info(f"{LOG_FLAG_PATCH} Imported MyPlexAccount from plexapi.myplex.
 
 from typing import List, Dict, Any, Tuple
 from utilities.settings import get_setting
-from database.database_reading import get_media_item_presence
+from database.database_reading import get_media_item_presence, get_media_item_presence_overall
 from queues.config_manager import load_config
 from cli_battery.app import trakt_client
 from cli_battery.app.direct_api import DirectAPI
@@ -315,10 +315,10 @@ def get_wanted_from_plex_watchlist(versions: Dict[str, bool]) -> List[Tuple[List
             # Ensure media_type is 'tv' or 'movie' for consistency downstream
             if media_type == 'show': media_type = 'tv' 
             
-            item_state = get_media_item_presence(imdb_id=imdb_id)
+            item_state = get_media_item_presence_overall(imdb_id=imdb_id)
             logging.debug(f"Item '{title}' (IMDB: {imdb_id}) - Presence: {item_state}")
 
-            if item_state == "Collected" and should_remove:
+            if item_state in ("Collected", "Partial") and should_remove:
                 if media_type == 'tv':
                     if keep_series:
                         logging.debug(f"Keeping collected TV series: '{title}' (IMDB: {imdb_id}) - keep_series is enabled.")

--- a/content_checkers/trakt.py
+++ b/content_checkers/trakt.py
@@ -9,7 +9,7 @@ import trakt.core
 import time
 import pickle
 import os
-from database.database_reading import get_all_media_items, get_media_item_presence
+from database.database_reading import get_all_media_items, get_media_item_presence, get_media_item_presence_overall
 from database.database_writing import update_media_item
 from datetime import datetime, date, timedelta, timezone
 from utilities.settings import get_setting
@@ -928,6 +928,12 @@ def fetch_items_from_trakt(
                 logging.error(f"This API method requires Trakt VIP. Upgrade at {upgrade_url}")
                 return []
 
+            elif status_code == 404:  # Not Found — resource no longer exists, no point retrying
+                logging.warning(
+                    f"Trakt API returned 404 for {url} — resource may no longer exist. Skipping."
+                )
+                return []
+
             elif status_code in (502, 504):  # Temporary gateway issues
                 delay = initial_delay * (2 ** attempt) + random.uniform(0, 1)
                 logging.warning(
@@ -1346,8 +1352,8 @@ def get_wanted_from_trakt_watchlist(versions: Dict[str, bool]) -> List[Tuple[Lis
                 movies_to_remove = []
                 shows_to_remove = []
                 for item in processed_items[:]:  # Create a copy to iterate while modifying
-                    item_state = get_media_item_presence(imdb_id=item['imdb_id'])
-                    if item_state == "Collected":
+                    item_state = get_media_item_presence_overall(imdb_id=item['imdb_id'])
+                    if item_state in ("Collected", "Partial"):
                         # If it's a TV show and we want to keep series, skip removal
                         if item['media_type'] == 'tv':
                             if keep_series:

--- a/routes/content_requestor_routes.py
+++ b/routes/content_requestor_routes.py
@@ -4,7 +4,6 @@ from .models import user_required, onboarding_required
 from .utils import is_user_system_enabled
 from utilities.web_scraper import search_trakt, parse_search_term, get_available_versions
 from cli_battery.app.direct_api import DirectAPI
-from queues.config_manager import load_config
 from database.wanted_items import add_wanted_items
 import logging
 import re
@@ -176,15 +175,24 @@ def request_content():
         processed_items = process_metadata([wanted_item])
         if not processed_items:
             # Handle cases where process_metadata returns None or an empty dict
-            logging.warning(f"process_metadata returned empty or None for TMDB ID {tmdb_id}. Content might already exist or is invalid.")
-            return jsonify({'error': 'Content already requested or already exists in library.'}), 400
-            
+            logging.warning(f"process_metadata returned empty or None for TMDB ID {tmdb_id}. Metadata fetch may have failed.")
+            return jsonify({'error': 'Could not retrieve metadata for this title. The battery may have stale or incorrect data — try forcing a metadata refresh from the library page.'}), 400
+
         # Combine movies and episodes from processed items
         all_items = processed_items.get('movies', []) + processed_items.get('episodes', [])
+        if not all_items and media_type == 'tv' and imdb_id:
+            # For TV shows: battery may have stale/incomplete episode data. Auto-refresh and retry once.
+            logging.info(f"No new items for TV show {imdb_id} — forcing battery metadata refresh and retrying.")
+            try:
+                DirectAPI.force_refresh_metadata(imdb_id)
+                processed_items = process_metadata([wanted_item])
+                if processed_items:
+                    all_items = processed_items.get('movies', []) + processed_items.get('episodes', [])
+            except Exception as e_refresh:
+                logging.warning(f"Auto-refresh failed for {imdb_id}: {e_refresh}")
         if not all_items:
-            logging.warning(f"No processable items found after metadata processing for TMDB ID {tmdb_id}. Content might already exist.")
-            # Return a more specific message indicating the item might already exist or was filtered
-            return jsonify({'error': 'Content already requested or already exists in library.'}), 400
+            logging.warning(f"No processable items found after metadata processing for TMDB ID {tmdb_id}. All items may already be in the database.")
+            return jsonify({'error': 'All episodes/items for this title are already in the database. If episodes are missing, try forcing a metadata refresh from the library page to update episode counts.'}), 400
             
         # Add content source to all items.
         # When user system is enabled, record the requesting user's username as the detail
@@ -196,11 +204,28 @@ def request_content():
         for item in all_items:
             item['content_source'] = 'content_requester'
             item['content_source_detail'] = source_detail
-            
+
         # Pass versions dictionary to add_wanted_items
-        add_wanted_items(all_items, versions)
-        
-        logging.info(f"Content request processed: TMDB ID {tmdb_id} -> IMDB ID {imdb_id} ({media_type}) with versions {versions}")
+        items_added = add_wanted_items(all_items, versions)
+
+        # If nothing was added for a TV show, the battery may have stale/incomplete episode data.
+        # Force-refresh and retry once to pick up any missing episodes.
+        if items_added == 0 and media_type == 'tv' and imdb_id:
+            logging.info(f"No new items added for TV show {imdb_id} (battery may be stale) — forcing refresh and retrying.")
+            try:
+                DirectAPI.force_refresh_metadata(imdb_id)
+                processed_items = process_metadata([wanted_item])
+                if processed_items:
+                    all_items = processed_items.get('movies', []) + processed_items.get('episodes', [])
+                    for item in all_items:
+                        item['content_source'] = 'content_requester'
+                        item['content_source_detail'] = source_detail
+                    items_added = add_wanted_items(all_items, versions)
+                    logging.info(f"After refresh, added {items_added} items for {imdb_id}")
+            except Exception as e_refresh:
+                logging.warning(f"Post-add refresh failed for {imdb_id}: {e_refresh}")
+
+        logging.info(f"Content request processed: TMDB ID {tmdb_id} -> IMDB ID {imdb_id} ({media_type}) with versions {versions}, items added: {items_added}")
         return jsonify({'success': True, 'item': wanted_item})
         
     except Exception as e:

--- a/routes/discover_routes.py
+++ b/routes/discover_routes.py
@@ -2094,6 +2094,7 @@ def details_data(tmdb_id, media_type):
 
         # For TV shows: Use TVDB for seasons/episodes if TVDB API key is configured
         # This ensures proper season splits (not TMDB absolute numbering for anime)
+        tvdb_slug = None
         if media_type == 'tv':
             tvdb_api_key = get_setting('TVDB', 'api_key', '')
             if tvdb_api_key:
@@ -2107,6 +2108,9 @@ def details_data(tmdb_id, media_type):
 
                         # Fetch show data from TVDB (returns full show metadata including seasons)
                         tvdb_show_data = tvdb_client.get_show_data(imdb_id_from_tmdb)
+
+                        if tvdb_show_data:
+                            tvdb_slug = tvdb_show_data.get('ids', {}).get('slug')
 
                         if tvdb_show_data and 'seasons' in tvdb_show_data:
                             # TVDB seasons format: {season_number: {'episode_count': N, 'episodes': {...}}}
@@ -2189,6 +2193,7 @@ def details_data(tmdb_id, media_type):
                 'tmdb_id': data.get('id'),
                 'imdb_id': data.get('external_ids', {}).get('imdb_id') if isinstance(data.get('external_ids'), dict) else None,
                 'tvdb_id': data.get('external_ids', {}).get('tvdb_id') if isinstance(data.get('external_ids'), dict) else None,
+                'tvdb_slug': tvdb_slug,
                 'seasons': data.get('seasons', []) if isinstance(data.get('seasons'), list) else []
             }
         else:
@@ -2283,64 +2288,47 @@ def season_episodes(tmdb_id, season_number):
         logging.info(f"Season episodes request for TMDB {tmdb_id}, season {season_number}")
         logging.info(f"TVDB API key configured: {bool(tvdb_api_key)}")
 
-        if tvdb_api_key:
+        # Always fetch episode list from TMDB live API — TMDB is authoritative for episode counts
+        # and always returns all episodes (including TBA ones). The battery cache may be stale.
+        logging.info(f"Fetching TMDB episodes for season {season_number} of TMDB ID {tmdb_id}")
+        url = f"https://api.themoviedb.org/3/tv/{tmdb_id}/season/{season_number}?api_key={tmdb_api_key}&language=en-US"
+        response = requests.get(url, timeout=15)
+        response.raise_for_status()
+        data = response.json()
+
+        # If TVDB is configured, supplement episode titles from TVDB (may have better English titles)
+        # but only for episodes where TMDB has no title — never use TVDB to limit the episode list.
+        if tvdb_api_key and data.get('episodes'):
             try:
                 from cli_battery.app import tvdb_client
                 from cli_battery.app.direct_api import DirectAPI
 
-                # Get IMDb ID from TMDB
-                logging.info(f"Converting TMDB ID {tmdb_id} to IMDb ID...")
                 imdb_id, source = DirectAPI.tmdb_to_imdb(str(tmdb_id), media_type='tv')
-                logging.info(f"IMDb ID resolution: {imdb_id} from {source}")
-
                 if imdb_id:
-                    logging.info(f"Fetching TVDB episodes for season {season_number} of TMDB ID {tmdb_id} (IMDb: {imdb_id})")
                     tvdb_show_data = tvdb_client.get_show_data(imdb_id)
-                    logging.info(f"TVDB show data received: {bool(tvdb_show_data)}")
-
                     if tvdb_show_data and 'seasons' in tvdb_show_data:
-                        # TVDB seasons format: {season_number: {'episode_count': N, 'episodes': {...}}}
                         tvdb_seasons = tvdb_show_data['seasons']
-
-                        # Get the requested season
                         season_data = tvdb_seasons.get(season_number) or tvdb_seasons.get(str(season_number))
-
                         if season_data and 'episodes' in season_data:
-                            # Convert TVDB episode format to TMDB-like format
-                            # TVDB: {ep_num: {'title': ..., 'overview': ..., 'first_aired': ..., 'runtime': ...}}
-                            # TMDB: [{'episode_number': N, 'name': ..., 'overview': ..., 'air_date': ..., 'runtime': ...}]
                             tvdb_episodes = season_data['episodes']
-                            episodes_list = []
-
+                            # Build lookup: ep_num -> tvdb title/overview/air_date
+                            tvdb_ep_map = {}
                             for ep_num, ep_data in tvdb_episodes.items():
                                 if isinstance(ep_data, dict):
-                                    episodes_list.append({
-                                        'episode_number': int(ep_num) if str(ep_num).isdigit() else ep_num,
-                                        'name': ep_data.get('title', f"Episode {ep_num}"),
-                                        'overview': ep_data.get('overview', ''),
-                                        'air_date': ep_data.get('first_aired', '').split('T')[0] if ep_data.get('first_aired') else None,
-                                        'runtime': ep_data.get('runtime', 0),
-                                        'still_path': None  # TVDB doesn't provide episode stills
-                                    })
-
-                            # Create TMDB-compatible response
-                            data = {
-                                'season_number': season_number,
-                                'episodes': sorted(episodes_list, key=lambda x: x['episode_number'])
-                            }
-                            logging.info(f"✅ Using TVDB episodes for season {season_number} ({len(episodes_list)} episodes)")
+                                    key = int(ep_num) if str(ep_num).isdigit() else ep_num
+                                    tvdb_ep_map[key] = ep_data
+                            # Supplement TMDB episodes with TVDB titles where TMDB has none
+                            for ep in data['episodes']:
+                                ep_num = ep.get('episode_number')
+                                if ep_num in tvdb_ep_map:
+                                    tvdb_ep = tvdb_ep_map[ep_num]
+                                    if not ep.get('name') and tvdb_ep.get('title'):
+                                        ep['name'] = tvdb_ep['title']
+                                    if not ep.get('air_date') and tvdb_ep.get('first_aired'):
+                                        ep['air_date'] = tvdb_ep['first_aired'].split('T')[0]
+                            logging.info(f"Supplemented TMDB episodes with TVDB titles for season {season_number}")
             except Exception as e:
-                logging.warning(f"Failed to fetch TVDB episodes for season {season_number}: {e}")
-                import traceback
-                logging.debug(f"TVDB error traceback: {traceback.format_exc()}")
-
-        # Fallback to TMDB if TVDB didn't work
-        if not data:
-            logging.info(f"Fetching TMDB episodes for season {season_number} of TMDB ID {tmdb_id}")
-            url = f"https://api.themoviedb.org/3/tv/{tmdb_id}/season/{season_number}?api_key={tmdb_api_key}&language=en-US"
-            response = requests.get(url, timeout=15)
-            response.raise_for_status()
-            data = response.json()
+                logging.debug(f"TVDB supplement failed for season {season_number}: {e}")
 
         # Query database for episodes in this show/season
         conn = get_db_connection()

--- a/routes/library_routes.py
+++ b/routes/library_routes.py
@@ -1490,6 +1490,7 @@ def show_detail_data(media_id):
                 'tmdb_id': show_data['tmdb_id'],
                 'imdb_id': show_data['imdb_id'],
                 'tvdb_id': tvdb_id,
+                'tvdb_slug': tvdb_slug,
                 'version': show_data['version'],
                 'poster_url': poster_url,
                 'backdrop_url': backdrop_url,
@@ -1824,6 +1825,53 @@ def refresh_show_metadata(media_id):
             media_id
         ))
 
+        # Add any episodes that are in the refreshed metadata but not yet in the DB.
+        # This handles the case where new episodes have been announced/released since the
+        # show was first requested (e.g. "3 of 8 episodes" becoming "8 of 8").
+        new_episodes_added = 0
+        try:
+            from metadata.metadata import process_metadata
+            from database.wanted_items import add_wanted_items
+
+            # Get the versions used by existing episodes of this show
+            cursor.execute(
+                "SELECT versions FROM media_items WHERE imdb_id = ? AND type = 'episode' AND versions IS NOT NULL LIMIT 1",
+                (imdb_id,)
+            )
+            versions_row = cursor.fetchone()
+            import json as _json
+            existing_versions = {}
+            if versions_row and versions_row[0]:
+                try:
+                    existing_versions = _json.loads(versions_row[0])
+                except Exception:
+                    pass
+
+            wanted_item = {
+                'imdb_id': imdb_id,
+                'tmdb_id': tmdb_id,
+                'media_type': 'tv',
+                'title': title,
+                'versions': existing_versions,
+                'content_source': 'content_requester',
+                'content_source_detail': 'Metadata-Refresh',
+            }
+            db_content.commit()  # Commit current updates before process_metadata reads the DB
+
+            processed = process_metadata([wanted_item])
+            if processed:
+                new_items = processed.get('episodes', [])
+                if new_items:
+                    for ep in new_items:
+                        ep['content_source'] = 'content_requester'
+                        ep['content_source_detail'] = 'Metadata-Refresh'
+                    added = add_wanted_items(new_items, existing_versions)
+                    new_episodes_added = added or 0
+                    if new_episodes_added:
+                        logging.info(f"Metadata refresh for {title}: added {new_episodes_added} previously-missing episode(s) to the queue.")
+        except Exception as e_add:
+            logging.warning(f"Could not add missing episodes during metadata refresh for {imdb_id}: {e_add}")
+
         db_content.commit()
         cursor.close()
         db_content.close()
@@ -1841,12 +1889,17 @@ def refresh_show_metadata(media_id):
             except Exception as e:
                 logging.warning(f"Failed to clear poster cache: {e}")
 
-        logging.info(f"Refreshed metadata for {title} (IMDb: {imdb_id}): Updated {updated_count} episode titles from {source}{', TMDB data updated' if tmdb_updated else ''}")
+        logging.info(f"Refreshed metadata for {title} (IMDb: {imdb_id}): Updated {updated_count} episode titles from {source}, added {new_episodes_added} missing episode(s){', TMDB data updated' if tmdb_updated else ''}")
+
+        msg = f'Metadata refreshed for {title}'
+        if new_episodes_added:
+            msg += f' — added {new_episodes_added} previously-missing episode(s) to the queue'
 
         return jsonify({
             'success': True,
-            'message': f'Metadata refreshed for {title}',
+            'message': msg,
             'updated_episodes': updated_count,
+            'new_episodes_added': new_episodes_added,
             'tmdb_updated': tmdb_updated,
             'source': source,
             'cache_cleared': tmdb_id is not None

--- a/static/css/tangerine/tangerine_library_movie.css
+++ b/static/css/tangerine/tangerine_library_movie.css
@@ -1169,7 +1169,7 @@ ease;
     .release-tags {
         display: block;
         align-self: center;
-        line-height: 3;
+        padding-bottom: 5px;
     }
     .release-title-wrapper {
         display: contents;
@@ -1233,7 +1233,7 @@ ease;
     .release-tags {
         display: block;
         align-self: center;
-        line-height: 3;
+        padding-bottom: 0px;
     }
     .release-title-wrapper {
         display: contents;

--- a/static/js/discover_addmedia.js
+++ b/static/js/discover_addmedia.js
@@ -796,7 +796,7 @@
         if (isMobile) {
             // MOBILE VIEW - Simple cards
             const header = document.createElement('h3');
-            header.textContent = `Torrent Results for ${title} (${year})`;
+            header.textContent = `Torrent Results for ${title}${year && !title.trim().endsWith(`(${year})`) ? ` (${year})` : ''}`;
             overlayContent.appendChild(header);
 
             if (allDisplayItems.length === 0) {
@@ -876,7 +876,7 @@
             }
             // Fallback to simple display if scraper.js function not available
             const header = document.createElement('h3');
-            header.textContent = `Torrent Results for ${title} (${year})`;
+            header.textContent = `Torrent Results for ${title}${year && !title.trim().endsWith(`(${year})`) ? ` (${year})` : ''}`;
             overlayContent.appendChild(header);
 
             const gridContainer = document.createElement('div');
@@ -940,7 +940,7 @@
         } else {
             // CLASSIC THEME - Simple grid
             const header = document.createElement('h3');
-            header.textContent = `Torrent Results for ${title} (${year})`;
+            header.textContent = `Torrent Results for ${title}${year && !title.trim().endsWith(`(${year})`) ? ` (${year})` : ''}`;
             overlayContent.appendChild(header);
 
             if (allDisplayItems.length === 0) {

--- a/static/js/discover_details.js
+++ b/static/js/discover_details.js
@@ -166,7 +166,8 @@ function displayContent(data) {
     }
 
     // Set title
-    document.getElementById('movie-title').textContent = data.title + (data.year ? ` (${data.year})` : '');
+    const titleAlreadyHasYear = data.year && data.title.trim().endsWith(`(${data.year})`);
+    document.getElementById('movie-title').textContent = data.title + (data.year && !titleAlreadyHasYear ? ` (${data.year})` : '');
     document.title = `${data.title} - Discover`;
 
     // Update library status badge based on db_status
@@ -284,11 +285,10 @@ function displayContent(data) {
     tmdbLinkDetail.textContent = data.tmdb_id;
 
     // Set TVDB link if available (TV shows only)
-    if (data.media_type === 'tv' && data.title) {
+    if (data.media_type === 'tv' && (data.tvdb_slug || data.title)) {
         const tvdbLink = document.getElementById('link-tvdb');
-        // TVDB uses slug-based URLs (e.g., /series/star-trek-starfleet-academy)
-        // Generate slug from title: lowercase, replace spaces with hyphens, remove special chars
-        const slug = data.title
+        // Use real TVDB slug from battery metadata when available, otherwise generate from title
+        const slug = data.tvdb_slug || data.title
             .toLowerCase()
             .replace(/[^\w\s-]/g, '') // Remove special characters except spaces and hyphens
             .replace(/\s+/g, '-')      // Replace spaces with hyphens

--- a/static/js/library_movie.js
+++ b/static/js/library_movie.js
@@ -197,7 +197,8 @@ function renderMovieHeader(movie) {
     if (window.DEBUG) console.log('[Movie Detail] Metadata values - overview:', movie.overview, 'genres:', movie.genres, 'network:', movie.network, 'status:', movie.status);
 
     // Set title with year in parentheses
-    const titleText = movie.title + (movie.year ? ` (${movie.year})` : '');
+    const titleAlreadyHasYear = movie.year && movie.title.trim().endsWith(`(${movie.year})`);
+    const titleText = movie.title + (movie.year && !titleAlreadyHasYear ? ` (${movie.year})` : '');
     const titleEl = document.getElementById('movie-title');
     if (titleEl) {
         titleEl.textContent = titleText;
@@ -526,7 +527,8 @@ function createFileRow(file, rowNumber, movie) {
     info.className = 'movie-file-info-section';
 
     const fileName = file.basename || file.filename || 'Unknown file';
-    const titleText = movie.title + (movie.year ? ` (${movie.year})` : '');
+    const titleAlreadyHasYearFile = movie.year && movie.title.trim().endsWith(`(${movie.year})`);
+    const titleText = movie.title + (movie.year && !titleAlreadyHasYearFile ? ` (${movie.year})` : '');
     const qualityTags = extractQualityTags(file.basename || file.filename || '');
     const tags = qualityTags.map(tag => createQualityBadge(tag)).join('');
     const version = file.version || 'Default';
@@ -645,6 +647,15 @@ function createFileRow(file, rowNumber, movie) {
         actions.appendChild(deleteBtn);
     }
 
+    // Mobile touch: tap the title to show filename as a popup (title= attr doesn't work on touch)
+    const titleEl = info.querySelector('.movie-file-title');
+    if (titleEl) {
+        titleEl.addEventListener('touchstart', function(e) {
+            e.preventDefault();
+            showFilenameTouchTooltip(titleEl, fileName);
+        }, { passive: false });
+    }
+
     row.appendChild(number);
     row.appendChild(statusIconElement);
     row.appendChild(info);
@@ -689,6 +700,60 @@ function handleMoveFileToWanted(fileId) {
 
 function movieError(message) {
     if (window.DEBUG) console.error('[Movie Detail] Error:', message);
+}
+
+let _filenameTouchTooltip = null;
+let _filenameTouchTimer = null;
+
+function showFilenameTouchTooltip(anchorEl, filename) {
+    // Remove any existing tooltip
+    if (_filenameTouchTooltip) {
+        _filenameTouchTooltip.remove();
+        _filenameTouchTooltip = null;
+    }
+    clearTimeout(_filenameTouchTimer);
+
+    const tooltip = document.createElement('div');
+    tooltip.textContent = filename;
+    tooltip.style.cssText = `
+        position: fixed;
+        bottom: 1.5rem;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(15, 15, 20, 0.95);
+        color: rgba(255,255,255,0.92);
+        font-size: 0.78rem;
+        padding: 0.5rem 0.85rem;
+        border-radius: 0.375rem;
+        border: 1px solid rgba(255,255,255,0.15);
+        box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+        max-width: 90vw;
+        word-break: break-all;
+        z-index: 9999;
+        pointer-events: none;
+        text-align: center;
+    `;
+    document.body.appendChild(tooltip);
+    _filenameTouchTooltip = tooltip;
+
+    // Auto-dismiss after 3 seconds
+    _filenameTouchTimer = setTimeout(() => {
+        if (_filenameTouchTooltip) {
+            _filenameTouchTooltip.remove();
+            _filenameTouchTooltip = null;
+        }
+    }, 3000);
+
+    // Dismiss on next touch anywhere
+    const dismiss = () => {
+        clearTimeout(_filenameTouchTimer);
+        if (_filenameTouchTooltip) {
+            _filenameTouchTooltip.remove();
+            _filenameTouchTooltip = null;
+        }
+        document.removeEventListener('touchstart', dismiss);
+    };
+    setTimeout(() => document.addEventListener('touchstart', dismiss, { once: true }), 50);
 }
 
 function alignSidebarWithFiles() {
@@ -935,7 +1000,8 @@ function showVersionModal(versions) {
     // Add heading
     const header = document.createElement('div');
     header.className = 'version-section-header';
-    header.innerHTML = `<h4>Requesting: ${movieData.title}${movieData.year ? ` (${movieData.year})` : ''}</h4>`;
+    const requestTitleHasYear = movieData.year && movieData.title.trim().endsWith(`(${movieData.year})`);
+    header.innerHTML = `<h4>Requesting: ${movieData.title}${movieData.year && !requestTitleHasYear ? ` (${movieData.year})` : ''}</h4>`;
     versionCheckboxes.appendChild(header);
 
     const separator = document.createElement('hr');

--- a/static/js/library_show.js
+++ b/static/js/library_show.js
@@ -200,7 +200,8 @@ function renderShowHeader(show) {
     console.log('[Show Detail] Metadata values - overview:', show.overview, 'genres:', show.genres, 'network:', show.network, 'status:', show.status);
 
     // Set title with year in parentheses
-    const titleText = show.title + (show.year ? ` (${show.year})` : '');
+    const titleAlreadyHasYear = show.year && show.title.trim().endsWith(`(${show.year})`);
+    const titleText = show.title + (show.year && !titleAlreadyHasYear ? ` (${show.year})` : '');
     const titleEl = document.getElementById('show-title');
     if (titleEl) {
         titleEl.textContent = titleText;
@@ -410,14 +411,13 @@ function renderShowHeader(show) {
     }
 
     const tvdbLink = document.getElementById('link-tvdb');
-    if (tvdbLink && show.title) {
-        // TVDB uses slug-based URLs (e.g., /series/star-trek-starfleet-academy)
-        // Generate slug from title: lowercase, replace spaces with hyphens, remove special chars
-        const slug = show.title
+    if (tvdbLink && (show.tvdb_slug || show.title)) {
+        // Use real slug from battery if available, otherwise generate from title as fallback
+        const slug = show.tvdb_slug || show.title
             .toLowerCase()
-            .replace(/[^\w\s-]/g, '') // Remove special characters except spaces and hyphens
-            .replace(/\s+/g, '-')      // Replace spaces with hyphens
-            .replace(/-+/g, '-')       // Replace multiple hyphens with single hyphen
+            .replace(/[^\w\s-]/g, '')
+            .replace(/\s+/g, '-')
+            .replace(/-+/g, '-')
             .trim();
         tvdbLink.href = `https://thetvdb.com/series/${slug}`;
     }
@@ -483,13 +483,12 @@ function renderShowHeader(show) {
     }
 
     const tvdbLinkDetail = document.getElementById('tvdb-link-detail');
-    if (tvdbLinkDetail && show.title) {
-        // TVDB uses slug-based URLs, generate slug from title
-        const slug = show.title
+    if (tvdbLinkDetail && (show.tvdb_slug || show.title)) {
+        const slug = show.tvdb_slug || show.title
             .toLowerCase()
-            .replace(/[^\w\s-]/g, '') // Remove special characters except spaces and hyphens
-            .replace(/\s+/g, '-')      // Replace spaces with hyphens
-            .replace(/-+/g, '-')       // Replace multiple hyphens with single hyphen
+            .replace(/[^\w\s-]/g, '')
+            .replace(/\s+/g, '-')
+            .replace(/-+/g, '-')
             .trim();
         tvdbLinkDetail.href = `https://thetvdb.com/series/${slug}`;
         tvdbLinkDetail.textContent = show.tvdb_id || 'View on TVDB';

--- a/static/js/scraper.js
+++ b/static/js/scraper.js
@@ -1149,7 +1149,8 @@ async function displayTorrentResults(data, title, year, version, mediaId, mediaT
                 
                 // Use clean title from header, store filename for toggle
                 const ShowInfo = `${season ? `<span class="season-info">S${season.toString().padStart(2, '0')}` : ''}${(torrent.parsed_info?.seasons?.length || 0) > 1 ? ` - ${torrent.parsed_info.seasons.length}</span>` : `</span>`} ${episode ? `<span class="ds-episode-info"> E${episode.toString().padStart(2, '0')}</span>`: ''}`;
-                const cleanTitle = `${title} (${year})${ShowInfo ? ` ${ShowInfo}` : ''}`;
+                const titleHasYear = year && title.trim().endsWith(`(${year})`);
+                const cleanTitle = `${title}${year && !titleHasYear ? ` (${year})` : ''}${ShowInfo ? ` ${ShowInfo}` : ''}`;
                 const filename = torrent.title || torrent.original_title || 'N/A';
                 
                 // Get score and color class
@@ -1335,7 +1336,7 @@ async function displayTorrentResults(data, title, year, version, mediaId, mediaT
                 // CLASSIC THEME - Original Desktop Table
                 overlayContent.innerHTML = '';
                 const header = document.createElement('h3');
-                header.textContent = `Torrent Results for ${title} (${year})`;
+                header.textContent = `Torrent Results for ${title}${year && !title.trim().endsWith(`(${year})`) ? ` (${year})` : ''}`;
                 overlayContent.appendChild(header);
                 
                 const table = document.createElement('table');


### PR DESCRIPTION
- Watchlist removal now correctly detects partially-collected TV shows (plex_watchlist, plex_rss_watchlist, trakt)
- Re-requesting a show with missing episodes now force-refreshes stale battery data and retries
- TVDB metadata no longer overwrites correct data when battery has a wrong show cached
- Discover page episode list now uses TMDB live API instead of stale battery cache
- TVDB link on discover/library pages now uses correct show slug from battery
- Year no longer duplicated in titles like "Show (2026) (2026)" on discover page
- Refreshing show metadata now adds newly available episodes to the database
- Trakt 404 errors no longer retry 5 times, now skip immediately with one warning
- Mobile: tap movie title in library to see full filename (same as desktop hover)
- Fix duplicate load_config import in content_requestor_routes.py