### PR TITLE
Add Torbox provider support and debrid path tracking

### DIFF
--- a/database/database_writing.py
+++ b/database/database_writing.py
@@ -181,7 +181,17 @@ def update_media_item_state(item_id, state, **kwargs):
         params = [state, datetime.now()]
 
         # Add optional fields to the query if they are provided
-        optional_fields = ['filled_by_title', 'filled_by_magnet', 'filled_by_file', 'filled_by_torrent_id', 'scrape_results', 'version', 'resolution', 'upgrading_from']
+        optional_fields = [
+            'filled_by_title',
+            'filled_by_magnet',
+            'filled_by_file',
+            'filled_by_torrent_id',
+            'scrape_results',
+            'version',
+            'resolution',
+            'upgrading_from',
+            'debrid_folder_name',
+        ]
         for field in optional_fields:
             if field in kwargs:
                 query += f", {field} = ?"

--- a/database/schema_management.py
+++ b/database/schema_management.py
@@ -232,6 +232,9 @@ def migrate_schema():
         if 'real_debrid_original_title' not in columns:
             conn.execute('ALTER TABLE media_items ADD COLUMN real_debrid_original_title TEXT')
             logging.info("Successfully added real_debrid_original_title column to media_items table.")
+        if 'debrid_folder_name' not in columns:
+            conn.execute('ALTER TABLE media_items ADD COLUMN debrid_folder_name TEXT')
+            logging.info("Successfully added debrid_folder_name column to media_items table.")
         if 'rescrape_original_torrent_title' not in columns:
             conn.execute('ALTER TABLE media_items ADD COLUMN rescrape_original_torrent_title TEXT')
             logging.info("Successfully added rescrape_original_torrent_title column to media_items table.")
@@ -876,6 +879,7 @@ def create_tables():
                 current_score REAL DEFAULT 0,
                 final_check_add_timestamp TIMESTAMP,
                 real_debrid_original_title TEXT,
+                debrid_folder_name TEXT,
                 rescrape_original_torrent_title TEXT,
                 force_priority BOOLEAN DEFAULT FALSE,
                 location_basename TEXT,

--- a/debrid/__init__.py
+++ b/debrid/__init__.py
@@ -4,6 +4,7 @@ from utilities.settings import get_setting, ensure_settings_file
 from .base import DebridProvider, TooManyDownloadsError, ProviderUnavailableError
 from .real_debrid import RealDebridProvider
 from .alldebrid import AllDebridProvider
+from .torbox import TorboxProvider
 from .common import (
     extract_hash_from_magnet,
     download_and_extract_hash,
@@ -38,6 +39,9 @@ def get_debrid_provider() -> DebridProvider:
     elif provider_name == 'alldebrid':
         logging.info("[DEBRID FACTORY] Instantiating AllDebridProvider")
         _provider_instance = AllDebridProvider()
+    elif provider_name == 'torbox':
+        logging.info("[DEBRID FACTORY] Instantiating TorboxProvider")
+        _provider_instance = TorboxProvider()
     else:
         raise ValueError(f"Unknown debrid provider: {provider_name}")
         
@@ -63,7 +67,7 @@ def get_provider_display_name() -> str:
     _name_map = {
         'realdebrid':  'Real-Debrid',
         'alldebrid':   'AllDebrid',
-        'torbox':      'TorBox',
+        'torbox':      'Torbox',
         'premiumize':  'Premiumize',
     }
     return _name_map.get(provider_name, provider_name.title() or 'Debrid')
@@ -78,6 +82,7 @@ __all__ = [
     'ProviderUnavailableError',
     'RealDebridProvider',
     'AllDebridProvider',
+    'TorboxProvider',
     'extract_hash_from_magnet',
     'download_and_extract_hash',
     'timed_lru_cache',

--- a/debrid/common/c7d9e45f.py
+++ b/debrid/common/c7d9e45f.py
@@ -31,6 +31,11 @@ _v = {
         'direct_cache': b'gAAAAABpWFBI5LpjoXHHD0M88gTWFJJWWF11I1WnE_R9QSKqdGH-SyKWb_T5GRqQdSRnsmckU2Tj34jDtXD_19qECoTcRaWI5A==',
         'bulk_cache': b'gAAAAABpWFBI-B0QZv1rn7ieePQt1aF2oEz82kz8xtXWFuTWotjEcgDNTi5SObW4gkTZC-Syosv-FpdZKcsfFp4uA6EJkfpBsQ==',
         'supports_uncached': b'gAAAAABpWFBICGPRNPbZGs_xgeF8eq78USs8nSgoZtkwbHN9lfQx-qI7Elm94EKrUFWoYNwu9x2dhNGZJ_PAu9T3FJds2QMHqg=='
+    },
+    'TorboxProvider': {
+        'direct_cache': b'gAAAAABp1nrtFaMtmAKXLZcEzkIZGAD5v7dckYhGzjfzOwaLS8OEjupwll-4kWTm1Fi2GpnZj-Pf6smZ1YEz3mVsd_6E7YS4NQ==',
+        'bulk_cache': b'gAAAAABp1nrtS2jcke2JzbNu5xhxikPpwq8TO65gJCAQhTc47WKOS4OsDD_6XL4Mmx4PPbMoPtRP3bupw439Pbz629xqhjIAEQ==',
+        'supports_uncached': b'gAAAAABp1nrtnsL7O_ZId4yOMeQxUiP3mHA_dTJUI4OIkJCKTKEYVCTv09HgIxAiICr9M-xFe0u61jOHMaloQFcNnuFYgvSv5w=='
     }
 }
 

--- a/debrid/generate_encrypted_values.py
+++ b/debrid/generate_encrypted_values.py
@@ -8,6 +8,11 @@ def generate_encrypted_values():
             'direct_cache': False, 
             'bulk_cache': False,
             'supports_uncached': True
+        },
+        'TorboxProvider': {
+            'direct_cache': True,
+            'bulk_cache': True,
+            'supports_uncached': True
         }
     }
     

--- a/debrid/torbox/__init__.py
+++ b/debrid/torbox/__init__.py
@@ -1,0 +1,3 @@
+from .client import TorboxProvider
+
+__all__ = ['TorboxProvider']

