### PR TITLE
Fixes and Improvements

### DIFF
--- a/routes/log_viewer_routes.py
+++ b/routes/log_viewer_routes.py
@@ -434,6 +434,8 @@ def stream_logs():
     def generate():
         last_timestamp = request.args.get('since', '')
         level = request.args.get('level', 'all').lower()
+        lines = request.args.get('lines', default=1000, type=int)
+        lines = max(100, min(lines, 5000))  # clamp to valid range
         # Increase polling interval to 500ms (was 50ms) to reduce CPU usage
         # 500ms is still responsive enough for log viewing while being 10x more efficient
         interval = 0.5
@@ -452,9 +454,9 @@ def stream_logs():
             try:
                 start_time = time.time()
 
-                # On first connection, get all logs up to MAX_LOGS
+                # On first connection, get all logs up to requested lines
                 if first_batch:
-                    logs = get_recent_logs(1000, level=level)
+                    logs = get_recent_logs(lines, level=level)
                     first_batch = False
                     # Populate seen_log_hashes with initial logs
                     for log in logs:
@@ -462,7 +464,7 @@ def stream_logs():
                         seen_log_hashes.add(log_hash)
                 else:
                     # After first batch, only get new logs since last timestamp
-                    raw_logs = get_recent_logs(1000, since=last_timestamp, level=level)
+                    raw_logs = get_recent_logs(lines, since=last_timestamp, level=level)
 
                     # Filter out duplicates using seen_log_hashes
                     logs = []

