### PR TITLE
Fix startup crash and library delete error in 0.7.31

### DIFF
--- a/database/collected_items.py
+++ b/database/collected_items.py
@@ -740,7 +740,7 @@ def add_collected_items(media_items_batch, recent=False, backfill=False, data_so
                                     airtime_cache[imdb_id] = '19:00'
                             
                             airtime = airtime_cache[imdb_id]
-                            conn.execute('''
+                            cursor = conn.execute('''
                                 INSERT OR REPLACE INTO media_items
                                 (imdb_id, tmdb_id, title, year, release_date, state, type, season_number, episode_number, episode_title, last_updated, metadata_updated, version, airtime, collected_at, original_collected_at, genres, filled_by_file, runtime, location_on_disk, upgraded, country, resolution, size)
                                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
@@ -755,7 +755,7 @@ def add_collected_items(media_items_batch, recent=False, backfill=False, data_so
 
                         # Queue newly-inserted items for post-processing (e.g. custom script, overlays)
                         # The UPDATE path does this at line ~541; INSERT path was previously missing it.
-                        new_item_id = conn.lastrowid
+                        new_item_id = cursor.lastrowid
                         if new_item_id:
                             new_item_row = conn.execute('SELECT * FROM media_items WHERE id = ?', (new_item_id,)).fetchone()
                             if new_item_row:

--- a/utilities/deletion_manager.py
+++ b/utilities/deletion_manager.py
@@ -1133,7 +1133,14 @@ class DeletionManager:
                 import json
                 sources_list = json.loads(item['content_sources']) if isinstance(item['content_sources'], str) else item['content_sources']
                 if sources_list:
-                    item_content_sources.extend(sources_list)
+                    for s in sources_list:
+                        if isinstance(s, dict):
+                            # content_sources stores dicts like {"source": "Overseerr_1", ...}
+                            source_name = s.get('source', '')
+                            if source_name:
+                                item_content_sources.append(source_name)
+                        elif isinstance(s, str):
+                            item_content_sources.append(s)
             except Exception as e:
                 logging.warning(f"[CONTENT_SOURCE_REMOVAL] Could not parse content_sources: {e}")
 

--- a/utilities/downsub.py
+++ b/utilities/downsub.py
@@ -15,15 +15,16 @@ except ImportError:
     from config.downsub_config import config
 
 # Import subliminal components
+SUBLIMINAL_AVAILABLE = False
 try:
     from subliminal import download_best_subtitles, save_subtitles, region
     from subliminal.video import Video
     from babelfish import Language
     import xml.parsers.expat
-except ImportError as e:
-    logging.error(f"Required subliminal packages not installed: {e}")
-    logging.error("Please install: pip install subliminal babelfish")
-    sys.exit(1)
+    SUBLIMINAL_AVAILABLE = True
+except Exception as e:
+    logging.warning(f"Subliminal packages not available: {e}")
+    logging.warning("Subtitle downloading will be disabled. Install with: pip install subliminal babelfish")
 
 # Logging configuration
 logging.basicConfig(
@@ -36,25 +37,28 @@ logging.basicConfig(
 )
 
 # Language mapping from config codes to babelfish Language objects
-LANGUAGE_MAP = {
-    'ara': Language('ara'),
-    'eng': Language('eng'), 
-    'fre': Language('fra'),
-    'fra': Language('fra'),  # Add fra mapping for consistency
-    'ger': Language('deu'),
-    'spa': Language('spa'),
-    'ita': Language('ita'),
-    'por': Language('por'),         # generic (keep if you want EU-PT too)
-    'pt-BR': Language.fromietf('pt-BR'),
-    'pob': Language('por', 'BR'),   # OpenSubtitles legacy code
-    'pb': Language('por', 'BR'),    # common alias
-    'dut': Language('nld'),
-    'rus': Language('rus'),
-    'chi': Language('zho'),
-    'zho': Language('zho'),  # Alternative code for Chinese
-    'jpn': Language('jpn'),
-    'kor': Language('kor'),
-}
+# Only populated when babelfish is available
+LANGUAGE_MAP = {}
+if SUBLIMINAL_AVAILABLE:
+    LANGUAGE_MAP = {
+        'ara': Language('ara'),
+        'eng': Language('eng'),
+        'fre': Language('fra'),
+        'fra': Language('fra'),  # Add fra mapping for consistency
+        'ger': Language('deu'),
+        'spa': Language('spa'),
+        'ita': Language('ita'),
+        'por': Language('por'),         # generic (keep if you want EU-PT too)
+        'pt-BR': Language.fromietf('pt-BR'),
+        'pob': Language('por', 'BR'),   # OpenSubtitles legacy code
+        'pb': Language('por', 'BR'),    # common alias
+        'dut': Language('nld'),
+        'rus': Language('rus'),
+        'chi': Language('zho'),
+        'zho': Language('zho'),  # Alternative code for Chinese
+        'jpn': Language('jpn'),
+        'kor': Language('kor'),
+    }
 
 def expand_languages(codes):
     """Turn config codes into babelfish Languages, expanding 'por' to BR/PT."""
@@ -327,10 +331,14 @@ def download_subtitles_for_video(video_path):
 def main(specific_file=None):
     """
     Main function that processes a single video file using simplified name-only parsing.
-    
+
     Args:
         specific_file (str, optional): Path to a specific file to process. Required.
     """
+    if not SUBLIMINAL_AVAILABLE:
+        logging.warning("Subliminal not available, skipping subtitle download.")
+        return
+
     # Reload configuration to pick up any changes
     config.reload()
     

--- a/utilities/post_processing.py
+++ b/utilities/post_processing.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import os
 import subprocess
 from utilities.settings import get_setting
-from .downsub import main as downsub_main
 
 
 def replace_cleanup_after_collect(item_dict):
@@ -290,6 +289,7 @@ def handle_state_change(item: Dict[str, Any]) -> None:
                     # Always use location_on_disk for subtitle downloads
                     file_path = fresh_item.get('location_on_disk')
                     if file_path:
+                        from .downsub import main as downsub_main
                         downsub_main(file_path)
                     else:
                         logging.warning("No location_on_disk found for item, skipping subtitle download")

--- a/utilities/release_parser.py
+++ b/utilities/release_parser.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 try:
     from guessit import guessit
     HAS_GUESSIT = True
-except ImportError:
+except Exception:
     HAS_GUESSIT = False
-    logger.warning("GuessIt library not installed. Using basic regex fallback for quality tag extraction.")
+    logger.warning("GuessIt library not available. Using basic regex fallback for quality tag extraction.")
 
 
 class ReleaseParser:


### PR DESCRIPTION
- Fix sys.exit(1) in downsub.py crashing all subprocesses on startup when subliminal unavailable; guard LANGUAGE_MAP behind availability flag; lazy-import downsub in post_processing to prevent module-level side effects; catch Exception (not just ImportError) in release_parser
- Fix delete_show "unhashable type: dict" by extracting source strings from content_sources dicts before adding to set in deletion_manager
- Fix collected_items lastrowid using cursor instead of connection