--- a/debrid/torbox/api.py
+++ b/debrid/torbox/api.py
@@ -1,0 +1,146 @@
+"""Torbox API client implementation."""
+
+import logging
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from ..base import ProviderUnavailableError, RateLimitError
+from .exceptions import TorboxAPIError, TorboxAuthError
+from utilities.settings import get_setting
+from routes.api_tracker import api
+
+
+_api_rate_limiter = {
+    'last_request_time': 0.0,
+    'min_interval': 0.25,
+    'lock': threading.Lock(),
+}
+
+
+def _wait_for_rate_limit() -> None:
+    with _api_rate_limiter['lock']:
+        current_time = time.time()
+        time_since_last = current_time - _api_rate_limiter['last_request_time']
+        min_interval = _api_rate_limiter['min_interval']
+        if time_since_last < min_interval:
+            time.sleep(min_interval - time_since_last)
+        _api_rate_limiter['last_request_time'] = time.time()
+
+
+def _decrease_rate_limit_on_success() -> None:
+    with _api_rate_limiter['lock']:
+        if _api_rate_limiter['min_interval'] > 0.25:
+            _api_rate_limiter['min_interval'] = max(0.25, _api_rate_limiter['min_interval'] * 0.95)
+
+
+def get_api_key() -> str:
+    api_key = get_setting('Debrid Provider', 'api_key')
+    if not api_key:
+        raise TorboxAuthError("No API key found in settings. Please configure in settings.")
+    return api_key
+
+
+def should_retry_error(exception: Exception) -> bool:
+    if isinstance(exception, api.exceptions.HTTPError):
+        return exception.response.status_code in [429, 500, 502, 503, 504]
+    return isinstance(exception, (api.exceptions.Timeout, api.exceptions.ConnectionError))
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type((api.exceptions.RequestException, TorboxAPIError, RateLimitError, api.exceptions.HTTPError)),
+    retry_error_callback=lambda retry_state: None,
+)
+def make_request(
+    method: str,
+    endpoint: str,
+    api_key: str,
+    data: Optional[Dict] = None,
+    files: Optional[Dict] = None,
+    json_data: Optional[Dict] = None,
+    **kwargs,
+) -> Any:
+    url = f"https://api.torbox.app/v1/api{endpoint}"
+    headers = kwargs.get('headers', {})
+    headers['Authorization'] = f'Bearer {api_key}'
+    kwargs['headers'] = headers
+
+    if 'timeout' not in kwargs:
+        kwargs['timeout'] = 30
+
+    _wait_for_rate_limit()
+
+    try:
+        if method.upper() == 'GET':
+            response = api.get(url, **kwargs)
+        elif method.upper() == 'POST':
+            response = api.post(url, data=data, files=files, json=json_data, **kwargs)
+        elif method.upper() == 'DELETE':
+            response = api.delete(url, **kwargs)
+        else:
+            raise ValueError(f"Unsupported HTTP method: {method}")
+
+        if response.status_code >= 400:
+            if response.status_code == 401:
+                raise TorboxAuthError("Invalid API key")
+            if response.status_code == 403:
+                raise TorboxAuthError("Access denied")
+            if response.status_code == 429:
+                retry_after = response.headers.get('Retry-After')
+                if retry_after:
+                    try:
+                        time.sleep(int(retry_after))
+                    except (TypeError, ValueError):
+                        pass
+                with _api_rate_limiter['lock']:
+                    _api_rate_limiter['min_interval'] = min(5.0, _api_rate_limiter['min_interval'] * 2)
+                raise RateLimitError("Torbox rate limit exceeded")
+            if response.status_code in [500, 502, 503, 504]:
+                raise TorboxAPIError(f"Torbox service temporarily unavailable (HTTP {response.status_code})")
+            response.raise_for_status()
+
+        if response.status_code == 204:
+            _decrease_rate_limit_on_success()
+            return {"success": True, "status_code": 204}
+
+        try:
+            result = response.json()
+        except ValueError:
+            _decrease_rate_limit_on_success()
+            return response.content
+
+        if isinstance(result, dict) and result.get('success') is False:
+            error_code = result.get('error') or 'UNKNOWN'
+            detail = result.get('detail') or 'Unknown error'
+            if error_code in {'BAD_TOKEN', 'AUTH_ERROR'}:
+                raise TorboxAuthError(detail)
+            raise TorboxAPIError(f"Torbox API error {error_code}: {detail}")
+
+        _decrease_rate_limit_on_success()
+        return result
+    except api.exceptions.Timeout:
+        raise ProviderUnavailableError("Torbox request timed out")
+    except api.exceptions.RequestException as e:
+        if should_retry_error(e):
+            raise TorboxAPIError(f"Temporary Torbox service error: {str(e)}")
+        raise ProviderUnavailableError(f"Torbox request failed: {str(e)}")
+
+
+def get_data_payload(result: Any) -> Any:
+    if isinstance(result, dict):
+        return result.get('data')
+    return result
+
+
+def get_all_torrents(api_key: str) -> List[Dict]:
+    result = make_request('GET', '/torrents/mylist', api_key, params={'bypass_cache': 'true'})
+    data = get_data_payload(result)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return [data]
+    return []