--- a/scraper/functions/filter_results.py
+++ b/scraper/functions/filter_results.py
@@ -939,23 +939,26 @@ def filter_results(
                         target_year = year  # Default to original year
                         
                         # Try to get the season-specific year from the database
-                        if imdb_id and season is not None:
+                        # Use original_season for year lookup when XEM/absolute remapping has occurred
+                        # (e.g. anime S03E12 remapped to scene S01E12 — look up S3 year, not S1 year)
+                        year_lookup_season = original_season if (original_season is not None and original_season != season) else season
+                        if imdb_id and year_lookup_season is not None:
                             # Check cache first
-                            cache_key = (imdb_id, season)
+                            cache_key = (imdb_id, year_lookup_season)
                             if cache_key in _season_year_cache:
                                 target_year = _season_year_cache[cache_key]
                                 # logging.debug(f"Using cached season year for {imdb_id} S{season}: {target_year}")
                             else:
                                 try:
                                     from database.database_reading import get_season_year
-                                    season_year = get_season_year(imdb_id=imdb_id, season_number=season)
+                                    season_year = get_season_year(imdb_id=imdb_id, season_number=year_lookup_season)
                                     if season_year:
                                         target_year = season_year
                                         _season_year_cache[cache_key] = season_year  # Cache the result
-                                        logging.info(f"Using season {season} air date year ({season_year}) instead of original show year ({year}) for '{original_title}'")
+                                        logging.info(f"Using season {year_lookup_season} air date year ({season_year}) instead of original show year ({year}) for '{original_title}'")
                                     else:
                                         # Fallback: Try to get season year from metadata API
-                                        logging.debug(f"No season year in database for {imdb_id} S{season}, trying metadata API fallback")
+                                        logging.debug(f"No season year in database for {imdb_id} S{year_lookup_season}, trying metadata API fallback")
                                         if direct_api:
                                             # Check metadata cache first
                                             if imdb_id in _show_metadata_cache:
@@ -969,11 +972,11 @@ def filter_results(
                                                     logging.warning(f"Error getting show metadata for {imdb_id}: {api_err}")
                                                     show_metadata = None
                                                     _show_metadata_cache[imdb_id] = None  # Cache the failure
-                                            
+
                                             if show_metadata and isinstance(show_metadata, dict):
                                                 trakt_seasons_data = show_metadata.get('seasons')
-                                                if isinstance(trakt_seasons_data, dict) and season in trakt_seasons_data:
-                                                    current_season_trakt_data = trakt_seasons_data[season]
+                                                if isinstance(trakt_seasons_data, dict) and year_lookup_season in trakt_seasons_data:
+                                                    current_season_trakt_data = trakt_seasons_data[year_lookup_season]
                                                     if isinstance(current_season_trakt_data, dict) and 'episodes' in current_season_trakt_data:
                                                         episodes_dict_for_season = current_season_trakt_data['episodes']
                                                         if episodes_dict_for_season:
@@ -993,15 +996,15 @@ def filter_results(
                                                                         season_year = utc_dt.year
                                                                         target_year = season_year
                                                                         _season_year_cache[cache_key] = season_year  # Cache the result
-                                                                        logging.info(f"Using season {season} air date year ({season_year}) from metadata API instead of original show year ({year}) for '{original_title}'")
+                                                                        logging.info(f"Using season {year_lookup_season} air date year ({season_year}) from metadata API instead of original show year ({year}) for '{original_title}'")
                                                                     except Exception as date_parse_err:
-                                                                        logging.warning(f"Failed to parse season {season} air date from metadata API: {date_parse_err}")
-                                    
+                                                                        logging.warning(f"Failed to parse season {year_lookup_season} air date from metadata API: {date_parse_err}")
+
                                     if target_year == year:  # If we still haven't found a season year
                                         _season_year_cache[cache_key] = year  # Cache the fallback
-                                        logging.debug(f"No season-specific year found for {imdb_id} S{season}, using original show year ({year})")
+                                        logging.debug(f"No season-specific year found for {imdb_id} S{year_lookup_season}, using original show year ({year})")
                                 except Exception as season_year_err:
-                                    logging.warning(f"Error getting season year for {imdb_id} S{season}: {season_year_err}, using original show year ({year})")
+                                    logging.warning(f"Error getting season year for {imdb_id} S{year_lookup_season}: {season_year_err}, using original show year ({year})")
                                     _season_year_cache[cache_key] = year  # Cache the fallback
                         
                         if isinstance(parsed_year, list):

--- a/static/css/debrid_manager.css
+++ b/static/css/debrid_manager.css
@@ -1266,6 +1266,7 @@
     border-bottom: 1px solid #1a1a1a;
 }
 .dm-bk-slot-row:last-child { border-bottom: none; }
+.dm-bk-slot-actions { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
 .dm-bk-slot-row-info {
     display: flex;
     align-items: center;

--- a/static/css/logs.css
+++ b/static/css/logs.css
@@ -50,11 +50,6 @@
             margin-right: 0 !important;
         }
 
-        .match-count {
-            font-size: 0.9em;
-            margin-top: 5px;
-        }
-
         .bottom-button {
             position: absolute !important;
             left: 50%;
@@ -66,10 +61,6 @@
         #pause-indicator {
             top: 124px !important;
             right: 10px !important;
-        }
-
-        #goto-container {
-            width: 100%;
         }
 
         /* --- START EDIT: Adjust height when task monitor overlay is visible --- */
@@ -114,6 +105,93 @@
         border: 1px solid #666;
         border-radius: 3px;
     }
+
+    /* ── Chip filter bar ─────────────────────────────────────────────── */
+    .log-filter-chips {
+        display: none;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 5px;
+        padding: 4px 12px;
+        background-color: #2a2a2a;
+        border-bottom: 1px solid #3a3a3a;
+        box-sizing: border-box;
+        overflow: visible;
+    }
+
+    .log-chip {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        padding: 2px 9px;
+        border-radius: 10px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        background: rgba(255, 255, 255, 0.06);
+        color: var(--chip-color, #aaa);
+        font-size: 0.73em;
+        font-family: monospace;
+        cursor: pointer;
+        transition: opacity 0.15s;
+        white-space: nowrap;
+        line-height: 1.6;
+        flex-shrink: 0;
+    }
+
+    .log-chip:hover { opacity: 0.75; }
+
+    .log-chip-disabled {
+        opacity: 0.3;
+        text-decoration: line-through;
+    }
+
+    .log-chip-more {
+        --chip-color: #777;
+        font-family: sans-serif;
+        letter-spacing: 0.02em;
+        border-style: dashed;
+    }
+
+    .log-chip-more-wrapper {
+        position: relative;
+        flex-shrink: 0;
+    }
+
+    .log-chip-dropdown {
+        position: fixed;
+        z-index: 9999;
+        background: #252525;
+        border: 1px solid #4a4a4a;
+        border-radius: 6px;
+        padding: 4px;
+        min-width: 200px;
+        max-height: 320px;
+        overflow-y: auto;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.5);
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+    }
+
+    .log-chip-dropdown-item {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        padding: 4px 10px;
+        border-radius: 4px;
+        border: none;
+        background: transparent;
+        color: var(--chip-color, #bbb);
+        font-size: 0.76em;
+        font-family: monospace;
+        cursor: pointer;
+        text-align: left;
+        white-space: nowrap;
+        transition: background 0.1s;
+    }
+
+    .log-chip-dropdown-item:hover { background: rgba(255,255,255,0.07); }
+    .log-chip-dropdown-item.log-chip-disabled { opacity: 0.3; text-decoration: line-through; }
+    /* ── End chip filter ─────────────────────────────────────────────── */
 
     #log-entries {
         flex-grow: 1;
@@ -337,6 +415,7 @@
 
     .log-message {
         color: #ecf0f1;  /* Light gray for the main message */
+        opacity: 0.9;
     }
 
     .log-duration {
@@ -351,85 +430,9 @@
     .log-message.error { color: #e74c3c; }
     .log-message.critical { color: #9b59b6; }
 
-    /* Remove the generic message color since we'll use level-specific colors */
-    .log-message {
-        opacity: 0.9;  /* Slightly reduce opacity to differentiate from level indicator */
-    }
-
-    /* Add styles for the goto search container */
-    .goto-container {
-        display: flex;
-        gap: 5px;
-    }
-
-    .goto-btn {
-        padding: 5px;
-        background-color: #444;
-        color: #f4f4f4;
-        border: 1px solid #666;
-        border-radius: 3px;
-        cursor: pointer;
-        font-size: 14px;
-    }
-
-    .goto-btn:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
-
-    .goto-btn:not(:disabled):hover {
-        background-color: #555;
-    }
-
-    .goto-nav-buttons {
-        display: flex;
-        gap: 2px;
-    }
-
-    .goto-nav-button {
-        padding: 5px;
-        background-color: #444;
-        color: #f4f4f4;
-        border: 1px solid #666;
-        border-radius: 3px;
-        cursor: pointer;
-    }
-
-    .goto-nav-button:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
-
-    .goto-nav-button:not(:disabled):hover {
-        background-color: #555;
-    }
-
-    .match-count {
-        color: #888;
-        font-size: 0.8em;
-        padding: 0 5px;
-        min-width: 45px;  /* Ensure consistent width for count */
-        text-align: left;
-    }
-
     /* Update the existing search box style */
     #log-search {
         min-width: 200px;
-    }
-
-    /* Add styles for highlighted matches */
-    .highlight-match {
-        background-color: rgba(255, 255, 0, 0.2);
-        outline: 2px solid rgba(255, 255, 0, 0.3);
-    }
-
-    #goto-search {
-        padding: 5px;
-        background-color: #444;
-        color: #f4f4f4;
-        border: 1px solid #666;
-        border-radius: 3px;
-        width: 150px;
     }
 
     /* Add styles for the bottom button */

--- a/static/css/tangerine/tangerine_debrid_manager.css
+++ b/static/css/tangerine/tangerine_debrid_manager.css
@@ -1474,7 +1474,13 @@ body[data-theme="tangerine"] .dm-bk-provider-label {
     font-weight: 600;
 }
 
-/* Restore button inside slot row */
+/* Restore / Dry Run buttons inside slot row */
+body[data-theme="tangerine"] .dm-bk-slot-actions {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    flex-shrink: 0;
+}
 body[data-theme="tangerine"] .dm-bk-slot-row .dm-btn {
     flex-shrink: 0;
 }

--- a/static/css/tangerine/tangerine_logs.css
+++ b/static/css/tangerine/tangerine_logs.css
@@ -63,6 +63,93 @@
         box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
     }
 
+    /* ── Chip filter bar (tangerine) ─────────────────────────────────── */
+    .log-filter-chips {
+        display: none;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 5px;
+        padding: 4px 12px;
+        background: rgba(255, 255, 255, 0.02);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+        box-sizing: border-box;
+        overflow: visible;
+    }
+
+    .log-chip {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        padding: 2px 9px;
+        border-radius: 20px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        background: rgba(255, 255, 255, 0.06);
+        color: var(--chip-color, #aaa);
+        font-size: 0.73em;
+        font-family: monospace;
+        cursor: pointer;
+        transition: opacity 0.15s;
+        white-space: nowrap;
+        line-height: 1.6;
+        flex-shrink: 0;
+    }
+
+    .log-chip:hover { opacity: 0.75; }
+
+    .log-chip-disabled {
+        opacity: 0.3;
+        text-decoration: line-through;
+    }
+
+    .log-chip-more {
+        --chip-color: #777;
+        font-family: sans-serif;
+        letter-spacing: 0.02em;
+        border-style: dashed;
+    }
+
+    .log-chip-more-wrapper {
+        position: relative;
+        flex-shrink: 0;
+    }
+
+    .log-chip-dropdown {
+        position: fixed;
+        z-index: 9999;
+        background: #1a1a24;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 6px;
+        padding: 4px;
+        min-width: 200px;
+        max-height: 320px;
+        overflow-y: auto;
+        box-shadow: 0 6px 20px rgba(0,0,0,0.6);
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+    }
+
+    .log-chip-dropdown-item {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        padding: 4px 10px;
+        border-radius: 4px;
+        border: none;
+        background: transparent;
+        color: var(--chip-color, #bbb);
+        font-size: 0.76em;
+        font-family: monospace;
+        cursor: pointer;
+        text-align: left;
+        white-space: nowrap;
+        transition: background 0.1s;
+    }
+
+    .log-chip-dropdown-item:hover { background: rgba(255, 107, 53, 0.1); }
+    .log-chip-dropdown-item.log-chip-disabled { opacity: 0.3; text-decoration: line-through; }
+    /* ── End chip filter ─────────────────────────────────────────────── */
+
     #log-entries {
         flex-grow: 1;
         overflow-y: auto;
@@ -308,95 +395,9 @@
         opacity: 0.9;  /* Slightly reduce opacity to differentiate from level indicator */
     }
 
-    /* Add styles for the goto search container */
-    .goto-container {
-        display: flex;
-        gap: 5px;
-    }
-
-    .goto-btn {
-        padding: 0.75rem 1rem;
-        background: rgba(255, 255, 255, 0.05);
-        color: #e0e0e0;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-radius: 12px;
-        cursor: pointer;
-        font-size: 14px;
-        transition: all 0.3s ease;
-    }
-
-    .goto-btn:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
-
-    .goto-btn:not(:disabled):hover {
-        background: rgba(255, 255, 255, 0.08);
-        border-color: rgba(255, 107, 53, 0.5);
-        box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
-    }
-
-    .goto-nav-buttons {
-        display: flex;
-        gap: 2px;
-    }
-
-    .goto-nav-button {
-        padding: 0.75rem;
-        background: rgba(255, 255, 255, 0.05);
-        color: #e0e0e0;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-radius: 12px;
-        cursor: pointer;
-        transition: all 0.3s ease;
-    }
-
-    .goto-nav-button:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
-
-    .goto-nav-button:not(:disabled):hover {
-        background: rgba(255, 255, 255, 0.08);
-        border-color: rgba(255, 107, 53, 0.5);
-        box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
-    }
-
-    .match-count {
-        color: #888;
-        font-size: 0.8em;
-        padding: 0 5px;
-        min-width: 45px;  /* Ensure consistent width for count */
-        text-align: left;
-    }
-
     /* Update the existing search box style */
     #log-search {
         min-width: 200px;
-    }
-
-    /* Add styles for highlighted matches */
-    .highlight-match {
-        background-color: rgba(255, 255, 0, 0.2);
-        outline: 2px solid rgba(255, 255, 0, 0.3);
-    }
-
-    #goto-search {
-        padding: 0.75rem 1rem;
-        background: rgba(255, 255, 255, 0.05);
-        color: #e0e0e0;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-radius: 12px;
-        transition: all 0.3s ease;
-        width: 250px;
-    }
-
-    #goto-search:focus,
-    #goto-search:hover {
-        outline: none;
-        background: rgba(255, 255, 255, 0.08);
-        border-color: rgba(255, 107, 53, 0.5);
-        box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
     }
 
     /* Add styles for the bottom button */
