### PR TITLE
bug fixes

### DIFF
--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -473,15 +473,61 @@ def _infer_timezone_from_network(network_name: str | None, country: str | None =
 # ─── Public API (matches trakt_client signatures) ────────────────────────────
 
 
+def _resolve_tvdb_id_via_tmdb(imdb_id: str, tmdb_api_key: str) -> Optional[int]:
+    """Try to resolve a TVDB series ID by looking up via TMDB ID.
+
+    Used when /search/remoteid/{imdb_id} returns null (TVDB hasn't linked the
+    IMDb ID yet) but the show exists on TVDB and can be found via its TMDB ID.
+    Returns the TVDB series ID if found, else None.
+    """
+    tmdb_id = _resolve_tmdb_id_from_imdb(imdb_id, tmdb_api_key, media_type='show')
+    if not tmdb_id:
+        return None
+
+    url = f"{TVDB_BASE_URL}/search/remoteid/{tmdb_id}"
+    resp = _make_request(url)
+    if not resp or resp.status_code != 200:
+        return None
+
+    data = resp.json().get('data') or []
+    for item in data:
+        series = item.get('series') if isinstance(item, dict) else None
+        if isinstance(series, dict) and series.get('id'):
+            tvdb_id = int(series['id'])
+            # Cache the mapping so future lookups don't need the TMDB roundtrip
+            _cache_tvdb_mapping(str(tvdb_id), imdb_id, 'show')
+            logger.info(f"TVDB: resolved {imdb_id} via TMDB ID {tmdb_id} → TVDB ID {tvdb_id}")
+            return tvdb_id
+
+    return None
+
+
+def _get_trakt_status(imdb_id: str) -> Optional[str]:
+    """Lightweight Trakt status check — fetches only show summary, returns status string or None."""
+    try:
+        from . import trakt_client
+        from .trakt_client import TRAKT_BASE_URL, _make_request as trakt_request
+        resp = trakt_request(f"{TRAKT_BASE_URL}/shows/{imdb_id}?extended=full")
+        if resp and resp.status_code == 200:
+            return resp.json().get('status')
+    except Exception as e:
+        logger.debug(f"TVDB: Trakt status cross-check failed for {imdb_id}: {e}")
+    return None
+
+
 def get_show_data(imdb_id: str) -> Optional[dict]:
     """Get full show metadata + aliases + seasons/episodes."""
     tvdb_id = _resolve_tvdb_id(imdb_id, media_type='show')
     if not tvdb_id:
-        logger.warning(f"TVDB: could not resolve IMDb {imdb_id} to TVDB ID, trying TMDB fallback")
+        # TVDB hasn't linked this IMDb ID yet — try resolving via TMDB ID
         tmdb_api_key = _get_tmdb_api_key()
         if tmdb_api_key:
-            return _fetch_tmdb_show_data(imdb_id, tmdb_api_key)
-        return None
+            tvdb_id = _resolve_tvdb_id_via_tmdb(imdb_id, tmdb_api_key)
+        if not tvdb_id:
+            logger.warning(f"TVDB: could not resolve IMDb {imdb_id} to TVDB ID, trying TMDB fallback")
+            if tmdb_api_key:
+                return _fetch_tmdb_show_data(imdb_id, tmdb_api_key)
+            return None
 
     url = f"{TVDB_BASE_URL}/series/{tvdb_id}/extended?meta=translations,episodes"
     resp = _make_request(url)
@@ -557,6 +603,14 @@ def get_show_data(imdb_id: str) -> Optional[dict]:
         # Fallback to extended response (may have non-English titles)
         seasons = _extract_seasons_from_extended(raw)
     show_data['seasons'] = seasons
+
+    # TVDB marks many canceled shows as 'Ended' — cross-check with Trakt
+    # which reliably distinguishes 'canceled' from 'ended'.
+    if show_data.get('status') == 'ended':
+        trakt_status = _get_trakt_status(imdb_id)
+        if trakt_status == 'canceled':
+            logger.info(f"TVDB: correcting status for {imdb_id} from 'ended' to 'canceled' (Trakt)")
+            show_data['status'] = 'canceled'
 
     return show_data
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,4 +1,3 @@
-from .trakt_friends_routes import trakt_friends_bp
 from flask import Blueprint, jsonify, redirect, url_for, render_template, g, request, abort, flash
 from functools import wraps
 import json
@@ -35,7 +34,6 @@ from .magnet_routes import magnet_bp
 from .performance_routes import performance_bp
 from .torrent_status_routes import torrent_status_bp
 from .settings_validation_routes import settings_validation_bp
-from .content_requestor_routes import content_requestor_bp
 from .connections_routes import connections_bp
 from .user_token_routes import user_token_bp
 from .symlink_tools_routes import symlink_tools_bp
@@ -43,6 +41,7 @@ from .metadata_routes import metadata_bp
 from .plex_labels_debug_routes import plex_labels_debug_bp
 from .discover_routes import discover_bp
 from .bazarr_spoofing_routes import bazarr_bp
+from .overlay_routes import overlay_bp, overlay_page_bp
 
 tooltip_bp = Blueprint('tooltip', __name__)
 
@@ -168,7 +167,9 @@ def register_blueprints(app):
         (metadata_bp, '/metadata'),
         (plex_labels_debug_bp, ''),
         (discover_bp, '/discover'),
-        (bazarr_bp, '')  # Mounted at root for /api/v3/* and /signalr/* paths
+        (bazarr_bp, ''),  # Mounted at root for /api/v3/* and /signalr/* paths
+        (overlay_page_bp, ''),  # Mounted at root for /overlays page
+        (overlay_bp, '')  # Mounted at root for /api/overlays/* paths (includes prefix in blueprint)
     ]
     
     for blueprint, url_prefix in blueprints:

--- a/routes/debug_routes.py
+++ b/routes/debug_routes.py
@@ -266,6 +266,29 @@ def refresh_release_dates_route():
     refresh_release_dates()
     return jsonify({'success': True, 'message': 'Release dates refreshed successfully'})
 
+@debug_bp.route('/reset_battery_show_cache', methods=['POST'])
+@admin_required
+def reset_battery_show_cache():
+    """Reset battery show cache by nulling last_trakt_fetch for all shows.
+    This forces a fresh re-fetch from TVDB/Trakt on the next TV status update,
+    which will correctly apply the canceled vs ended cross-check fix.
+    """
+    try:
+        from cli_battery.app.database import managed_session, Item
+        with managed_session() as session:
+            updated = session.query(Item).filter(Item.type == 'show').update(
+                {'last_trakt_fetch': None},
+                synchronize_session=False
+            )
+        logging.info(f"[Reset Battery Cache] Nulled last_trakt_fetch for {updated} shows in battery DB")
+        return jsonify({
+            'success': True,
+            'message': f'Reset cache for {updated} shows. Run "Update TV Show Status" task to re-fetch status from TVDB/Trakt.'
+        })
+    except Exception as e:
+        logging.error(f"reset_battery_show_cache error: {e}", exc_info=True)
+        return jsonify({'success': False, 'error': str(e)}), 500
+
 @debug_bp.route('/delete_database', methods=['POST'])
 @admin_required
 def delete_database():

--- a/routes/library_routes.py
+++ b/routes/library_routes.py
@@ -1710,6 +1710,18 @@ def refresh_show_metadata(media_id):
                 'error': f'Could not fetch metadata from {source or "API"}'
             }), 500
 
+        # Extract show-level metadata from DirectAPI results (Source of Truth)
+        show_title = metadata.get('title', title)
+        show_year = str(metadata.get('year', '')) if metadata.get('year') else None
+        show_status = metadata.get('status', '')
+
+        # Format genres from list to comma-separated string
+        genres_list = metadata.get('genres', [])
+        if isinstance(genres_list, list):
+            show_genres = ', '.join(genres_list) if genres_list else None
+        else:
+            show_genres = str(genres_list) if genres_list else None
+
         # Update episode titles and air dates from fresh metadata
         updated_count = 0
         if 'seasons' in metadata:
@@ -1761,7 +1773,7 @@ def refresh_show_metadata(media_id):
                             if cursor.rowcount > 0:
                                 updated_count += cursor.rowcount
 
-        # Fetch fresh show-level metadata from TMDB
+        # Fetch fresh show-level metadata from TMDB (Optional fallback/supplement)
         tmdb_updated = False
         if tmdb_id:
             try:
@@ -1774,44 +1786,51 @@ def refresh_show_metadata(media_id):
                     response.raise_for_status()
                     tmdb_data = response.json()
 
-                    # Extract show-level metadata (only fields that exist in database)
-                    show_title = tmdb_data.get('name', title)
-                    show_year = tmdb_data.get('first_air_date', '')[:4] if tmdb_data.get('first_air_date') else None
-                    genres = ', '.join([g['name'] for g in tmdb_data.get('genres', [])])
-                    status = tmdb_data.get('status', '')
-
-                    # Update show-level metadata in media_items (title and genres for episodes)
-                    cursor.execute("""
-                        UPDATE media_items
-                        SET title = ?,
-                            genres = ?
-                        WHERE imdb_id = ? AND type = 'episode'
-                    """, (
-                        show_title,
-                        genres,
-                        imdb_id
-                    ))
-
-                    # Update show-level metadata in tv_shows table (title, year, status)
-                    cursor.execute("""
-                        UPDATE tv_shows
-                        SET title = ?,
-                            year = ?,
-                            status = ?,
-                            last_updated = ?
-                        WHERE imdb_id = ?
-                    """, (
-                        show_title,
-                        show_year,
-                        status,
-                        datetime.now(),
-                        imdb_id
-                    ))
+                    # Only update fields from TMDB if they are missing from DirectAPI/Battery
+                    if not show_year:
+                        show_year = tmdb_data.get('first_air_date', '')[:4] if tmdb_data.get('first_air_date') else None
+                    if not show_genres:
+                        show_genres = ', '.join([g['name'] for g in tmdb_data.get('genres', [])])
+                    if not show_status:
+                        show_status = tmdb_data.get('status', '')
 
                     tmdb_updated = True
-                    logging.info(f"Updated TMDB metadata for {show_title} in both media_items and tv_shows tables")
+                    logging.info(f"Updated supplementary TMDB metadata for {show_title}")
             except Exception as e:
-                logging.warning(f"Failed to update TMDB metadata: {e}")
+                logging.warning(f"Failed to fetch supplementary TMDB metadata: {e}")
+
+        # Update show-level metadata in media_items (title and genres for episodes)
+        cursor.execute("""
+            UPDATE media_items
+            SET title = ?,
+                genres = ?
+            WHERE imdb_id = ? AND type = 'episode'
+        """, (
+            show_title,
+            show_genres,
+            imdb_id
+        ))
+        try:
+            # Update show-level metadata in tv_shows table (title, year, status)
+            cursor.execute("""
+                UPDATE tv_shows
+                SET title = ?,
+                    year = ?,
+                    status = ?,
+                    last_updated = ?
+                WHERE imdb_id = ?
+            """, (
+                show_title,
+                show_year,
+                show_status,
+                datetime.now(),
+                imdb_id
+            ))
+
+            tmdb_updated = True
+            logging.info(f"Updated metadata for {show_title} in both media_items and tv_shows tables")
+        except Exception as e:
+            logging.warning(f"Failed to update show metadata: {e}")
 
         # Also update timestamps for all episodes (even if title didn't change)
         cursor.execute(f"""

--- a/routes/statistics_routes.py
+++ b/routes/statistics_routes.py
@@ -254,7 +254,7 @@ def get_recently_aired_and_airing_soon(days_past: int = 2, days_future: int = 1,
         
         # Use a single optimized query with GROUP BY instead of temporary tables and joins
         optimized_query = """
-        SELECT 
+        SELECT
             title,
             season_number,
             episode_number,
@@ -268,9 +268,10 @@ def get_recently_aired_and_airing_soon(days_past: int = 2, days_future: int = 1,
                 WHEN SUM(CASE WHEN state = 'Collected' THEN 1 ELSE 0 END) > 0 THEN 'Collected'
                 ELSE MAX(state)
             END as state,
-            MAX(upgrading_from) as upgrading_from -- Get upgrading_from if present
+            MAX(upgrading_from) as upgrading_from, -- Get upgrading_from if present
+            MAX(year) as year
         FROM media_items
-        WHERE type = 'episode' 
+        WHERE type = 'episode'
           AND release_date BETWEEN ? AND ?
           AND state != 'Blacklisted'  -- Exclude blacklisted items
         GROUP BY title, season_number, episode_number
@@ -308,7 +309,7 @@ def get_recently_aired_and_airing_soon(days_past: int = 2, days_future: int = 1,
         now_timestamp = now.timestamp()
         
         for result in results:
-            title, season, episode, release_date, airtime, imdb_id, tmdb_id, state, upgrading_from = result
+            title, season, episode, release_date, airtime, imdb_id, tmdb_id, state, upgrading_from, year = result
             try:
                 release_date = datetime.fromisoformat(release_date) if isinstance(release_date, str) else release_date
                 
@@ -354,7 +355,8 @@ def get_recently_aired_and_airing_soon(days_past: int = 2, days_future: int = 1,
                         'release_date': release_date.date(),
                         'display_status': display_status, # Store first status found for the group
                         'imdb_id': imdb_id,
-                        'tmdb_id': tmdb_id
+                        'tmdb_id': tmdb_id,
+                        'year': year
                     }
                 
                 # If any episode in the group is collected or checking_upgrade, prioritize that status
@@ -403,8 +405,18 @@ def get_recently_aired_and_airing_soon(days_past: int = 2, days_future: int = 1,
                 
                 episode_range = ", ".join(episode_parts)
                 
+                # Strip embedded year from display title (e.g. "Matlock (2024)" → "Matlock")
+                raw_title = show['title']
+                show_year = show.get('year')
+                if show_year and raw_title.endswith(f" ({show_year})"):
+                    display_title = raw_title[:-(len(f" ({show_year})"))]
+                else:
+                    display_title = raw_title
+
                 formatted_item = {
-                    'title': f"{show['title']} S{show['season']:02d}{episode_range}",
+                    'title': f"{display_title} S{show['season']:02d}{episode_range}",
+                    'show_title': display_title,
+                    'year': show_year,
                     'air_datetime': show['air_datetime'],
                     'sort_key': show['air_datetime'].isoformat(),
                     'display_status': show['display_status'], # Use the determined status
@@ -615,8 +627,12 @@ def root():
                 )
                 movie['formatted_collected_at'] = movie['formatted_date']
                 movie['formatted_size'] = format_file_size(movie.get('size'))
+                # Strip embedded year from title to avoid double year in display
+                yr = movie.get('year')
+                if yr and movie['title'].endswith(f" ({yr})"):
+                    movie['title'] = movie['title'][:-(len(f" ({yr})"))]
                 recently_added['movies'].append(movie)
-        
+
         # Process shows
         if 'shows' in recently_added_data:
             for show in recently_added_data['shows']:
@@ -626,6 +642,10 @@ def root():
                 )
                 show['formatted_collected_at'] = show['formatted_date']
                 show['formatted_size'] = format_file_size(show.get('size'))
+                # Strip embedded year from title to avoid double year in display
+                yr = show.get('year')
+                if yr and show['title'].endswith(f" ({yr})"):
+                    show['title'] = show['title'][:-(len(f" ({yr})"))]
                 recently_added['shows'].append(show)
         
         # Get recently upgraded items
@@ -646,6 +666,11 @@ def root():
 
                 # Format file size
                 item['formatted_size'] = format_file_size(item.get('size'))
+
+                # Strip embedded year from title to avoid double year in display
+                yr = item.get('year')
+                if yr and item['title'].endswith(f" ({yr})"):
+                    item['title'] = item['title'][:-(len(f" ({yr})"))]
 
                 # For original_collected_at, use the existing value if available
                 if item.get('original_collected_at'):
@@ -725,6 +750,10 @@ def set_time_preference():
             recently_added = loop.run_until_complete(get_recently_added_items(movie_limit=recently_added_limit, show_limit=recently_added_limit))
             # Format recently added items
             for item in recently_added.get('movies', []) + recently_added.get('shows', []):
+                # Strip embedded year from title to avoid double year in display
+                yr = item.get('year')
+                if yr and item.get('title', '').endswith(f" ({yr})"):
+                    item['title'] = item['title'][:-(len(f" ({yr})"))]
                 if 'collected_at' in item and item['collected_at'] is not None:
                     try:
                         # Try parsing with microseconds
@@ -768,10 +797,15 @@ def set_time_preference():
                 for item in recently_upgraded:
                     # Format the upgrade date using collected_at for better differentiation
                     item['formatted_date'] = format_datetime_preference(
-                        item['collected_at'], 
+                        item['collected_at'],
                         use_24hour_format
                     )
-                    
+
+                    # Strip embedded year from title to avoid double year in display
+                    yr = item.get('year')
+                    if yr and item['title'].endswith(f" ({yr})"):
+                        item['title'] = item['title'][:-(len(f" ({yr})"))]
+
                     # For original_collected_at, use the existing value if available
                     if item.get('original_collected_at'):
                         item['original_collected_at'] = format_datetime_preference(
@@ -862,6 +896,10 @@ def recently_added():
 
     # Format times for recently added items
     for item in recently_added['movies'] + recently_added['shows']:
+        # Strip embedded year from title to avoid double year in display
+        yr = item.get('year')
+        if yr and item.get('title', '').endswith(f" ({yr})"):
+            item['title'] = item['title'][:-(len(f" ({yr})"))]
         if 'collected_at' in item and item['collected_at'] is not None:
             try:
                 # Try parsing with microseconds
@@ -1182,8 +1220,12 @@ def index_api():
                     movie['collected_at'],
                     use_24hour_format
                 )
+                # Strip embedded year from title to avoid double year in display
+                yr = movie.get('year')
+                if yr and movie['title'].endswith(f" ({yr})"):
+                    movie['title'] = movie['title'][:-(len(f" ({yr})"))]
                 recently_added['movies'].append(movie)
-        
+
         # Process shows
         if 'shows' in recently_added_data:
             for show in recently_added_data['shows']:
@@ -1191,8 +1233,12 @@ def index_api():
                     show['collected_at'],
                     use_24hour_format
                 )
+                # Strip embedded year from title to avoid double year in display
+                yr = show.get('year')
+                if yr and show['title'].endswith(f" ({yr})"):
+                    show['title'] = show['title'][:-(len(f" ({yr})"))]
                 recently_added['shows'].append(show)
-        
+
         # Get recently upgraded items
         upgrade_enabled = get_setting('Scraping', 'enable_upgrading', False)
         if upgrade_enabled:
@@ -1209,6 +1255,11 @@ def index_api():
                 # Format file size
                 item['formatted_size'] = format_file_size(item.get('size'))
 
+                # Strip embedded year from title to avoid double year in display
+                yr = item.get('year')
+                if yr and item['title'].endswith(f" ({yr})"):
+                    item['title'] = item['title'][:-(len(f" ({yr})"))]
+
                 # For original_collected_at, use the existing value if available
                 if item.get('original_collected_at'):
                     item['original_collected_at'] = format_datetime_preference(
@@ -1221,10 +1272,10 @@ def index_api():
                     item['original_collected_at'] = 'Unknown'
         else:
             recently_upgraded = []
-    
+
     finally:
         loop.close()
-    
+
     # Check if TMDB API key is set
     tmdb_api_key = get_setting('TMDB', 'api_key', '')
     stats['tmdb_api_key_set'] = bool(tmdb_api_key)

--- a/static/js/library_movie.js
+++ b/static/js/library_movie.js
@@ -155,6 +155,11 @@ async function loadMovieData() {
 
         if (data.success) {
             movieData = data.movie;
+            // Strip year from title if already embedded (e.g. "Alien (2025)" → "Alien")
+            // so the scraper doesn't receive a double year in the payload
+            if (movieData.year && movieData.title) {
+                movieData.title = movieData.title.replace(new RegExp(`\\s*\\(${movieData.year}\\)$`), '').trim();
+            }
             movieData.has_pending_replace = data.has_pending_replace || false;
             filesData = data.files;
 

--- a/static/js/library_show.js
+++ b/static/js/library_show.js
@@ -105,6 +105,11 @@ async function loadShowData() {
 
         if (data.success) {
             showData = data.show;
+            // Strip year from title if already embedded (e.g. "Scrubs (2026)" → "Scrubs")
+            // so the scraper doesn't receive a double year in the payload
+            if (showData.year && showData.title) {
+                showData.title = showData.title.replace(new RegExp(`\\s*\\(${showData.year}\\)$`), '').trim();
+            }
             seasonsData = data.seasons;
 
             // Add phantom rows for missing episodes before stats calculation

--- a/static/js/scraper.js
+++ b/static/js/scraper.js
@@ -657,7 +657,7 @@ async function displayTorrentResults(data, title, year, version, mediaId, mediaT
         if (e.matches) { // Mobile view
             overlayContent.innerHTML = `
                 <h3>
-                    Torrent Results for ${title} (${year})
+                    Torrent Results for ${title}${year && !title.trim().endsWith(`(${year})`) ? ` (${year})` : ''}
                 </h3>`;
 
             // Get versions from page dropdown
@@ -900,7 +900,7 @@ async function displayTorrentResults(data, title, year, version, mediaId, mediaT
             
             modalHeader.innerHTML = `
                 <div class="torrent-modal-title-section">
-                    <h3>Torrent Results for ${title} (${year})</h3>
+                    <h3>Torrent Results for ${title}${year && !title.trim().endsWith(`(${year})`) ? ` (${year})` : ''}</h3>
                     <div class="torrent-stats">
                         <span>${allDisplayItems.length} results</span>
                         <span>Search: ${searchDuration}ms</span>

--- a/templates/debug_functions.html
+++ b/templates/debug_functions.html
@@ -44,6 +44,12 @@
             </form>
         </div>
         <div class="debug_item">
+            <h3>Reset Battery Show Status Cache</h3>
+            <p class="description">Forces all shows in the battery DB to be re-fetched from TVDB/Trakt on the next run. Use this to fix incorrect show statuses (e.g. "Ended" instead of "Canceled"). After running this, trigger "Update TV Show Status" from the Task Manager.</p>
+            <button type="button" class="btn" id="reset-battery-show-cache-btn">Reset Show Cache</button>
+            <p id="reset-battery-show-cache-result" style="margin-top:8px;"></p>
+        </div>
+        <div class="debug_item">
             <h3>Delete Database</h3>
             <p class="description">This will delete the database and all cache files (*.cache*.pkl) from the db_content directory.</p>
             <form action="{{ url_for('debug.delete_database') }}" method="POST" id="delete-database-form">
@@ -1607,6 +1613,29 @@ if (document.readyState === 'loading') {
                     });
                 }
             });
+        });
+
+        // Reset battery show cache button
+        document.getElementById('reset-battery-show-cache-btn').addEventListener('click', function() {
+            const btn = this;
+            const result = document.getElementById('reset-battery-show-cache-result');
+            btn.disabled = true;
+            btn.textContent = 'Resetting...';
+            result.textContent = '';
+            fetch('/debug/reset_battery_show_cache', { method: 'POST' })
+                .then(r => r.json())
+                .then(data => {
+                    btn.disabled = false;
+                    btn.textContent = 'Reset Show Cache';
+                    result.style.color = data.success ? 'green' : 'red';
+                    result.textContent = data.success ? data.message : ('Error: ' + data.error);
+                })
+                .catch(err => {
+                    btn.disabled = false;
+                    btn.textContent = 'Reset Show Cache';
+                    result.style.color = 'red';
+                    result.textContent = 'Error: ' + err.message;
+                });
         });
 
         // Load versions for the version propagator dropdowns

--- a/templates/library_show.html
+++ b/templates/library_show.html
@@ -340,10 +340,6 @@
                             <span class="detail-label">Library</span>
                             <code id="show-path" class="detail-code">-</code>
                         </div>
-                        <div class="detail-row">
-                            <span class="detail-label">Season Folders</span>
-                            <span id="show-season-folders" class="detail-value">-</span>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -348,6 +348,8 @@
                     <li>
                         <div class="show-info clickable"
                              data-title="${item.title}"
+                             data-show-title="${item.show_title || item.title}"
+                             data-year="${item.year || ''}"
                              data-imdb-id="${item.imdb_id}"
                              data-tmdb-id="${item.tmdb_id}"
                              data-season="${item.season_number}"
@@ -699,20 +701,14 @@
             const btn = event.currentTarget;
             const showInfo = btn.closest('li').querySelector('.show-info');
 
-            const title = showInfo.dataset.title;
             const imdbId = btn.dataset.imdbId;
             const tmdbId = btn.dataset.tmdbId;
             const season = parseInt(btn.dataset.season);
             const episode = parseInt(btn.dataset.episode);
 
-            // Call selectMedia from scraper.js to search for this specific episode
-            // Note: We need to extract year from title if present (format: "Show Title (2020)")
-            const yearMatch = title.match(/\((\d{4})\)$/);
-            // Use current year as fallback if no year in title (required by endpoint)
-            const year = yearMatch ? yearMatch[1] : new Date().getFullYear().toString();
-            // Remove year if present, and also remove S##E## pattern
-            let cleanTitle = yearMatch ? title.replace(/\s*\(\d{4}\)$/, '') : title;
-            cleanTitle = cleanTitle.replace(/\s+S\d+E\d+$/i, ''); // Remove season/episode from end
+            // Use pre-parsed show_title and year from data attributes (avoids regex parsing issues)
+            const cleanTitle = showInfo.dataset.showTitle || showInfo.dataset.title.replace(/\s+S\d+E\d+.*$/i, '').replace(/\s*\(\d{4}\)\s*$/, '').trim();
+            const year = showInfo.dataset.year || new Date().getFullYear().toString();
 
             // Get version from show data if available (default to 'Default')
             const version = 'Default';
@@ -1010,6 +1006,8 @@
                     <li>
                         <div class="show-info clickable"
                              data-title="{{ item.title }}"
+                             data-show-title="{{ item.show_title | default(item.title) }}"
+                             data-year="{{ item.year or '' }}"
                              data-imdb-id="{{ item.imdb_id }}"
                              data-tmdb-id="{{ item.tmdb_id }}"
                              data-season="{{ item.season_number }}"


### PR DESCRIPTION
Fix statistics double-year display, show status canceled detection, and library metadata priority

Cross-check TVDB 'ended' status against Trakt to correctly identify canceled shows; add debug function to reset battery show cache; use DirectAPI as source of truth for show metadata in library routes; strip embedded years in statistics recently-added sections.