--- a/debrid/torbox/client.py
+++ b/debrid/torbox/client.py
@@ -1,0 +1,495 @@
+import asyncio
+import hashlib
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import bencodepy
+
+from ..base import DebridProvider, ProviderUnavailableError, TooManyDownloadsError, TorrentAdditionError
+from ..common import extract_hash_from_magnet, is_unwanted_file, is_video_file, timed_lru_cache
+from ..status import TorrentFetchStatus, TorrentInfoStatus, TorrentStatus
+from .api import get_all_torrents, get_api_key, get_data_payload, make_request
+from .exceptions import TorboxAPIError, TorboxAuthError
+from database.not_wanted_magnets import add_to_not_wanted
+from utilities.phalanx_db_cache_manager import PhalanxDBClassManager
+from utilities.settings import get_setting
+
+
+class TorboxProvider(DebridProvider):
+    """Torbox implementation of the DebridProvider interface."""
+
+    PROVIDER_NAME = "Torbox"
+    API_BASE_URL = "https://api.torbox.app/v1/api"
+    MAX_DOWNLOADS = 9999
+
+    def __init__(self):
+        super().__init__()
+        self._cached_torrent_ids = {}
+        self._cached_torrent_titles = {}
+        self._all_torrent_ids = {}
+        self.phalanx_enabled = get_setting('UI Settings', 'enable_phalanx_db', default=False)
+        self.phalanx_cache = PhalanxDBClassManager() if self.phalanx_enabled else None
+
+    def _load_api_key(self) -> str:
+        try:
+            return get_api_key()
+        except Exception as e:
+            logging.error(f"Failed to load Torbox API key: {str(e)}", exc_info=True)
+            raise ProviderUnavailableError(f"Failed to load API key: {str(e)}")
+
+    @property
+    def api_key(self) -> str:
+        return self._load_api_key()
+
+    def check_connectivity(self) -> Tuple[bool, Optional[Dict[str, Any]]]:
+        try:
+            make_request('GET', '/user/me', self.api_key)
+            return True, None
+        except TorboxAuthError as e:
+            return False, {"service": "Debrid Provider API", "type": "AUTH_ERROR", "status_code": None, "message": str(e)}
+        except (ProviderUnavailableError, TorboxAPIError) as e:
+            return False, {"service": "Debrid Provider API", "type": "CONNECTION_ERROR", "status_code": None, "message": str(e)}
+        except Exception as e:
+            return False, {"service": "Debrid Provider API", "type": "CONNECTION_ERROR", "status_code": None, "message": str(e)}
+
+    def _extract_hash(self, magnet_or_hash: Optional[str], temp_file_path: Optional[str] = None) -> Optional[str]:
+        hash_value = None
+        if temp_file_path:
+            try:
+                with open(temp_file_path, 'rb') as f:
+                    torrent_data = bencodepy.decode(f.read())
+                    info = torrent_data[b'info']
+                    hash_value = hashlib.sha1(bencodepy.encode(info)).hexdigest().lower()
+            except Exception as e:
+                logging.error(f"Could not extract hash from torrent file: {str(e)}")
+        elif magnet_or_hash:
+            if magnet_or_hash.startswith('magnet:'):
+                hash_value = extract_hash_from_magnet(magnet_or_hash)
+            elif len(magnet_or_hash) == 40 and all(c in '0123456789abcdefABCDEF' for c in magnet_or_hash):
+                hash_value = magnet_or_hash.lower()
+        return hash_value.lower() if hash_value else None
+
+    def _normalize_files(self, info: Dict[str, Any]) -> List[Dict[str, Any]]:
+        files = []
+        for file_info in info.get('files', []) or []:
+            name = file_info.get('name') or file_info.get('short_name') or ''
+            files.append({
+                'id': file_info.get('id'),
+                'path': name,
+                'name': os.path.basename(name) if name else '',
+                'bytes': file_info.get('size', 0),
+                'selected': True,
+            })
+        return files
+
+    def _map_status(self, info: Dict[str, Any]) -> TorrentStatus:
+        state = (info.get('download_state') or '').lower()
+        if state in {'cached', 'completed', 'downloaded'} or info.get('cached') or info.get('download_finished'):
+            return TorrentStatus.CACHED
+        if state in {'downloading', 'queued', 'meta_download', 'metadata', 'checking'} or info.get('active'):
+            return TorrentStatus.DOWNLOADING
+        if state in {'error', 'failed'}:
+            return TorrentStatus.ERROR
+        return TorrentStatus.UNKNOWN
+
+    def _normalize_torrent_info(self, info: Dict[str, Any]) -> Dict[str, Any]:
+        status = self._map_status(info)
+        progress_fraction = info.get('progress', 0) or 0
+        if progress_fraction <= 1:
+            progress = progress_fraction * 100
+        else:
+            progress = progress_fraction
+
+        normalized = dict(info)
+        normalized['id'] = str(info.get('id', ''))
+        normalized['hash'] = (info.get('hash') or '').lower()
+        normalized['filename'] = info.get('name', '')
+        normalized['debrid_folder_name'] = info.get('name', '') or info.get('download_path', '')
+        normalized['files'] = self._normalize_files(info)
+        normalized['bytes'] = info.get('size', 0)
+        normalized['progress'] = progress
+        if status == TorrentStatus.CACHED:
+            normalized['status'] = 'downloaded'
+        elif status == TorrentStatus.DOWNLOADING:
+            normalized['status'] = 'downloading'
+        elif status == TorrentStatus.ERROR:
+            normalized['status'] = 'error'
+        else:
+            normalized['status'] = (info.get('download_state') or 'unknown').lower()
+        return normalized
+
+    def _find_existing_torrent(self, hash_value: str) -> Optional[Dict[str, Any]]:
+        for torrent in get_all_torrents(self.api_key):
+            if (torrent.get('hash') or '').lower() == hash_value.lower():
+                return torrent
+        return None
+
+    async def is_cached(
+        self,
+        magnet_links: Union[str, List[str]],
+        temp_file_path: Optional[str] = None,
+        result_title: Optional[str] = None,
+        result_index: Optional[str] = None,
+        remove_uncached: bool = True,
+        remove_cached: bool = False,
+        skip_phalanx_db: bool = False,
+        imdb_id: Optional[str] = None
+    ) -> Union[bool, Dict[str, bool], None]:
+        if isinstance(magnet_links, str):
+            items = [magnet_links]
+            return_single = True
+        else:
+            items = magnet_links
+            return_single = False
+
+        hashes = []
+        results: Dict[str, Optional[bool]] = {}
+        phalanx_misses: List[str] = []
+
+        for magnet_link in items:
+            hash_value = self._extract_hash(magnet_link, temp_file_path=temp_file_path)
+            if not hash_value:
+                try:
+                    add_to_not_wanted(magnet_link)
+                except Exception:
+                    pass
+                results[magnet_link] = None
+                continue
+
+            if not skip_phalanx_db and self.phalanx_enabled and self.phalanx_cache:
+                try:
+                    phalanx_result = self.phalanx_cache.get_cache_status(hash_value)
+                    if phalanx_result is not None:
+                        results[hash_value] = bool(phalanx_result.get('is_cached'))
+                        continue
+                except Exception as e:
+                    logging.error(f"Error checking PhalanxDB cache for {hash_value}: {str(e)}")
+
+            hashes.append(hash_value)
+            phalanx_misses.append(hash_value)
+
+        if hashes:
+            try:
+                params = [('hash', hash_value) for hash_value in hashes]
+                response = make_request('GET', '/torrents/checkcached', self.api_key, params=params)
+                cached_payload = get_data_payload(response) or {}
+                for hash_value in hashes:
+                    is_hit = hash_value in cached_payload
+                    results[hash_value] = is_hit
+                    if self.phalanx_enabled and self.phalanx_cache:
+                        try:
+                            self.phalanx_cache.update_cache_status(hash_value, is_hit)
+                        except Exception as e:
+                            logging.error(f"Failed to update PhalanxDB for {hash_value}: {str(e)}")
+            except Exception as e:
+                logging.error(f"Error checking Torbox cache status: {str(e)}")
+                for hash_value in phalanx_misses:
+                    results[hash_value] = None
+
+        if return_single:
+            return next(iter(results.values())) if results else None
+        return results
+
+    def get_subscription_status(self) -> Dict[str, Any]:
+        try:
+            if get_setting("Debrid Provider", "api_key") == "demo_key":
+                return {'days_remaining': None, 'expiration': None, 'premium': False}
+
+            result = make_request('GET', '/user/me', self.api_key)
+            user_info = get_data_payload(result) or {}
+            expiration = user_info.get('premium_expires_at')
+            days_remaining = None
+            if expiration:
+                try:
+                    exp_dt = datetime.fromisoformat(expiration.replace('Z', '+00:00')).replace(tzinfo=None)
+                    days_remaining = max(0, (exp_dt - datetime.utcnow()).days)
+                except Exception as e:
+                    logging.warning(f"Failed parsing Torbox expiration '{expiration}': {e}")
+
+            return {
+                'days_remaining': days_remaining,
+                'expiration': expiration,
+                'premium': bool(user_info.get('is_subscribed')),
+                'username': user_info.get('email', '').split('@')[0],
+                'email': user_info.get('email', ''),
+                'points': 0,
+                'locale': '',
+                'type': f"plan_{user_info.get('plan')}" if user_info.get('plan') is not None else '',
+            }
+        except Exception as e:
+            logging.error(f"Error fetching Torbox subscription status: {str(e)}")
+            return {'days_remaining': None, 'expiration': None, 'premium': None, 'error': str(e)}
+
+    def add_torrent(self, magnet_link: Optional[str], temp_file_path: Optional[str] = None) -> Optional[str]:
+        try:
+            hash_value = self._extract_hash(magnet_link, temp_file_path=temp_file_path)
+            if hash_value:
+                existing = self._find_existing_torrent(hash_value)
+                if existing:
+                    torrent_id = str(existing.get('id', ''))
+                    self._all_torrent_ids[hash_value] = torrent_id
+                    self._cached_torrent_ids[hash_value] = torrent_id if existing.get('cached') or (existing.get('download_state') == 'cached') else self._cached_torrent_ids.get(hash_value)
+                    self._cached_torrent_titles[hash_value] = existing.get('name', '')
+                    return torrent_id
+
+            if temp_file_path:
+                with open(temp_file_path, 'rb') as f:
+                    files = {'file': (os.path.basename(temp_file_path), f)}
+                    result = make_request('POST', '/torrents/createtorrent', self.api_key, files=files)
+            elif magnet_link:
+                result = make_request('POST', '/torrents/createtorrent', self.api_key, data={'magnet': magnet_link})
+            else:
+                raise ValueError("Either magnet_link or temp_file_path must be provided")
+
+            payload = get_data_payload(result) or {}
+            torrent_id = payload.get('torrent_id') or payload.get('id')
+            if not torrent_id and hash_value:
+                existing = self._find_existing_torrent(hash_value)
+                torrent_id = existing.get('id') if existing else None
+
+            if not torrent_id:
+                raise TorrentAdditionError(f"Failed to add torrent - response: {result}")
+
+            torrent_id = str(torrent_id)
+
+            for _ in range(30):
+                info = self.get_torrent_info(torrent_id)
+                if info:
+                    if hash_value:
+                        self._all_torrent_ids[hash_value] = torrent_id
+                        self._cached_torrent_titles[hash_value] = info.get('filename', '')
+                        if info.get('status') == 'downloaded':
+                            self._cached_torrent_ids[hash_value] = torrent_id
+                    return torrent_id
+                time.sleep(1)
+
+            raise TorrentAdditionError("Timed out waiting for Torbox torrent to become available")
+        except Exception as e:
+            logging.error(f"Error adding torrent to Torbox: {str(e)}")
+            raise
+
+    @timed_lru_cache(seconds=1)
+    def get_active_downloads(self) -> Tuple[int, int]:
+        try:
+            if get_setting("Debrid Provider", "api_key") == "demo_key":
+                return 0, 0
+
+            torrents = get_all_torrents(self.api_key)
+            active_count = sum(1 for torrent in torrents if (torrent.get('download_state') or '').lower() not in {'cached', 'completed', 'downloaded'})
+            return active_count, max(active_count + 10, 10)
+        except TooManyDownloadsError:
+            raise
+        except Exception as e:
+            logging.error(f"Error getting Torbox active downloads: {str(e)}", exc_info=True)
+            raise ProviderUnavailableError(f"Failed to get active downloads: {str(e)}")
+
+    def get_user_traffic(self) -> Dict[str, Any]:
+        try:
+            if get_setting("Debrid Provider", "api_key") == "demo_key":
+                return {'downloaded': 0, 'limit': None}
+
+            result = make_request('GET', '/user/me', self.api_key)
+            user_info = get_data_payload(result) or {}
+            downloaded_gb = round((user_info.get('total_bytes_downloaded', 0) or 0) / (1024 ** 3), 2)
+            return {
+                'downloaded': downloaded_gb,
+                'limit': None,
+                'total_bytes_downloaded': user_info.get('total_bytes_downloaded', 0),
+            }
+        except Exception as e:
+            logging.error(f"Error getting Torbox traffic information: {str(e)}")
+            raise ProviderUnavailableError(f"Failed to get user traffic: {str(e)}")
+
+    def get_torrent_info(self, torrent_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            result = make_request('GET', '/torrents/mylist', self.api_key, params={'bypass_cache': 'true', 'id': torrent_id})
+            payload = get_data_payload(result)
+            if isinstance(payload, list):
+                if not payload:
+                    return None
+                info = payload[0]
+            elif isinstance(payload, dict):
+                info = payload
+            else:
+                return None
+
+            normalized = self._normalize_torrent_info(info)
+            hash_value = normalized.get('hash', '')
+            status = self._map_status(info)
+            self.update_status(torrent_id, status)
+
+            if hash_value:
+                self._all_torrent_ids[hash_value] = str(torrent_id)
+                if status == TorrentStatus.CACHED:
+                    self._cached_torrent_ids[hash_value] = str(torrent_id)
+                    self._cached_torrent_titles[hash_value] = normalized.get('filename', '')
+
+            return normalized
+        except Exception as e:
+            if "404" in str(e):
+                self.update_status(torrent_id, TorrentStatus.REMOVED)
+            else:
+                logging.error(f"Error getting Torbox torrent info: {str(e)}")
+                self.update_status(torrent_id, TorrentStatus.ERROR)
+            return None
+
+    def get_torrent_info_with_status(self, torrent_id: str) -> TorrentInfoStatus:
+        try:
+            info = self.get_torrent_info(torrent_id)
+            if info:
+                return TorrentInfoStatus(status=TorrentFetchStatus.OK, data=info, message=None, http_status_code=200)
+            return TorrentInfoStatus(status=TorrentFetchStatus.NOT_FOUND, data=None, message="Torrent not found", http_status_code=404)
+        except Exception as e:
+            return TorrentInfoStatus(status=TorrentFetchStatus.UNKNOWN_ERROR, data=None, message=str(e), http_status_code=None)
+
+    def get_cached_torrent_id(self, hash_value: str) -> Optional[str]:
+        return self._cached_torrent_ids.get(hash_value)
+
+    def get_cached_torrent_title(self, hash_value: str) -> Optional[str]:
+        return self._cached_torrent_titles.get(hash_value)
+
+    def list_active_torrents(self) -> List[Dict[str, Any]]:
+        try:
+            torrents = []
+            for torrent in get_all_torrents(self.api_key):
+                normalized = self._normalize_torrent_info(torrent)
+                torrents.append({
+                    'id': normalized.get('id', ''),
+                    'filename': normalized.get('filename', ''),
+                    'hash': normalized.get('hash', ''),
+                    'status': normalized.get('status', ''),
+                    'progress': normalized.get('progress', 0),
+                    'bytes': normalized.get('bytes', 0),
+                    'original_filename': normalized.get('filename', ''),
+                })
+            return torrents
+        except Exception as e:
+            logging.error(f"Error listing Torbox torrents: {str(e)}")
+            return []
+
+    def remove_torrent(self, torrent_id: str, removal_reason: Optional[str] = None) -> bool:
+        hash_value = None
+        try:
+            info = self.get_torrent_info(torrent_id)
+            if info:
+                hash_value = info.get('hash', '').lower()
+
+            make_request(
+                'POST',
+                '/torrents/controltorrent',
+                self.api_key,
+                json_data={'operation': 'delete', 'torrent_id': int(torrent_id)},
+            )
+
+            self.update_status(torrent_id, TorrentStatus.REMOVED)
+            if hash_value:
+                from database.torrent_tracking import mark_torrent_removed
+
+                mark_torrent_removed(hash_value, removal_reason or "Manual removal")
+                self._cached_torrent_ids.pop(hash_value, None)
+                self._cached_torrent_titles.pop(hash_value, None)
+                self._all_torrent_ids.pop(hash_value, None)
+            return True
+        except Exception as e:
+            logging.error(f"Error removing Torbox torrent {torrent_id}: {str(e)}", exc_info=True)
+            raise
+
+    def cleanup(self) -> None:
+        try:
+            self.verify_torrent_presence()
+        except Exception as e:
+            logging.error(f"Error during Torbox cleanup: {str(e)}")
+        finally:
+            super().cleanup()
+
+    def verify_torrent_presence(self, hash_value: str = None) -> bool:
+        try:
+            active_hashes = {
+                (torrent.get('hash') or '').lower(): str(torrent.get('id'))
+                for torrent in get_all_torrents(self.api_key)
+                if torrent.get('hash')
+            }
+            from database.torrent_tracking import mark_torrent_removed
+
+            if hash_value:
+                if hash_value.lower() not in active_hashes:
+                    mark_torrent_removed(hash_value, "Torrent no longer exists in Torbox")
+                    return False
+                return True
+
+            success = True
+            for tracked_hash in list(self._cached_torrent_ids.keys()):
+                if tracked_hash.lower() not in active_hashes:
+                    mark_torrent_removed(tracked_hash, "Torrent no longer exists in Torbox")
+                    success = False
+            return success
+        except Exception as e:
+            logging.error(f"Error verifying Torbox torrent presence: {str(e)}")
+            return False
+
+    def get_torrent_file_list(self, magnet_link: str) -> Optional[Tuple[List[Dict], str, str]]:
+        torrent_id = None
+        info = None
+        try:
+            torrent_id = self.add_torrent(magnet_link)
+            if not torrent_id:
+                return None
+
+            time.sleep(3)
+            info = self.get_torrent_info(torrent_id)
+            if not info:
+                return None
+
+            files = info.get('files', [])
+            if isinstance(files, dict):
+                files = list(files.values())
+            elif not isinstance(files, list):
+                files = []
+            return files, info.get('filename', 'Unknown Filename'), torrent_id
+        except Exception as e:
+            logging.error(f"An unexpected error occurred during Torbox torrent file listing: {str(e)}")
+            return None
+        finally:
+            if torrent_id:
+                try:
+                    self.remove_torrent(torrent_id, "Temporary add for file listing")
+                except Exception as e:
+                    logging.error(f"Error removing temporary Torbox torrent {torrent_id}: {str(e)}")
+                    self.update_status(torrent_id, TorrentStatus.UNKNOWN)
+
+    def is_cached_sync(
+        self,
+        magnet_link: str,
+        temp_file_path: Optional[str] = None,
+        result_title: Optional[str] = None,
+        result_index: Optional[str] = None,
+        remove_uncached: bool = True,
+        remove_cached: bool = False,
+        skip_phalanx_db: bool = False,
+        imdb_id: Optional[str] = None
+    ) -> Union[bool, Dict[str, bool], None]:
+        try:
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+            return loop.run_until_complete(
+                self.is_cached(
+                    magnet_link,
+                    temp_file_path,
+                    result_title,
+                    result_index,
+                    remove_uncached,
+                    remove_cached,
+                    skip_phalanx_db,
+                    imdb_id
+                )
+            )
+        except Exception as e:
+            logging.error(f"Error in Torbox is_cached_sync: {str(e)}")
+            return None

--- a/debrid/torbox/exceptions.py
+++ b/debrid/torbox/exceptions.py
@@ -1,0 +1,15 @@
+"""Torbox-specific exceptions."""
+
+from ..base import DebridProviderError
+
+
+class TorboxError(DebridProviderError):
+    """Base exception for Torbox errors."""
+
+
+class TorboxAPIError(TorboxError):
+    """Raised when the Torbox API returns an error."""
+
+
+class TorboxAuthError(TorboxError):
+    """Raised when Torbox authentication fails."""

--- a/queues/adding_queue.py
+++ b/queues/adding_queue.py
@@ -477,6 +477,7 @@ class AddingQueue:
                     continue
 
                 matched_file_basename = match_result[0] # Now contains basename
+                debrid_folder_name = torrent_info.get('debrid_folder_name') or torrent_title
                 logging.info(f"Best matching file (basename) for {item_identifier}: {matched_file_basename}")
 
 
@@ -488,7 +489,8 @@ class AddingQueue:
                     title=torrent_title, # This title has now been effectively filtered
                     link=magnet,
                     filled_by_file=matched_file_basename, 
-                    torrent_id=torrent_info.get('id')
+                    torrent_id=torrent_info.get('id'),
+                    debrid_folder_name=debrid_folder_name,
                 )
                 processed_this_item = True # Mark primary item as processed for delay logic
 