@@ -454,11 +455,6 @@
             margin-right: 0 !important;
         }
 
-        .match-count {
-            font-size: 0.9em;
-            margin-top: 5px;
-        }
-
         .bottom-button {
             position: absolute !important;
             left: 50%;
@@ -472,22 +468,9 @@
             right: 10px !important;
         }
 
-        #goto-container {
-            width: 100%;
-        }
-
         /* --- START EDIT: Adjust height when task monitor overlay is visible --- */
         body.has-bottom-overlay .log-container {
             height: calc(100vh - 100px); /* existing offset + overlay */
-        }
-        .goto-btn {
-            padding: 0.55rem .4rem;
-        }
-        #goto-search {
-            width: auto;
-        }
-        .goto-container {
-            flex-flow: wrap;
         }
     }
 

--- a/templates/debrid_manager.html
+++ b/templates/debrid_manager.html
@@ -2519,12 +2519,19 @@ function _bkRenderSlots(status) {
             <span class="dm-bk-slot-stats">${count}${count && size !== '—' ? ' · ' : ''}${size !== '—' ? size : ''}</span>
         </div>
     </div>
-    <button class="dm-btn dm-btn-secondary dm-btn-sm dm-bk-restore-btn"
-            onclick="bkRestore('${filename}', this)"
-            title="Restore from this backup">
-        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
-        Restore
-    </button>
+    <div class="dm-bk-slot-actions">
+        <button class="dm-btn dm-btn-secondary dm-btn-sm dm-bk-restore-btn"
+                onclick="bkRestore('${filename}', this, true)"
+                title="Preview what would be restored without making any changes">
+            Dry Run
+        </button>
+        <button class="dm-btn dm-btn-secondary dm-btn-sm dm-bk-restore-btn"
+                onclick="bkRestore('${filename}', this, false)"
+                title="Restore from this backup">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+            Restore
+        </button>
+    </div>
 </div>`;
         }
     }
@@ -2695,34 +2702,50 @@ document.getElementById('cl-run-btn').addEventListener('click', async function()
     btn.innerHTML = '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0f01-15.357-2m15.357 2H15"/></svg> Run Now';
 });
 
-async function bkRestore(filename, btn) {
-    if (!confirm(`Restore from "${filename}"?\n\nThis will re-add any torrents missing from your current debrid library. Existing torrents are not affected.`)) return;
+async function bkRestore(filename, btn, dryRun) {
+    if (dryRun) {
+        if (!confirm(`Dry run for "${filename}"?\n\nThis will preview what would be restored without making any changes to your debrid library.`)) return;
+    } else {
+        if (!confirm(`Restore from "${filename}"?\n\nThis will re-add any torrents missing from your current debrid library. Existing torrents are not affected.`)) return;
+    }
+    // Disable all restore/dry-run buttons in this row to prevent double-clicks
+    const row = btn.closest('.dm-bk-slot-row');
+    const rowBtns = row ? row.querySelectorAll('button') : [btn];
+    rowBtns.forEach(b => b.disabled = true);
     const origHtml = btn.innerHTML;
-    btn.disabled = true;
     btn.innerHTML = '<span class="dm-spinner"></span>';
     const msg = document.getElementById('bk-save-msg');
     try {
         const r = await fetch('/debrid_manager/api/backup/restore', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({filename}),
+            body: JSON.stringify({filename, dry_run: dryRun}),
         });
         const data = await r.json();
         msg.style.display = '';
         if (data.success) {
             msg.className = 'dm-backup-msg dm-backup-msg-ok';
-            msg.textContent = `Restore complete: ${data.added} added, ${data.skipped} already present${data.failed ? ', ' + data.failed + ' failed' : ''}.`;
+            if (dryRun) {
+                const failNote = data.failures && data.failures.length ? `, ${data.failures.length} would fail` : '';
+                msg.textContent = `Dry run: ${data.added} would be added, ${data.skipped} already present${failNote}. No changes made.`;
+            } else {
+                const failNote = data.failed ? `, ${data.failed} failed` : '';
+                msg.textContent = `Restore complete: ${data.added} added, ${data.skipped} already present${failNote}.`;
+                if (data.failures && data.failures.length) {
+                    console.warn('Restore failures:', data.failures);
+                }
+            }
         } else {
             msg.className = 'dm-backup-msg dm-backup-msg-err';
-            msg.textContent = 'Restore failed: ' + (data.message || data.error || 'unknown');
+            msg.textContent = (dryRun ? 'Dry run failed: ' : 'Restore failed: ') + (data.message || data.error || 'unknown');
         }
-        setTimeout(() => { msg.style.display = 'none'; }, 8000);
+        setTimeout(() => { msg.style.display = 'none'; }, 10000);
     } catch(e) {
         msg.style.display = '';
         msg.className = 'dm-backup-msg dm-backup-msg-err';
         msg.textContent = 'Error: ' + e.message;
     }
-    btn.disabled = false;
+    rowBtns.forEach(b => b.disabled = false);
     btn.innerHTML = origHtml;
 }
 

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -2,7 +2,20 @@
 
 
 {% block head %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/logs.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/logs.css') }}?v=7">
+<script>
+(function(){
+    var theme = localStorage.getItem('selectedTheme') || 'tangerine';
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/static/css/tangerine/tangerine_logs.css?v=7';
+    link.id = 'theme-tangerine-logs';
+    link.setAttribute('data-theme-css', 'tangerine');
+    if (theme === 'tangerine') {
+        document.head.appendChild(link);
+    }
+})();
+</script>
 {% endblock %}
 {% block title %}Logs{% endblock %}
 
@@ -19,22 +32,13 @@
             <option value="error">Error</option>
             <option value="critical">Critical</option>
         </select>
-        <div class="goto-container">
-            <button class="goto-btn" onclick="navigateToFirstMatch()">⭱ First</button>
-            <button class="goto-nav-button" id="prev-match" title="Previous match (Shift+Enter)" disabled>
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
-                </svg>
-            </button>
-            <input type="text" id="goto-search" placeholder="Go to... (Enter/Shift+Enter to navigate)" />
-            <button class="goto-nav-button" id="next-match" title="Next match (Enter)" disabled>
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-                </svg>
-            </button>
-            <button class="goto-btn" onclick="navigateToLastMatch()">⭳ Last</button>
-            <span class="match-count"></span>
-        </div>
+        <select id="log-lines-select" title="Number of log lines to display">
+            <option value="100">100 lines</option>
+            <option value="500">500 lines</option>
+            <option value="1000" selected>1000 lines</option>
+            <option value="2000">2000 lines</option>
+            <option value="5000">5000 lines</option>
+        </select>
         <input type="text" id="log-search" placeholder="Filter logs...">
         <button id="share-logs-btn" title="Share logs via transfer.sh">
             Share Logs
@@ -47,6 +51,7 @@
             </svg>
         </button>
     </div>
+    <div id="log-filter-chips" class="log-filter-chips"></div>
     <div id="log-entries">
     {% for log in logs %}
     <div class="log-entry {{ log.level }}" data-level="{{ log.level }}">{{ log.timestamp }} - {{ log.level.upper() }} - {{ log.message }}</div>
@@ -63,13 +68,182 @@
 <script>
 let lastLogTimestamp = '';
 let currentLevel = 'all';
+let currentLines = 1000;
 let isPaused = false;
 let isScrolledToBottom = true;
-let isSearchActive = false;
-let currentMatches = [];
-let currentMatchIndex = -1;
-const MAX_LOGS = 1500;
+const MAX_LOGS = 5000;
 const renderedLogIds = new Set(); // Track rendered logs to prevent duplicates
+
+// ── CHIP FILTER STATE ──────────────────────────────────────────────────────
+const CHIP_COLORS = [
+    '#ffa657','#f2cc60','#7ee787','#a5d6ff',
+    '#d2a8ff','#ff7eb6','#79c0ff','#e8b4a0'
+];
+const MAX_VISIBLE_CHIPS = 20;
+
+const FILE_GROUPS = {
+    queues:   ['adding_queue','scraping_queue','checking_queue','unreleased_queue','queue_manager','zilean_upgrade','base_queue','wanted_queue','upgrading_queue','blacklisted_queue','sleeping_queue','pending_uncached_queue','pre_release_queue','final_check_queue'],
+    scraper:  ['scraper','scraper_manager','media_matcher','jackett','prowlarr','knightcrawler','mediafusion','torrentio','zilean','nyaa','rank_results','filter_results','deduplicate_results','reverse_parser','renderer','web_scraper','media_info'],
+    torrent:  ['torrent_processor','torrent_tracking','client','magnet','debrid_backup'],
+    database: ['database','database_writing','database_reading','collected_items','wanted_items','not_wanted_magnets','schema_management','migrations','phalanx_db_cache_manager','db_init','maintenance'],
+    plex:     ['plex_functions','plex_client','plex_label_manager','plex_db_functions','plex_matching_functions','plex_watchlist','plex_rss_watchlist','overlay_manager','badge_manager','poster_cache'],
+    trakt:    ['trakt','trakt_client','trakt_coordinator','trakt_auth'],
+    routes:   ['program_operation_routes','content_requestor_routes','web_server','scraper_routes','library_routes','settings_routes','debug_routes','database_routes','overlay_routes','queues_routes','api_summary_routes'],
+    system:   ['main','base','config_manager','settings','scheduled_tasks','notifications','post_processing','statistics','cache_cleanup','ai_health_monitor','symlink_verification','run_program','initialization'],
+};
+
+// Build reverse map: filename -> group
+const FILE_TO_GROUP = {};
+for (const [group, files] of Object.entries(FILE_GROUPS)) {
+    for (const f of files) FILE_TO_GROUP[f] = group;
+}
+
+// group -> { count, color, enabled }
+const chipState = new Map();
+let chipDropdownOpen = false;
+
+// Pre-assign stable colors to groups
+const GROUP_COLORS = {
+    queues:   '#ffa657',
+    scraper:  '#f2cc60',
+    torrent:  '#7ee787',
+    database: '#a5d6ff',
+    plex:     '#d2a8ff',
+    trakt:    '#ff7eb6',
+    routes:   '#79c0ff',
+    system:   '#e8b4a0',
+};
+
+function extractFuncName(log) {
+    // message format from parse_log_line: "file.py:func_name:lineno - actual message"
+    const m = log.message.match(/^([^.:]+)\.py:[^:]+:\d+/);
+    if (!m) return null;
+    const stem = m[1];
+    return FILE_TO_GROUP[stem] || stem; // fall back to stem if unmapped
+}
+
+function registerFuncName(funcName) {
+    if (!funcName) return;
+    if (chipState.has(funcName)) {
+        chipState.get(funcName).count++;
+    } else {
+        chipState.set(funcName, {
+            count: 1,
+            color: GROUP_COLORS[funcName] || '#aaa',
+            enabled: true
+        });
+    }
+}
+
+function renderChips() {
+    const bar = document.getElementById('log-filter-chips');
+    if (!bar) return;
+
+    // Sort by count desc, take top 5 + rest
+    const sorted = Array.from(chipState.entries())
+        .sort((a, b) => b[1].count - a[1].count);
+    const visible = sorted.slice(0, MAX_VISIBLE_CHIPS);
+    const overflow = sorted.slice(MAX_VISIBLE_CHIPS);
+
+    bar.innerHTML = '';
+
+    if (sorted.length === 0) {
+        bar.style.display = 'none';
+        return;
+    }
+    bar.style.display = 'flex';
+
+    visible.forEach(([name, data]) => {
+        const chip = document.createElement('button');
+        chip.className = 'log-chip' + (data.enabled ? '' : ' log-chip-disabled');
+        chip.style.setProperty('--chip-color', data.color);
+        chip.textContent = name;
+        chip.title = `${data.count} occurrences`;
+        chip.addEventListener('click', () => {
+            data.enabled = !data.enabled;
+            chip.classList.toggle('log-chip-disabled');
+            applyChipFilter();
+        });
+        bar.appendChild(chip);
+    });
+
+    // Toggle all/none button
+    const allEnabled = sorted.every(([, d]) => d.enabled);
+    const toggleAll = document.createElement('button');
+    toggleAll.className = 'log-chip log-chip-more';
+    toggleAll.textContent = allEnabled ? 'Hide all' : 'Show all';
+    toggleAll.title = allEnabled ? 'Disable all filters' : 'Enable all filters';
+    toggleAll.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const enable = !sorted.every(([, d]) => d.enabled);
+        sorted.forEach(([, d]) => { d.enabled = enable; });
+        applyChipFilter();
+        renderChips();
+    });
+    bar.appendChild(toggleAll);
+
+    if (overflow.length > 0) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'log-chip-more-wrapper';
+
+        const moreBtn = document.createElement('button');
+        moreBtn.className = 'log-chip log-chip-more';
+        moreBtn.textContent = `+${overflow.length} more`;
+        moreBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            chipDropdownOpen = !chipDropdownOpen;
+            if (chipDropdownOpen) {
+                const rect = moreBtn.getBoundingClientRect();
+                dropdown.style.top = (rect.bottom + 5) + 'px';
+                dropdown.style.left = rect.left + 'px';
+                dropdown.style.display = 'flex';
+            } else {
+                dropdown.style.display = 'none';
+            }
+        });
+
+        const dropdown = document.createElement('div');
+        dropdown.className = 'log-chip-dropdown';
+        dropdown.style.display = 'none';
+        overflow.forEach(([name, data]) => {
+            const item = document.createElement('button');
+            item.className = 'log-chip-dropdown-item' + (data.enabled ? '' : ' log-chip-disabled');
+            item.style.setProperty('--chip-color', data.color);
+            item.textContent = `${name} (${data.count})`;
+            item.addEventListener('click', (e) => {
+                e.stopPropagation();
+                data.enabled = !data.enabled;
+                item.classList.toggle('log-chip-disabled');
+                applyChipFilter();
+            });
+            dropdown.appendChild(item);
+        });
+
+        wrapper.appendChild(moreBtn);
+        wrapper.appendChild(dropdown);
+        bar.appendChild(wrapper);
+    }
+}
+
+function applyChipFilter() {
+    const logEntries = document.getElementById('log-entries');
+    const searchTerm = document.getElementById('log-search').value.toLowerCase();
+    logEntries.querySelectorAll('.log-entry').forEach(div => {
+        const funcName = div.dataset.func;
+        const chipOk = !funcName || !chipState.has(funcName) || chipState.get(funcName).enabled;
+        const searchOk = !searchTerm || div.textContent.toLowerCase().includes(searchTerm);
+        div.style.display = (chipOk && searchOk) ? '' : 'none';
+    });
+}
+
+document.addEventListener('click', () => {
+    if (chipDropdownOpen) {
+        chipDropdownOpen = false;
+        const dd = document.querySelector('.log-chip-dropdown');
+        if (dd) dd.style.display = 'none';
+    }
+});
+// ── END CHIP FILTER ────────────────────────────────────────────────────────
 
 function checkScrollPosition() {
     const logEntries = document.getElementById('log-entries');
@@ -111,14 +285,18 @@ function scrollToBottom(element) {
 
 function updateLogs(forceRefresh = false) {
     const levelFilter = document.getElementById('log-level-filter').value.toLowerCase();
+    const linesVal = parseInt(document.getElementById('log-lines-select').value, 10) || 1000;
 
-    // If forcing refresh or changing levels, reset and start new stream
-    if (levelFilter !== currentLevel || forceRefresh) {
+    // If forcing refresh or changing levels/lines, reset and start new stream
+    if (levelFilter !== currentLevel || linesVal !== currentLines || forceRefresh) {
         const logEntries = document.getElementById('log-entries');
         lastLogTimestamp = '';
         logEntries.innerHTML = ''; // Clear existing logs
         renderedLogIds.clear(); // Clear duplicate tracking
+        chipState.clear();
+        renderChips();
         currentLevel = levelFilter;
+        currentLines = linesVal;
         isPaused = false;
         document.getElementById('pause-indicator').style.display = 'none';
         
@@ -162,7 +340,6 @@ function updateLogs(forceRefresh = false) {
                     if (isPaused) return;
                     
                     const searchTerm = document.getElementById('log-search').value.toLowerCase();
-                    const gotoTerm = document.getElementById('goto-search').value.toLowerCase();
                     const logEntries = document.getElementById('log-entries');
                     let addedLogs = false;
                     
@@ -175,35 +352,30 @@ function updateLogs(forceRefresh = false) {
                         chunk.forEach(log => {
                             // Create unique ID for this log entry
                             const logId = `${log.timestamp}-${log.level}-${log.message}`;
-                            
+
                             // Skip if we've already rendered this exact log
                             if (renderedLogIds.has(logId)) {
                                 return; // Skip duplicate
                             }
-                            
+
                             // Mark this log as rendered
                             renderedLogIds.add(logId);
-                            
+
+                            // Track function name for chip filter
+                            const funcName = extractFuncName(log);
+                            registerFuncName(funcName);
+
                             // Create the log entry div
                             const div = createHighlightedLogEntry(log);
-                            
-                            // Apply filter - hide if doesn't match search term
+                            if (funcName) div.dataset.func = funcName;
+
+                            // Apply text search filter
                             const logText = `${log.timestamp} - ${log.level.toUpperCase()} - ${log.message}`.toLowerCase();
-                            if (searchTerm && !logText.includes(searchTerm)) {
+                            const chipOk = !funcName || !chipState.has(funcName) || chipState.get(funcName).enabled;
+                            if ((searchTerm && !logText.includes(searchTerm)) || !chipOk) {
                                 div.style.display = 'none';
                             }
-                            
-                            // If we're in search mode and this log matches the goto term
-                            if (isSearchActive && logText.includes(gotoTerm)) {
-                                currentMatches.push(div);
-                                // If this is a new match and we're at the end, highlight it
-                                if (currentMatchIndex === currentMatches.length - 2) {
-                                    navigateToMatch(currentMatches.length - 1);
-                                } else {
-                                    updateGotoNavButtons();
-                                }
-                            }
-                            
+
                             fragment.appendChild(div);
                             addedLogs = true;
                         });
@@ -214,21 +386,13 @@ function updateLogs(forceRefresh = false) {
                             // Remove old logs if we're over the limit
                             while (logEntries.children.length > MAX_LOGS) {
                                 logEntries.removeChild(logEntries.firstChild);
-                                // Update matches array if we removed a match
-                                if (currentMatches.length > 0 && currentMatches[0].parentNode !== logEntries) {
-                                    currentMatches.shift();
-                                    if (currentMatchIndex > 0) {
-                                        currentMatchIndex--;
-                                    }
-                                    updateGotoNavButtons();
-                                }
                             }
                         }
                     }
 
                     if (addedLogs) {
                         lastLogTimestamp = data.logs[data.logs.length - 1].timestamp;
-                        
+                        renderChips();
                         if (isScrolledToBottom) {
                             requestAnimationFrame(() => scrollToBottom(logEntries));
                         }
@@ -283,7 +447,7 @@ function updateLogs(forceRefresh = false) {
         };
 
         // Create new EventSource connection with current interval
-        window.logStream = new EventSource(`/logs/api/logs/stream?level=${encodeURIComponent(levelFilter)}&interval=${window.lastPerformanceMetrics.interval}`);
+        window.logStream = new EventSource(`/logs/api/logs/stream?level=${encodeURIComponent(levelFilter)}&lines=${linesVal}&interval=${window.lastPerformanceMetrics.interval}`);
         
         window.logStream.onopen = function() {
             console.log('Stream connected, waiting for first message...');
@@ -314,7 +478,7 @@ function reconnectStream(levelFilter, interval) {
     
     // Small delay to ensure old connection is fully closed
     setTimeout(() => {
-        window.logStream = new EventSource(`/logs/api/logs/stream?level=${encodeURIComponent(levelFilter)}&interval=${interval}`);
+        window.logStream = new EventSource(`/logs/api/logs/stream?level=${encodeURIComponent(levelFilter)}&lines=${currentLines}&interval=${interval}`);
         // Reattach event handlers from stored handlers
         window.logStream.onmessage = window.streamHandlers.onMessage;
         window.logStream.onerror = window.streamHandlers.onError;
@@ -323,23 +487,9 @@ function reconnectStream(levelFilter, interval) {
 }
 
 function filterLogs() {
-    // Apply filter client-side without restarting the stream
-    const searchTerm = document.getElementById('log-search').value.toLowerCase();
-    const logEntries = document.getElementById('log-entries');
-    const allEntries = logEntries.querySelectorAll('.log-entry');
-    
-    allEntries.forEach(entry => {
-        const logText = entry.textContent.toLowerCase();
-        if (!searchTerm || logText.includes(searchTerm)) {
-            entry.style.display = '';
-        } else {
-            entry.style.display = 'none';
-        }
-    });
-    
-    // Scroll to bottom if we were already there
+    applyChipFilter();
     if (isScrolledToBottom) {
-        scrollToBottom(logEntries);
+        scrollToBottom(document.getElementById('log-entries'));
     }
 }
 
@@ -348,11 +498,20 @@ function loadSavedLogLevel() {
     if (savedLevel) {
         document.getElementById('log-level-filter').value = savedLevel;
     }
+    const savedLines = localStorage.getItem('selectedLogLines');
+    if (savedLines) {
+        document.getElementById('log-lines-select').value = savedLines;
+    }
 }
 
 document.getElementById('log-level-filter').addEventListener('change', (event) => {
     localStorage.setItem('selectedLogLevel', event.target.value);
-    updateLogs(true);  // Force a refresh when the level changes
+    updateLogs(true);
+});
+
+document.getElementById('log-lines-select').addEventListener('change', (event) => {
+    localStorage.setItem('selectedLogLines', event.target.value);
+    updateLogs(true);
 });
 
 document.getElementById('log-entries').addEventListener('scroll', checkScrollPosition);
@@ -603,147 +762,6 @@ function createHighlightedLogEntry(log) {
 
     return div;
 }
-
-// Add goto search functionality
-function performGotoSearch() {
-    const searchTerm = document.getElementById('goto-search').value.toLowerCase();
-    const logEntries = document.getElementById('log-entries');
-    currentMatches = [];
-    currentMatchIndex = -1;
-    isSearchActive = !!searchTerm;  // Set search active if we have a search term
-
-    // Clear previous highlights
-    logEntries.querySelectorAll('.highlight-match').forEach(el => {
-        el.classList.remove('highlight-match');
-    });
-
-    if (!searchTerm) {
-        updateGotoNavButtons();
-        return;
-    }
-
-    // Find all matching log entries
-    Array.from(logEntries.children).forEach((entry, index) => {
-        if (entry.textContent.toLowerCase().includes(searchTerm)) {
-            currentMatches.push(entry);
-        }
-    });
-
-    updateGotoNavButtons();
-    if (currentMatches.length > 0) {
-        navigateToMatch(0);
-    }
-}
-
-function updateGotoNavButtons() {
-    const prevButton = document.getElementById('prev-match');
-    const nextButton = document.getElementById('next-match');
-    const matchCount = document.querySelector('.match-count');
-    
-    prevButton.disabled = currentMatches.length === 0 || currentMatchIndex <= 0;
-    nextButton.disabled = currentMatches.length === 0 || currentMatchIndex >= currentMatches.length - 1;
-    
-    if (currentMatches.length > 0) {
-        matchCount.textContent = `${currentMatchIndex + 1}/${currentMatches.length}`;
-    } else {
-        matchCount.textContent = '';
-    }
-}
-
-function navigateToMatch(index) {
-    if (index < 0 || index >= currentMatches.length) return;
-
-    // Remove previous highlight
-    document.querySelectorAll('.highlight-match').forEach(el => {
-        el.classList.remove('highlight-match');
-    });
-
-    const match = currentMatches[index];
-    match.classList.add('highlight-match');
-    currentMatchIndex = index;
-    
-    // Scroll the match into view
-    match.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    updateGotoNavButtons();
-}
-
-function navigateToFirstMatch() {
-    if (currentMatches && currentMatches.length > 0) {
-        currentMatchIndex = 0;
-        navigateToMatch(currentMatchIndex);
-        updateGotoNavButtons();
-    }
-}
-
-function navigateToLastMatch() {
-    if (currentMatches && currentMatches.length > 0) {
-        currentMatchIndex = currentMatches.length - 1;
-        navigateToMatch(currentMatchIndex);
-        updateGotoNavButtons();
-    }
-}
-
-// Add event listeners for goto search
-document.getElementById('goto-search').addEventListener('input', (e) => {
-    if (e.target.value) {
-        isPaused = true;
-        document.getElementById('pause-indicator').style.display = 'block';
-    } else {
-        isPaused = false;
-        document.getElementById('pause-indicator').style.display = 'none';
-    }
-});
-
-document.getElementById('goto-search').addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-        if (e.shiftKey) {
-            // Shift+Enter for previous
-            if (currentMatchIndex > 0) {
-                navigateToMatch(currentMatchIndex - 1);
-            }
-        } else {
-            // Enter for next
-            if (currentMatches.length === 0) {
-                performGotoSearch();
-            } else if (currentMatchIndex < currentMatches.length - 1) {
-                navigateToMatch(currentMatchIndex + 1);
-            }
-        }
-    }
-});
-
-document.getElementById('prev-match').addEventListener('click', () => {
-    if (currentMatchIndex > 0) {
-        navigateToMatch(currentMatchIndex - 1);
-    }
-});
-
-document.getElementById('next-match').addEventListener('click', () => {
-    if (currentMatches.length === 0) {
-        performGotoSearch();
-    } else if (currentMatchIndex < currentMatches.length - 1) {
-        navigateToMatch(currentMatchIndex + 1);
-    }
-});
-
-// Update the goto search event listener to perform searches as user types
-document.getElementById('goto-search').addEventListener('input', (e) => {
-    if (!e.target.value) {
-        isSearchActive = false;
-        currentMatches = [];
-        currentMatchIndex = -1;
-        document.querySelectorAll('.highlight-match').forEach(el => {
-            el.classList.remove('highlight-match');
-        });
-        updateGotoNavButtons();
-    } else {
-        // Debounce the search to avoid too many searches while typing
-        clearTimeout(window.searchTimeout);
-        window.searchTimeout = setTimeout(() => {
-            performGotoSearch();
-        }, 300);  // Wait 300ms after typing stops before searching
-    }
-});
 
 // Add function to scroll to bottom and resume logging
 function scrollToBottomAndResume() {

--- a/templates/settings_tabs/ui_settings_tangerine.html
+++ b/templates/settings_tabs/ui_settings_tangerine.html
@@ -217,9 +217,9 @@
         <!-- Auto Run Program -->
         <div class="settings-form-group">
             <label class="settings-title">
-                <input type="checkbox" id="auto-run-program" name="UI Settings.auto_run_program"
-                       data-section="UI Settings" data-key="auto_run_program"
-                       {% if settings.get('UI Settings', {}).get('auto_run_program', True) %}checked{% endif %}>
+                <input type="checkbox" id="auto-run-program" name="Debug.auto_run_program"
+                       data-section="Debug" data-key="auto_run_program"
+                       {% if settings.get('Debug', {}).get('auto_run_program', False) %}checked{% endif %}>
                 Auto Run Program
             </label>
             <p class="settings-description">When enabled, the program will automatically start running when the application starts</p>


### PR DESCRIPTION
fix: auto_run_program saves to Debug section in tangerine settings UI
fix: anime year lookup uses original_season when XEM remapping differs from scrape season
feat: log viewer chip filter groups filenames into 8 categories with hide/show all toggle
fix: log chips unstyled in tangerine theme - load tangerine_logs.css directly via inline script
fix: log chips appearance:none to override browser default button styles
fix: mobile log chip bar wraps instead of overflowing
fix: remove stale chipColorIndex leftover variable in logs.html
fix: merge duplicate .log-message CSS rules in logs.css