### PR TITLE
Fix location_on_disk update, memory trim, upgrade hub extras, watchli…

### DIFF
--- a/content_checkers/plex_watchlist.py
+++ b/content_checkers/plex_watchlist.py
@@ -568,3 +568,72 @@ def remove_from_plex_watchlist_by_item(item: dict) -> dict:
         logging.error(f"[PLEX_WATCHLIST_REMOVE] {result['message']}", exc_info=True)
 
     return result
+
+
+def remove_from_other_plex_watchlist_by_item(item: dict, token: str) -> dict:
+    """
+    Remove an item from another user's Plex Watchlist using their token.
+
+    Args:
+        item:  Dictionary with media item details (must have 'imdb_id', 'title', 'type')
+        token: Plex auth token belonging to the other user
+
+    Returns:
+        dict with 'success' boolean, 'message' string, optional 'not_found' boolean
+    """
+    start_time = time.time()
+    result = {'success': False, 'message': ''}
+
+    try:
+        account = MyPlexAccount(token=token)
+    except Exception as e:
+        result['message'] = f'Failed to connect to Other Plex account: {e}'
+        logging.error(f"[PLEX_WATCHLIST_REMOVE_OTHER] {result['message']}")
+        return result
+
+    imdb_id = item.get('imdb_id')
+    title   = item.get('title', 'Unknown')
+
+    if not imdb_id:
+        result['message'] = f'No IMDB ID provided for item: {title}'
+        logging.warning(f"[PLEX_WATCHLIST_REMOVE_OTHER] {result['message']}")
+        return result
+
+    logging.info(f"[PLEX_WATCHLIST_REMOVE_OTHER] Attempting to remove '{title}' (IMDB: {imdb_id}) "
+                 f"from {account.username}'s Plex Watchlist")
+    try:
+        watchlist = account.watchlist()
+        item_to_remove = None
+        for watchlist_item in watchlist:
+            for guid in getattr(watchlist_item, 'guids', []):
+                guid_str = str(guid.id) if hasattr(guid, 'id') else str(guid)
+                if f'imdb://{imdb_id}' in guid_str or imdb_id in guid_str:
+                    item_to_remove = watchlist_item
+                    break
+            if item_to_remove:
+                break
+
+        if not item_to_remove:
+            result['message'] = f"'{title}' (IMDB: {imdb_id}) not found in {account.username}'s Plex Watchlist"
+            result['not_found'] = True
+            logging.info(f"[PLEX_WATCHLIST_REMOVE_OTHER] {result['message']}")
+            return result
+
+        account.removeFromWatchlist(item_to_remove)
+        result['success'] = True
+        result['message'] = (f"Successfully removed '{title}' from {account.username}'s Plex Watchlist "
+                             f"(took {time.time() - start_time:.4f}s)")
+        logging.info(f"[PLEX_WATCHLIST_REMOVE_OTHER] {result['message']}")
+
+    except AttributeError as e:
+        if 'removeFromWatchlist' in str(e):
+            result['message'] = 'Plex API does not support watchlist removal (plexapi version too old)'
+            logging.warning(f"[PLEX_WATCHLIST_REMOVE_OTHER] {result['message']}: {e}")
+        else:
+            result['message'] = f'Attribute error: {e}'
+            logging.error(f"[PLEX_WATCHLIST_REMOVE_OTHER] {result['message']}", exc_info=True)
+    except Exception as e:
+        result['message'] = f'Error removing from Other Plex Watchlist: {e}'
+        logging.error(f"[PLEX_WATCHLIST_REMOVE_OTHER] {result['message']}", exc_info=True)
+
+    return result