@@ -533,7 +535,8 @@ class AddingQueue:
                                 title=torrent_title,
                                 link=magnet,
                                 filled_by_file=related_file_basename, # Pass the basename
-                                torrent_id=torrent_info.get('id')
+                                torrent_id=torrent_info.get('id'),
+                                debrid_folder_name=debrid_folder_name,
                             )
                             # move_to_checking handles removal from original queue (Scraping/Wanted)
 

--- a/queues/queue_manager.py
+++ b/queues/queue_manager.py
@@ -658,7 +658,16 @@ class QueueManager:
         except Exception as e:
             logging.error(f"Failed to send Adding state change notification: {str(e)}")
 
-    def move_to_checking(self, item: Dict[str, Any], from_queue: str, title: str, link: str, filled_by_file: str, torrent_id: str = None):
+    def move_to_checking(
+        self,
+        item: Dict[str, Any],
+        from_queue: str,
+        title: str,
+        link: str,
+        filled_by_file: str,
+        torrent_id: str = None,
+        debrid_folder_name: str = None,
+    ):
         item_identifier = self.generate_identifier(item)
 
         # GHOSTLIST CHECK: Prevent ghostlisted/blacklisted items from being moved to Checking
@@ -721,7 +730,8 @@ class QueueManager:
             filled_by_title=title,
             filled_by_magnet=link,
             filled_by_file=filled_by_file,
-            filled_by_torrent_id=torrent_id
+            filled_by_torrent_id=torrent_id,
+            debrid_folder_name=debrid_folder_name,
         )
         
         # Copy downloading flag from original item

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -4005,7 +4005,7 @@ class ProgramRunner:
         conn = get_db_connection()
         cursor = conn.cursor()
         try:
-            items = cursor.execute('SELECT id, title, filled_by_title, filled_by_file, type, imdb_id, tmdb_id, season_number, episode_number, year, version, original_scraped_torrent_title, real_debrid_original_title, last_updated, upgrading_from, upgrading_from_torrent_id FROM media_items WHERE state = "Checking" AND (ghostlisted IS NULL OR ghostlisted = 0)').fetchall()
+            items = cursor.execute('SELECT id, title, filled_by_title, filled_by_file, type, imdb_id, tmdb_id, season_number, episode_number, year, version, original_scraped_torrent_title, real_debrid_original_title, debrid_folder_name, last_updated, upgrading_from, upgrading_from_torrent_id FROM media_items WHERE state = "Checking" AND (ghostlisted IS NULL OR ghostlisted = 0)').fetchall()
         except sqlite3.Error as db_err:
             logging.error(f"Database error fetching items for Plex check: {db_err}")
             conn.close()
@@ -4085,6 +4085,7 @@ class ProgramRunner:
                 # --- START: Ensure new field is fetched ---
                 original_scraped_torrent_title = item_dict['original_scraped_torrent_title'] or ''
                 real_debrid_original_title = item_dict['real_debrid_original_title'] or ''
+                debrid_folder_name = item_dict['debrid_folder_name'] or ''
                 # --- END: Ensure new field is fetched ---
 
                 if not filled_by_title or not filled_by_file: # This check might need re-evaluation if filled_by_title can be empty but other titles exist
@@ -4099,6 +4100,10 @@ class ProgramRunner:
                 # --- Construct potential paths in order of priority ---
                 paths_to_check = []
                 base_path = plex_file_location # Base path to check within
+
+                # 0. Exact provider folder name
+                if debrid_folder_name:
+                    paths_to_check.append(os.path.join(base_path, debrid_folder_name, current_filename))
 
                 # 1. Original Scraped Torrent Title (raw)
                 if original_scraped_torrent_title:
@@ -4335,6 +4340,7 @@ class ProgramRunner:
                 # --- START: Ensure new field is fetched ---
                 original_scraped_torrent_title = item_dict['original_scraped_torrent_title'] or ''
                 real_debrid_original_title = item_dict['real_debrid_original_title'] or ''
+                debrid_folder_name = item_dict['debrid_folder_name'] or ''
                 # --- END: Ensure new field is fetched ---
 
                 if not filled_by_title or not current_filename: 
@@ -4346,6 +4352,11 @@ class ProgramRunner:
                 # --- START: UNIFIED FILE SEARCH LOGIC (consistent with disabled checks mode) ---
                 paths_to_check_info = [] # Stores dicts: {'name': folder_name, 'path': full_path, 'type': log_type}
                 base_path = plex_file_location
+
+                # 0. Exact provider folder name
+                if debrid_folder_name:
+                    path = os.path.join(base_path, debrid_folder_name, current_filename)
+                    paths_to_check_info.append({'name': debrid_folder_name, 'path': path, 'type': 'debrid_folder_name'})
 
                 # 1. Original Scraped Torrent Title (raw)
                 if original_scraped_torrent_title:
@@ -7633,4 +7644,3 @@ def run_program():
 
 if __name__ == "__main__":
     run_program()
-

--- a/routes/api_tracker.py
+++ b/routes/api_tracker.py
@@ -148,7 +148,7 @@ class APITracker:
         self.current_url = None
         self._args = None
         self.rate_limiter = APIRateLimiter()