--- a/database/collected_items.py
+++ b/database/collected_items.py
@@ -441,6 +441,15 @@ def add_collected_items(media_items_batch, recent=False, backfill=False, data_so
                         db_item_id = existing_db_item['id']
                         logging.debug(f"[Collection Debug] Found existing DB item ID {db_item_id} for lookup_key '{lookup_key}', state: {existing_db_item['state']}")
 
+                        # Skip if this Plex entry is the OLD pre-upgrade file. After an upgrade,
+                        # both the old file (upgrading_from) and new file (filled_by_file) can appear
+                        # in Plex simultaneously. Processing the old file would set location_on_disk
+                        # back to the stale path, undoing the new file's correct update.
+                        _upgrading_from = existing_db_item.get('upgrading_from')
+                        if _upgrading_from and filename == os.path.basename(_upgrading_from):
+                            logging.info(f"[Collection] Skipping stale pre-upgrade Plex entry '{filename}' for DB item {db_item_id} (upgrading_from match, new file is '{existing_db_item.get('filled_by_file')}')")
+                            continue
+
                         is_this_db_item_checking = existing_db_item['state'] == 'Checking'
                         # other_checking_items_exist = checking_items_count > 0 and (not is_this_db_item_checking or checking_items_count > 1)
 

--- a/database/zilean_upgrade.py
+++ b/database/zilean_upgrade.py
@@ -1350,8 +1350,25 @@ def scan_for_upgrades(max_workers: int = 20, scan_limit: Optional[int] = None,
             logger.info(f"[UPGRADE_HUB] Scan limit {scan_limit}: scanning {scan_limit}/{len(all_collected)} items")
             all_collected = all_collected[:scan_limit]
 
-        movies   = [i for i in all_collected if i['type'] == 'movie']
-        episodes = [i for i in all_collected if i['type'] == 'episode']
+        movies_raw = [i for i in all_collected if i['type'] == 'movie']
+        episodes   = [i for i in all_collected if i['type'] == 'episode']
+
+        # Deduplicate movies by (imdb_id, version): keep only the largest file per
+        # group. Torrents often contain extras (interviews, samples, featurettes)
+        # that end up as separate Collected rows with the same imdb_id. Scanning
+        # them individually produces spurious high-% upgrades (a 0.09 GB Sample.mkv
+        # looks like a +300% improvement vs. any real release).
+        _movie_best: dict = {}
+        for _m in movies_raw:
+            _key = (_m['imdb_id'], (_m.get('version') or default_version).rstrip('*').strip())
+            _existing = _movie_best.get(_key)
+            if _existing is None or _item_size_gb(_m) > _item_size_gb(_existing):
+                _movie_best[_key] = _m
+        movies = list(_movie_best.values())
+        _dedup_removed = len(movies_raw) - len(movies)
+        if _dedup_removed:
+            logger.info(f"[UPGRADE_HUB] Deduped {_dedup_removed} extra/duplicate movie files "
+                        f"(kept largest per imdb_id+version, {len(movies)} unique movies remain)")
 
         # Pre-populate version settings cache for every unique version in this
         # scan batch.  Workers only read the dict — no locking needed.

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -4425,6 +4425,7 @@ class ProgramRunner:
                     _item_type_lookup = 'show' if item_dict['type'] == 'episode' else item_dict['type']
                     # File path search: ask Plex "do you have this exact file?"
                     # Embed file in URL directly (not as kwarg) so requests doesn't alter the value.
+                    _plex_location = None
                     if actual_file_path:
                         _plex_filename = os.path.basename(actual_file_path)
                         _is_episode = item_dict['type'] == 'episode'
@@ -4436,6 +4437,10 @@ class ProgramRunner:
                                 _fp_results = plex.fetchItems(f'/library/sections/{_section.key}/all?file={_plex_filename}{_type_param}')
                                 if _fp_results:
                                     _force_collect_reason = f"file indexed in Plex confirmed (tick {current_tick})"
+                                    try:
+                                        _plex_location = _fp_results[0].media[0].parts[0].file
+                                    except Exception:
+                                        pass
                                     break
                             except Exception as _e_fp:
                                 logging.debug(f"[PlexCheck] File path search failed for item {item_id}: {_e_fp}")
@@ -4452,6 +4457,24 @@ class ProgramRunner:
                                     _results = _section.search(**{'guid': f'tmdb://{_tmdb_id}'})
                                 if _results:
                                     _force_collect_reason = f"direct Plex GUID lookup confirmed in library (tick {current_tick})"
+                                    # Try to extract location_on_disk from the matched Plex item,
+                                    # preferring the part whose filename matches filled_by_file.
+                                    if not _plex_location:
+                                        _new_basename = os.path.basename(item_dict.get('filled_by_file') or '')
+                                        try:
+                                            for _pi in _results:
+                                                for _pm in getattr(_pi, 'media', []):
+                                                    for _pp in getattr(_pm, 'parts', []):
+                                                        _pp_file = getattr(_pp, 'file', '') or ''
+                                                        if _new_basename and os.path.basename(_pp_file) == _new_basename:
+                                                            _plex_location = _pp_file
+                                                            break
+                                                    if _plex_location:
+                                                        break
+                                                if _plex_location:
+                                                    break
+                                        except Exception:
+                                            pass
                                     break
                             except Exception as _e_search:
                                 logging.debug(f"[PlexCheck] Direct GUID search failed for item {item_id}: {_e_search}")
@@ -4479,13 +4502,21 @@ class ProgramRunner:
                             _conn_fb = get_db_connection()
                             _cur_fb = _conn_fb.cursor()
                             _now_fb = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-                            _cur_fb.execute(
-                                'UPDATE media_items SET state = "Collected", collected_at = ? WHERE id = ? AND state = "Checking" AND (ghostlisted IS NULL OR ghostlisted = 0)',
-                                (_now_fb, item_id)
-                            )
+                            if _plex_location:
+                                _cur_fb.execute(
+                                    'UPDATE media_items SET state = "Collected", collected_at = ?, location_on_disk = ? WHERE id = ? AND state = "Checking" AND (ghostlisted IS NULL OR ghostlisted = 0)',
+                                    (_now_fb, _plex_location, item_id)
+                                )
+                            else:
+                                _cur_fb.execute(
+                                    'UPDATE media_items SET state = "Collected", collected_at = ? WHERE id = ? AND state = "Checking" AND (ghostlisted IS NULL OR ghostlisted = 0)',
+                                    (_now_fb, item_id)
+                                )
                             if _cur_fb.rowcount > 0:
                                 _conn_fb.commit()
                                 logging.info(f"[PlexCheck] Marked item {item_id} ({item_title_for_log}) as Collected ({_force_collect_reason}).")
+                                if _plex_location:
+                                    logging.info(f"[PlexCheck] Updated location_on_disk for item {item_id} ({item_title_for_log}): {_plex_location}")
                                 _fb_details = get_media_item_by_id(item_id)
                                 if _fb_details:
                                     handle_state_change(dict(_fb_details))
@@ -6110,10 +6141,16 @@ class ProgramRunner:
             # Force glibc to return freed arena pages to the OS immediately.
             try:
                 import gc, ctypes
-                _before_rss = _read_current_rss_kb()
+                def _rss_kb():
+                    with open('/proc/self/status') as _f:
+                        for _l in _f:
+                            if _l.startswith('VmRSS:'):
+                                return int(_l.split()[1])
+                    return 0
+                _before_rss = _rss_kb()
                 gc.collect()
                 ctypes.CDLL('libc.so.6').malloc_trim(0)
-                _after_rss = _read_current_rss_kb()
+                _after_rss = _rss_kb()
                 logging.info(f"[OVERLAY_SYNC] malloc_trim: RSS {_before_rss//1024} MB → {_after_rss//1024} MB (freed {(_before_rss - _after_rss)//1024} MB)")
             except Exception as _e:
                 logging.info(f"[OVERLAY_SYNC] malloc_trim skipped: {_e}")
@@ -7186,7 +7223,12 @@ def get_and_add_all_collected_from_plex(bypass=False, backfill=False):
                 if 'all_raw_episodes' in locals():
                     all_raw_episodes = None  # type: ignore
                 gc.collect()
-                logging.info("[MemCleanup] Cleared collected content and forced GC after Plex full scan.")
+                try:
+                    import ctypes as _ct
+                    _ct.CDLL('libc.so.6').malloc_trim(0)
+                    logging.info("[MemCleanup] Cleared collected content, GC + malloc_trim after Plex full scan.")
+                except Exception:
+                    logging.info("[MemCleanup] Cleared collected content and forced GC after Plex full scan.")
             except Exception as e_cleanup:
                 logging.debug(f"[MemCleanup] Exception during cleanup: {e_cleanup}")
             # ----------------------------------------------------------------

--- a/routes/overlay_routes.py
+++ b/routes/overlay_routes.py
@@ -16,6 +16,7 @@ from database.core import get_db_connection as _get_db_connection
 _SYSTEM_LOGO_DIR = Path(__file__).parent.parent / 'overlays' / 'assets' / 'logos'
 _USER_LOGO_DIR = Path('/user/config/overlay_assets/logos')
 
+from routes.models import admin_required
 from overlays import OverlayManager, LayoutManager, LayoutValidator
 from overlays.element_definitions import get_all_elements_by_category
 from overlays.activity_logger import log_activity
@@ -39,11 +40,13 @@ overlay_bp = Blueprint('overlay_api', __name__)
 
 # HTML routes
 @overlay_page_bp.route('/overlays')
+@admin_required
 def overlays_page():
     """Serve the overlay management UI."""
     return render_template('overlays.html')
 
 @overlay_page_bp.route('/overlays/builder')
+@admin_required
 def layout_builder_page():
     """Serve the layout builder UI."""
     return render_template('layout_builder.html')

--- a/templates/base.html
+++ b/templates/base.html
@@ -837,7 +837,7 @@
                         ('database.index', 'Database'),
                         ('database.phalanxdb_status', 'Phalanx DB'),
                         ('performance.performance_dashboard', 'Performance Dashboard')] +
-                        ([] if is_limited_environment() else [('debrid_manager.index', 'Debrid Manager'), ('upgrade_hub.index', 'Upgrade Hub')]) + [
+                        ([] if is_limited_environment() or (is_user_system_enabled() and not (current_user.is_authenticated and current_user.role == 'admin')) else [('debrid_manager.index', 'Debrid Manager'), ('upgrade_hub.index', 'Upgrade Hub')]) + [
                         ('connections.index', 'Connections'),
                         ('api_summary.index', 'API Summary'),
                         ('real_time_api.index', 'Real Time API')
@@ -852,8 +852,7 @@
                         ('user_token.collect_tokens_page', 'Plex User Token M.'),
                         ('symlink_tools.index', 'Symlink Tools'),
                         ('metadata.metadata_debug', 'Metadata Debug'),
-                        ('overlay_page.overlays_page', 'Overlays')
-                    ]
+                    ] + ([('overlay_page.overlays_page', 'Overlays')] if not is_user_system_enabled() or (current_user.is_authenticated and current_user.role == 'admin') else [])
                 } %}
 
                 {% set menu_icons = {

--- a/utilities/post_processing.py
+++ b/utilities/post_processing.py
@@ -247,6 +247,48 @@ def run_custom_script(item: Dict[str, Any]) -> None:
     except Exception as e:
         logging.error(f"Failed to run custom script: {str(e)}")
 
+def _handle_plex_watchlist_removal(item: Dict[str, Any]) -> None:
+    """Remove item from My Plex Watchlist or Other Plex Watchlist based on its content_source."""
+    if not get_setting('Debug', 'plex_watchlist_removal', False):
+        return
+
+    # Respect the keep_series setting: skip episodes/shows if enabled
+    keep_series = get_setting('Debug', 'plex_watchlist_keep_series', False)
+    if keep_series and item.get('type') in ('episode', 'show'):
+        logging.debug(f"[WATCHLIST_REMOVE] Skipping series '{item.get('title')}' (plex_watchlist_keep_series enabled)")
+        return
+
+    content_source = item.get('content_source', '')
+    if not content_source:
+        return
+
+    # Resolve source type from source config (e.g. "My Plex Watchlist_1" → type "My Plex Watchlist")
+    from queues.config_manager import load_config
+    config = load_config()
+    source_config = config.get('Content Sources', {}).get(content_source, {})
+    source_type = source_config.get('type', '')
+
+    if source_type == 'My Plex Watchlist':
+        from content_checkers.plex_watchlist import remove_from_plex_watchlist_by_item
+        result = remove_from_plex_watchlist_by_item(item)
+        if result.get('success'):
+            logging.info(f"[WATCHLIST_REMOVE] Removed '{item.get('title')}' from My Plex Watchlist")
+        elif not result.get('not_found'):
+            logging.warning(f"[WATCHLIST_REMOVE] Could not remove '{item.get('title')}' from My Plex Watchlist: {result.get('message')}")
+
+    elif source_type == 'Other Plex Watchlist':
+        token = source_config.get('token', '')
+        if not token:
+            logging.warning(f"[WATCHLIST_REMOVE] No token found for source '{content_source}', cannot remove from watchlist")
+            return
+        from content_checkers.plex_watchlist import remove_from_other_plex_watchlist_by_item
+        result = remove_from_other_plex_watchlist_by_item(item, token)
+        if result.get('success'):
+            logging.info(f"[WATCHLIST_REMOVE] Removed '{item.get('title')}' from Other Plex Watchlist ({content_source})")
+        elif not result.get('not_found'):
+            logging.warning(f"[WATCHLIST_REMOVE] Could not remove '{item.get('title')}' from Other Plex Watchlist ({content_source}): {result.get('message')}")
+
+
 def handle_state_change(item: Dict[str, Any]) -> None:
     """
     Handle any post-processing needed when an item enters a new state.
@@ -343,6 +385,14 @@ def handle_state_change(item: Dict[str, Any]) -> None:
                     replace_cleanup_after_collect(dict(fresh_item))
                 except Exception as e:
                     logging.error(f"Failed to run replace cleanup after collect: {str(e)}")
+
+            # Remove from Plex Watchlist if the setting is enabled and the item
+            # came from a My Plex Watchlist or Other Plex Watchlist source.
+            if state == 'Collected':
+                try:
+                    _handle_plex_watchlist_removal(dict(fresh_item))
+                except Exception as e:
+                    logging.error(f"Failed to handle Plex Watchlist removal: {e}")
 
             # Apply poster overlay in a background thread (non-blocking).
             # Duplicate-run protection is handled inside apply_overlay_for_new_item


### PR DESCRIPTION
…st removal, and admin-only nav

- task_check_plex_files: update location_on_disk from Plex file path when marking item Collected
- collected_items: skip stale pre-upgrade Plex entry (upgrading_from match); fix size always updating with COALESCE
- task_overlay_sync: fix broken malloc_trim (undefined _read_current_rss_kb); inline /proc/self/status read
- get_and_add_all_collected_from_plex: add malloc_trim after GC cleanup to return arena pages to OS
- zilean_upgrade: deduplicate movies by (imdb_id, version) keeping largest file, eliminating extras/samples from upgrade scan
- plex_watchlist: add remove_from_other_plex_watchlist_by_item() for Other Plex Watchlist token-based removal
- post_processing: add _handle_plex_watchlist_removal() hooked into handle_state_change on Collected
- overlay_routes: add @admin_required to overlays_page and layout_builder_page
- base.html: hide Overlays, Debrid Manager, Upgrade Hub from non-admin roles when user system is enabled