-        self.monitored_domains = {'api.real-debrid.com', 'api.alldebrid.com', 'api.trakt.tv', 'torrentio.strem.fun'}
+        self.monitored_domains = {'api.real-debrid.com', 'api.alldebrid.com', 'api.torbox.app', 'api.trakt.tv', 'torrentio.strem.fun'}
 
     @property
     def args(self):

--- a/routes/scraper_routes.py
+++ b/routes/scraper_routes.py
@@ -520,6 +520,7 @@ def add_torrent_to_debrid():
                 filled_by_file = os.path.basename(largest_file['path'])
                 # Get the torrent title from torrent_info's filename
                 filled_by_title = torrent_info.get('filename', '') or os.path.basename(os.path.dirname(largest_file['path']))
+                debrid_folder_name = torrent_info.get('debrid_folder_name') or filled_by_title
 
                 # Extract resolution from torrent title
                 resolution = extract_resolution_from_filename(original_scraped_torrent_title) if original_scraped_torrent_title else None
@@ -547,6 +548,7 @@ def add_torrent_to_debrid():
                     'genres': json.dumps(genres),  # JSON encode the genres list
                     'current_score': current_score,
                     'real_debrid_original_title': torrent_info.get('original_filename'),
+                    'debrid_folder_name': debrid_folder_name,
                     'content_source': 'content_requester',
                     'content_source_detail': current_user.username if (is_user_system_enabled() and current_user.is_authenticated) else 'CD-Discover',
                     'selected_folder': selected_folder,  # User-selected folder from dropdown
@@ -634,7 +636,35 @@ def add_torrent_to_debrid():
                                 
                                 if match_result:
                                     matching_filepath_basename, _ = match_result # Unpack the tuple
+
+                                    # Resolve the exact matched torrent file so we can persist the
+                                    # provider's real folder/file names for deterministic local lookup.
+                                    matched_file_dict = next(
+                                        (
+                                            file_dict for file_dict in torrent_files
+                                            if os.path.basename(file_dict.get('path', '')) == matching_filepath_basename
+                                        ),
+                                        None
+                                    )
+
                                     episode_item['filled_by_file'] = matching_filepath_basename # Use the basename
+
+                                    if matched_file_dict:
+                                        matched_path = matched_file_dict.get('path', '')
+                                        matched_folder_name = os.path.basename(os.path.dirname(matched_path))
+                                        if matched_folder_name:
+                                            episode_item['filled_by_title'] = matched_folder_name
+                                            episode_item['debrid_folder_name'] = matched_folder_name
+                                        logging.info(
+                                            f"Season pack exact match for {title} S{season_number}E{episode_num}: "
+                                            f"folder='{episode_item.get('debrid_folder_name')}', "
+                                            f"file='{episode_item.get('filled_by_file')}'"
+                                        )
+                                    else:
+                                        logging.warning(
+                                            f"Matched basename '{matching_filepath_basename}' for {title} "
+                                            f"S{season_number}E{episode_num} but could not resolve original torrent path."
+                                        )
                                     
                                     # Add episode to database
                                     from database import add_media_item
@@ -696,6 +726,7 @@ def add_torrent_to_debrid():
                                         filled_by_title = ?,
                                         filled_by_file = ?,
                                         original_scraped_torrent_title = ?,
+                                        debrid_folder_name = ?,
                                         current_score = ?,
                                         ghostlisted = 0,
                                         blacklisted_date = NULL,
@@ -704,6 +735,7 @@ def add_torrent_to_debrid():
                                        WHERE id = ?''',
                                     (actual_magnet_to_add, torrent_id, item.get('filled_by_title'),
                                      item.get('filled_by_file'), original_scraped_torrent_title,
+                                     item.get('debrid_folder_name'),
                                      current_score, _dt.now(), existing_id)
                                 )
                                 _conn.commit()

--- a/routes/settings_validation_routes.py
+++ b/routes/settings_validation_routes.py
@@ -140,6 +140,33 @@ def validate_debrid_api_key(api_key, provider="RealDebrid"):
         except requests.exceptions.RequestException as e:
             return False, f"Error validating AllDebrid API key: {str(e)}"
 
+    elif provider == "Torbox":
+        try:
+            response = requests.get(
+                "https://api.torbox.app/v1/api/user/me",
+                headers={'Authorization': f'Bearer {api_key}'},
+                timeout=10
+            )
+
+            if response.status_code == 200:
+                try:
+                    data = response.json()
+                    if data.get('success') is True:
+                        return True, "Torbox API key is valid"
+                    return False, "Invalid Torbox API response"
+                except ValueError:
+                    return False, "Invalid Torbox API response format"
+            elif response.status_code == 401:
+                return False, "Invalid Torbox API key"
+            elif response.status_code == 403:
+                return False, "Access denied - please check your Torbox API key"
+            else:
+                return False, f"Torbox API error (HTTP {response.status_code})"
+        except requests.exceptions.Timeout:
+            return False, "Timeout while validating Torbox API key"
+        except requests.exceptions.RequestException as e:
+            return False, f"Error validating Torbox API key: {str(e)}"
+
     return False, f"Unsupported debrid provider: {provider}"
 
 def validate_trakt_credentials(client_id, client_secret):

--- a/templates/debrid_manager.html
+++ b/templates/debrid_manager.html
@@ -2423,6 +2423,8 @@ function _bkFmtSize(bytes) {
     return (bytes/1048576).toFixed(1) + ' MB';
 }
 
+const providerLabel = (pfx) => ({ rd: 'Real-Debrid', ad: 'AllDebrid', tb: 'Torbox' }[pfx] || pfx.toUpperCase());
+
 function _bkRenderActivity(status) {
     const el = document.getElementById('bk-activity');
     if (!el) return;
@@ -2431,12 +2433,11 @@ function _bkRenderActivity(status) {
     const lastCleanup = status.last_cleanup ? _bkFmtTs(status.last_cleanup) : 'Never';
     const providers   = status.providers || {};
     const cs          = (status.cleanup_stats || {}).last || null;
-
     // ── Backup section ──
     let backupSection = '';
     if (Object.keys(providers).length) {
         for (const [pfx, slots] of Object.entries(providers)) {
-            const label = pfx === 'rd' ? 'Real-Debrid' : 'AllDebrid';
+            const label = providerLabel(pfx);
             backupSection += `<div class="dm-bk-activity-provider">${label} Backup</div>`;
             for (const [slot, info] of Object.entries(slots)) {
                 const ts    = info.timestamp ? _bkFmtTs(info.timestamp) : '—';
@@ -2459,7 +2460,7 @@ function _bkRenderActivity(status) {
     // ── Cleanup section ──
     let cleanupSection = `<div class="dm-backup-activity-divider"></div>`;
     if (cs) {
-        const pfxLabel = cs.provider === 'rd' ? 'Real-Debrid' : 'AllDebrid';
+        const pfxLabel = providerLabel(cs.provider);
         const total    = cs.total ?? 0;
         const errs     = cs.deleted_errors  ?? 0;
         const dupes    = cs.deleted_dupes   ?? 0;
@@ -2505,7 +2506,7 @@ function _bkRenderSlots(status) {
 
     let html = '';
     for (const [pfx, slots] of Object.entries(providers)) {
-        const label = pfx === 'rd' ? 'Real-Debrid' : 'AllDebrid';
+        const label = providerLabel(pfx);
         html += `<div class="dm-bk-provider-label">${label}</div>`;
         for (const [slot, info] of Object.entries(slots)) {
             if (!info.exists) continue;
@@ -3553,7 +3554,7 @@ function _rcRenderUntracked(items) {
         <td style="text-align:center">${plexBadge}</td>
         <td class="dm-col-actions">
             <button class="dm-btn dm-btn-danger dm-btn-sm dm-rc-del-btn"
-                data-tid="${escHtml(item.filled_by_torrent_id)}" title="Delete from RD">Delete from RD</button>
+                data-tid="${escHtml(item.filled_by_torrent_id)}" title="Delete from debrid provider">Delete from Debrid</button>
         </td>
     </tr>`;
     }).join('');

--- a/templates/onboarding_step_2.html
+++ b/templates/onboarding_step_2.html
@@ -165,6 +165,7 @@
         <select id="debrid_provider" name="debrid_provider" required class="onboarding-input">
             <option value="RealDebrid" {% if settings.get('Debrid Provider', {}).get('provider', '') == 'RealDebrid' %}selected{% endif %}>RealDebrid</option>
             <option value="AllDebrid" {% if settings.get('Debrid Provider', {}).get('provider', '') == 'AllDebrid' %}selected{% endif %}>AllDebrid</option>
+            <option value="Torbox" {% if settings.get('Debrid Provider', {}).get('provider', '') == 'Torbox' %}selected{% endif %}>Torbox</option>
         </select>
 
         <label for="debrid_api_key" class="onboarding-label">Debrid API Key:</label>
@@ -827,6 +828,8 @@ document.addEventListener('DOMContentLoaded', function() {
             formData.set('realdebrid_api_key', apiKey);
         } else if (provider === 'AllDebrid') {
             formData.set('alldebrid_api_key', apiKey);
+        } else if (provider === 'Torbox') {
+            formData.set('torbox_api_key', apiKey);
         }
         
         try {
@@ -967,6 +970,5 @@ function checkTraktAuthStatus() {
 
 {% include 'onboarding_navigation.html' with context %}
 {% endblock %}
-
 
 

--- a/templates/settings_tabs/scraping.html
+++ b/templates/settings_tabs/scraping.html
@@ -796,7 +796,7 @@
                         {% if key == 'enable_upgrading' %}
                             <p class="settings-description">Enable upgrading of items in the queue.</p>
                         {% elif key == 'enable_upgrading_cleanup' %}
-                            <p class="settings-description">Enable cleanup of original items after successful upgrade (removes original item from Plex and Real-Debrid).</p>
+                            <p class="settings-description">Enable cleanup of original items after successful upgrade (removes original item from Plex and the configured debrid provider).</p>
                         {% elif key == 'require_physical_release' %}
                             <p class="settings-description">Only mark as Wanted after physical release date is available.</p>
                         {% elif key == 'enable_spanish_episode_parsing' %}

--- a/templates/settings_tabs/scraping_tangerine.html
+++ b/templates/settings_tabs/scraping_tangerine.html
@@ -927,7 +927,7 @@ document.addEventListener('scrapingContentLoaded', function() {
                         {% if key == 'enable_upgrading' %}
                             <p class="settings-description">Enable upgrading of items in the queue.</p>
                         {% elif key == 'enable_upgrading_cleanup' %}
-                            <p class="settings-description">Enable cleanup of original items after successful upgrade (removes original item from Plex and Real-Debrid).</p>
+                            <p class="settings-description">Enable cleanup of original items after successful upgrade (removes original item from Plex and the configured debrid provider).</p>
                         {% elif key == 'require_physical_release' %}
                             <p class="settings-description">Only mark as Wanted after physical release date is available.</p>
                         {% elif key == 'enable_spanish_episode_parsing' %}

--- a/utilities/debrid_backup.py
+++ b/utilities/debrid_backup.py
@@ -1,6 +1,6 @@
 """
 Debrid Backup Utility
-Handles backup and restore of Real-Debrid and AllDebrid torrent libraries.
+Handles backup and restore of Real-Debrid, AllDebrid, and Torbox torrent libraries.
 
 Backup strategy (rd.py-inspired):
   - Up to 3 rotating slots: 1d, 3d, 7d (user-configurable retention intervals)
@@ -143,6 +143,30 @@ def fetch_ad_magnets(api_key: str) -> List[dict]:
         return []
 
 
+def fetch_tb_torrents(api_key: str) -> List[dict]:
+    """Fetch all Torbox torrents."""
+    import requests
+    try:
+        r = requests.get(
+            'https://api.torbox.app/v1/api/torrents/mylist',
+            headers={'Authorization': f'Bearer {api_key}'},
+            params={'bypass_cache': 'true'},
+            timeout=30,
+        )
+        if r.status_code != 200:
+            logging.error(f'{_LOG_TAG} Torbox /torrents/mylist returned {r.status_code}')
+            return []
+        data = r.json().get('data', [])
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return [data]
+        return []
+    except Exception as e:
+        logging.error(f'{_LOG_TAG} Torbox fetch error: {e}')
+        return []
+
+
 # ---------------------------------------------------------------------------
 # Core backup logic
 # ---------------------------------------------------------------------------
@@ -186,6 +210,9 @@ def run_backup(force: bool = False) -> dict:
     elif 'AllDebrid' in provider_name or pname == 'AllDebrid':
         prefix = 'ad'
         torrents = fetch_ad_magnets(provider.api_key)
+    elif 'Torbox' in provider_name or pname == 'Torbox':
+        prefix = 'tb'
+        torrents = fetch_tb_torrents(provider.api_key)
     else:
         return {'success': False, 'message': f'Unsupported provider: {pname}'}
 
@@ -280,7 +307,7 @@ def get_backup_status() -> dict:
         'providers':    {},
     }
 
-    for prefix in ('rd', 'ad'):
+    for prefix in ('rd', 'ad', 'tb'):
         slots = {}
         for s in ('1d', '3d', '7d'):
             info = slot_info(prefix, s)
@@ -447,6 +474,53 @@ def restore_from_file(filename: str, dry_run: bool = False) -> dict:
             'failures': failed,
         }
 
+    elif 'Torbox' in provider_name or pname == 'Torbox':
+        current = fetch_tb_torrents(provider.api_key)
+        current_hashes = {t.get('hash', '').lower() for t in current if t.get('hash')}
+
+        import requests
+        added = []
+        skipped = []
+        failed = []
+
+        headers = {'Authorization': f'Bearer {provider.api_key}'}
+        for item in backup:
+            item_hash = (item.get('hash') or '').lower()
+            if not item_hash:
+                failed.append({'hash': '?', 'reason': 'no hash'})
+                continue
+            if item_hash in current_hashes:
+                skipped.append(item_hash)
+                continue
+            if dry_run:
+                added.append(item_hash)
+                continue
+            try:
+                magnet = f'magnet:?xt=urn:btih:{item_hash}'
+                r = requests.post(
+                    'https://api.torbox.app/v1/api/torrents/createtorrent',
+                    headers=headers,
+                    data={'magnet': magnet},
+                    timeout=30,
+                )
+                resp = r.json()
+                if not resp.get('success'):
+                    failed.append({'hash': item_hash, 'reason': resp.get('detail') or resp.get('error') or 'unknown error'})
+                    continue
+                added.append(item_hash)
+                time.sleep(0.2)
+            except Exception as e:
+                failed.append({'hash': item_hash, 'reason': str(e)})
+
+        return {
+            'success': True,
+            'total':   len(backup),
+            'added':   len(added),
+            'skipped': len(skipped),
+            'failed':  len(failed),
+            'failures': failed,
+        }
+
     else:
         return {'success': False, 'message': f'Restore not implemented for {provider_name}'}
 
@@ -530,6 +604,8 @@ def run_cleanup(force: bool = False) -> dict:
         return _cleanup_rd(provider.api_key, settings)
     elif 'AllDebrid' in provider_name:
         return _cleanup_ad(provider.api_key, settings)
+    elif 'Torbox' in provider_name:
+        return _cleanup_tb(provider.api_key, settings)
     else:
         return {'success': False, 'message': f'Unsupported provider: {provider_name}'}
 
@@ -743,6 +819,113 @@ def _cleanup_ad(api_key: str, settings: dict) -> dict:
         'deleted_stalled':  len(deleted_stalled),
         'total_deleted':    total,
         'message':          f'Cleanup complete: {total} magnets removed',
+    }
+
+
+def _cleanup_tb(api_key: str, settings: dict) -> dict:
+    """Torbox cleanup implementation."""
+    import requests
+
+    delete_errors = settings.get('cleanup_delete_errors', True)
+    delete_dupes = settings.get('cleanup_delete_dupes', True)
+    delete_stalled = settings.get('cleanup_delete_stalled', False)
+    stalled_days = settings.get('cleanup_stalled_days', 3)
+    stalled_cutoff = stalled_days * 86400
+
+    torrents = fetch_tb_torrents(api_key)
+    now = time.time()
+    headers = {'Authorization': f'Bearer {api_key}'}
+
+    def _tb_delete(torrent_id, reason: str):
+        try:
+            r = requests.post(
+                'https://api.torbox.app/v1/api/torrents/controltorrent',
+                headers=headers,
+                json={'operation': 'delete', 'torrent_id': int(torrent_id)},
+                timeout=15,
+            )
+            logging.info(f'{_LOG_TAG} Deleted Torbox torrent {torrent_id} ({reason}) — {r.status_code}')
+            time.sleep(0.1)
+            return r.status_code == 200
+        except Exception as e:
+            logging.warning(f'{_LOG_TAG} Failed to delete Torbox torrent {torrent_id}: {e}')
+            return False
+
+    deleted_errors = []
+    deleted_dupes = []
+    deleted_stalled = []
+
+    surviving = []
+    for torrent in torrents:
+        status = (torrent.get('download_state') or '').lower()
+        if delete_errors and status in {'error', 'failed'}:
+            if _tb_delete(torrent.get('id'), 'error status'):
+                deleted_errors.append(torrent.get('id'))
+            continue
+        surviving.append(torrent)
+
+    if delete_stalled:
+        still_surviving = []
+        for torrent in surviving:
+            created_at = torrent.get('created_at')
+            created_ts = 0
+            if created_at:
+                try:
+                    created_ts = time.mktime(time.strptime(created_at, '%Y-%m-%dT%H:%M:%SZ'))
+                except Exception:
+                    created_ts = 0
+            progress = torrent.get('progress', 0) or 0
+            if progress <= 0 and created_ts and (now - created_ts) > stalled_cutoff:
+                if _tb_delete(torrent.get('id'), f'stalled {stalled_days}d'):
+                    deleted_stalled.append(torrent.get('id'))
+                continue
+            still_surviving.append(torrent)
+        surviving = still_surviving
+
+    if delete_dupes:
+        by_hash: dict = {}
+        for torrent in surviving:
+            h = (torrent.get('hash') or '').lower()
+            if not h:
+                continue
+            by_hash.setdefault(h, []).append(torrent)
+        for _, copies in by_hash.items():
+            if len(copies) < 2:
+                continue
+            copies.sort(
+                key=lambda c: (
+                    1 if c.get('cached') or (c.get('download_state') == 'cached') else 0,
+                    c.get('progress', 0) or 0,
+                    int(c.get('id') or 0),
+                ),
+                reverse=True,
+            )
+            for torrent in copies[1:]:
+                if _tb_delete(torrent.get('id'), 'duplicate'):
+                    deleted_dupes.append(torrent.get('id'))
+
+    total = len(deleted_errors) + len(deleted_dupes) + len(deleted_stalled)
+
+    log = _read_log()
+    log['last_cleanup'] = now
+    log.setdefault('cleanup_stats', {})['last'] = {
+        'timestamp': now,
+        'deleted_errors': len(deleted_errors),
+        'deleted_dupes': len(deleted_dupes),
+        'deleted_stalled': len(deleted_stalled),
+        'total': total,
+        'provider': 'tb',
+    }
+    _write_log(log)
+
+    return {
+        'success': True,
+        'provider': 'tb',
+        'deleted_errors': len(deleted_errors),
+        'deleted_dupes': len(deleted_dupes),
+        'deleted_stalled': len(deleted_stalled),
+        'total_deleted': total,
+        'message': f'Cleanup complete: {total} torrents removed',
     }
 
 

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1093,13 +1093,25 @@ def check_local_file_for_item(item: Dict[str, Any], is_webhook: bool = False, ex
             filled_by_title = item.get('filled_by_title', '')
             original_torrent_title = item.get('original_scraped_torrent_title', '')
             real_debrid_original_title = item.get('real_debrid_original_title', '')
+            debrid_folder_name = item.get('debrid_folder_name', '')
             current_filename = item['filled_by_file'] # The actual file we are looking for
 
             found_file = False
             source_file = None # Initialize source_file
             source_folder = None # Track the folder where the file was found
 
-            # --- Check Order: Original Torrent Title -> Filled By Title ---
+            # --- Check Order: Exact provider folder -> Original Torrent Title -> Filled By Title ---
+
+            # 0. Check exact provider folder name persisted from the debrid API.
+            if debrid_folder_name:
+                potential_folder = os.path.join(original_path, debrid_folder_name)
+                potential_path = os.path.join(potential_folder, current_filename)
+                logging.debug(f"Attempt 0: Checking path using debrid_folder_name: {potential_path}")
+                if os.path.exists(potential_path):
+                    source_file = potential_path
+                    source_folder = potential_folder
+                    found_file = True
+                    logging.info(f"Found file using debrid_folder_name: {source_file}")
 
             # 1. Check original_scraped_torrent_title (raw)
             if original_torrent_title:
@@ -2214,6 +2226,7 @@ def _find_source_file_in_base(item: Dict[str, Any], base_search_path: str, filen
     logging.debug(f"[_find_source_file_in_base] Searching for '{filename_only}' under '{base_search_path}' for item ID {item.get('id')}")
 
     possible_folder_names = [
+        item.get('debrid_folder_name', ''),
         item.get('original_scraped_torrent_title', ''),
         item.get('real_debrid_original_title', ''),
         item.get('filled_by_title', ''),

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -275,7 +275,7 @@ SETTINGS_SCHEMA = {
             "type": "string",
             "description": "Debrid service provider",
             "default": "RealDebrid",
-            "choices": ["RealDebrid", "AllDebrid"]
+            "choices": ["RealDebrid", "AllDebrid", "Torbox"]
         },
         "api_key": {
             "type": "string",


### PR DESCRIPTION
## Summary
- add Torbox provider support across debrid factory, validation, backup/cleanup, and onboarding/settings flows
- persist provider folder names for deterministic local file lookup
- fix regressions in checking path resolution, backup UI provider labels, and Torbox duplicate cleanup ordering

## Verification
- python3 -m py_compile database/database_writing.py database/schema_management.py debrid/__init__.py debrid/common/c7d9e45f.py debrid/generate_encrypted_values.py debrid/torbox/api.py debrid/torbox/client.py queues/adding_queue.py queues/queue_manager.py queues/run_program.py routes/api_tracker.py routes/scraper_routes.py routes/settings_validation_routes.py utilities/debrid_backup.py utilities/local_library_scan.py utilities/settings_schema.py
