### PR TITLE
Fixes and Improvements

### DIFF
--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -503,7 +503,23 @@ def _resolve_tvdb_id_via_tmdb(imdb_id: str, tmdb_api_key: str) -> Optional[int]:
 
 
 def _get_trakt_status(imdb_id: str) -> Optional[str]:
-    """Lightweight Trakt status check — fetches only show summary, returns status string or None."""
+    """Lightweight Trakt status check — fetches only show summary, returns status string or None.
+
+    Skips immediately if the GlobalTraktCoordinator reports an active cooldown —
+    avoids blocking the caller (e.g. a web request) for the full cooldown period.
+    """
+    try:
+        from utilities.trakt_coordinator import GlobalTraktCoordinator
+        cooldown = GlobalTraktCoordinator.get_instance().get_cooldown_status()
+        if cooldown.get('active'):
+            logger.debug(
+                f"TVDB: skipping Trakt status cross-check for {imdb_id} "
+                f"— Trakt cooldown active ({cooldown.get('remaining_seconds', 0):.0f}s remaining)"
+            )
+            return None
+    except Exception:
+        pass
+
     try:
         from . import trakt_client
         from .trakt_client import TRAKT_BASE_URL, _make_request as trakt_request

--- a/database/manual_blacklist.py
+++ b/database/manual_blacklist.py
@@ -123,7 +123,7 @@ def get_manual_blacklist() -> Dict[str, Dict[str, str]]:
     try:
         with open(BLACKLIST_FILE, 'r') as f:
             blacklist = json.load(f)
-            # Sanitize data: ensure all titles and years are strings
+            # Sanitize data: ensure all titles and years are strings, seasons is a list
             for imdb_id, item in blacklist.items():
                 if 'title' in item and not isinstance(item['title'], str):
                     item['title'] = str(item['title']) if item['title'] is not None else 'Unknown'
@@ -131,6 +131,8 @@ def get_manual_blacklist() -> Dict[str, Dict[str, str]]:
                 if 'year' in item and not isinstance(item['year'], str):
                     item['year'] = str(item['year']) if item['year'] is not None else ''
                     logging.warning(f"Converted non-string year to string for IMDb ID {imdb_id}: {item['year']}")
+                if 'seasons' not in item:
+                    item['seasons'] = []
             return blacklist
     except FileNotFoundError:
         return {}

--- a/database/zilean_upgrade.py
+++ b/database/zilean_upgrade.py
@@ -587,7 +587,7 @@ def _make_current_result(filename: str, title: str, size_bytes: float = 0,
 
     Key design decisions:
       - `title` is set to the CLEAN query title (e.g. "Star Wars: The Rise of Skywalker"),
-        NOT the raw filename.  rank_result_key runs a regex check for /episode|season|s\d{2}/
+        NOT the raw filename.  rank_result_key runs a regex check for /episode|season|s\\d{2}/
         on the result title to detect wrong content-type and applies a -500 penalty.
         Filenames like "Star.Wars.Episode.IX..." or "Handmaids.Tale.S03..." would
         incorrectly trigger that penalty if the filename were used as the title.
@@ -1129,6 +1129,7 @@ def _scan_episode(item: Dict, zilean_instance: str, zilean_settings: Dict,
     candidate_scored = [
         (s, r) for s, r in candidate_scored
         if (r.get('parsed_info') or {}).get('episodes')
+        and episode in (r.get('parsed_info') or {}).get('episodes', [])
     ]
     if not candidate_scored:
         return None

--- a/help_content/overlays_builder.md
+++ b/help_content/overlays_builder.md
@@ -24,13 +24,15 @@ The builder is divided into three panels:
 
 This is where you pick badge types to add to the canvas. Each type adds a badge with sensible defaults that you can then customize in the right panel.
 
-*   **Tray** — A background panel behind a group of badges. Use this as a semi-transparent strip or box at the bottom (or anywhere) of the poster to give badges a unified background. Trays support solid or gradient fills, borders, and rounded corners. Add a tray first, then position badges on top of it for a polished look.
+*   **Tray** — A background panel that sits behind a group of badges. Use it as a semi-transparent strip or box — typically at the bottom of the poster — to give badges a unified visual foundation. Trays support solid or gradient fills, optional borders, border radius, and opacity. Add a tray first, then position badges on top of it. A tray has no text or icon of its own — it is purely a background element. Configured via the **Tray Properties** panel when selected.
 
-*   **Text Badges** — Dynamic text rendered directly onto the poster. The text value comes from a template variable (e.g., `{{imdbRating}}`, `{{resolution}}`, `{{audioChannels}}`). Fully customizable: font, size, weight, color, background, optional icon/logo. Use these for ratings, codec names, resolution labels, year, network, studio, and more.
+*   **Text Badges** — The most versatile badge type. Renders text directly onto the poster, driven by a `{{variable}}` template (e.g., `{{imdbRating}}`, `{{resolution}}`, `{{audioChannels}}`). Supports a background box, an optional icon/logo to the left or right of the text, full font control (family, size, weight, color, alignment), and optional vertical stacking for two-line labels. Presets are available for every common data type (ratings, resolution, HDR, audio, video codec, network, studio, content rating, show status, versions) plus a free-form Custom type for any combination of text and variables. Use Text Badges when you want precise control over appearance or need to display data that Smart Badges do not cover. Configured via the **Badge Properties** panel when selected.
 
-*   **Smart Badges / Library Badges** — PNG image badges auto-selected at render time based on the item's metadata. Instead of drawing text, the system looks up the matching PNG file from your Badge Library (e.g., `audio-truehd-atmos.png` for a TrueHD Atmos track). The badge category (audio codec, video codec, etc.) and the item's actual metadata determine which image is shown. Requires badge assets to be uploaded in the Badge Library.
+*   **Smart Badges / Library Badges** — Image-based badges auto-selected at render time from your Badge Library. Instead of rendering text, the system looks up the matching PNG file based on the item's metadata (e.g., it selects `audio-truehd-atmos.png` for a TrueHD Atmos track). You control the badge's size and position in the layout; the correct image is chosen automatically. Requires PNG assets to be uploaded in the Badge Library. If no matching asset exists for a given item, the badge is silently skipped — no error, no empty space. Configured via the **Smart Badge Properties** panel when selected (size, position, badge category).
 
-*   **Designed Badges** — SVG vector badges served from the badge library. These scale without quality loss and are selected the same way as Smart Badges (by metadata match). Designed badges are vector alternatives to PNG smart badges.
+*   **Designed Badges** — SVG vector equivalents of Smart Badges. Selected the same way (by metadata match from the Badge Library), but use vector SVG files which scale perfectly at any size. Use Designed Badges when you have SVG assets and want crisp rendering at all poster dimensions. Configured via the same properties panel as Smart Badges.
+
+*   **Title Logo** — A special badge that renders the movie or TV show title onto the poster. When **Enable Textless / Clean Posters** is on and a textless (language-neutral) poster is found, the title is rendered using a clearlogo PNG from TMDB — a transparent logo image in the style of the title's official branding. If no clearlogo exists, falls back to rendering the title text using the configured font. The Title Logo is the main reason to use textless posters: it lets you place the title at any position with any styling, instead of relying on the baked-in title from the standard poster. Configured via the **Title Logo Properties** panel when selected (position mode, anchor point, size, font fallback settings).
 
 **Layout Badges List:**
 
@@ -140,6 +142,7 @@ Visible when any badge (text, smart, or designed) is selected.
     *   **Media Info:** Resolution, HDR Format, Audio Codec, Audio Channels, Video Codec, Format/Source
     *   **Library:** Network, Studio, Content Rating, Show Status, Versions/Duplicates
     *   **Custom:** A freeform text/template expression of your own design
+    *   **File Match:** A conditional badge that only renders when the video filename contains a specified search term — see below for details
     *   Changing the type applies that type's default style preset. Your position is preserved but visual properties reset to defaults for the new type.
 
 *   **Background:** (toggle-able)
@@ -203,6 +206,26 @@ Opens from the **?** button in the canvas toolbar. Lists every available `{{vari
 7.  Use the **Preview Data** section to test different metadata combinations and confirm all badges look correct.
 8.  Click **Save**.
 9.  Return to the Overlay Management page, select the new layout in the Movies or TV Shows tab, and click **Generate Selected** on a few items to test before running **Generate Library**.
+
+---
+
+**File Match Badge:**
+
+The **File Match** badge type renders only when the video filename contains a specified search term. This is useful for flagging attributes that aren't available as standard metadata — such as extended cuts, director's cuts, specific encode groups, or any keyword present in the filename.
+
+*   **File Match section** (visible only when badge type is set to File Match):
+    *   **Search Term:** The text to look for in the filename. The match is case-insensitive — `REMUX`, `remux`, and `Remux` all match the same files.
+    *   **Display Text:** The text shown on the badge when a match is found. Leave empty to display the search term itself.
+    *   **Use icon instead of text:** When enabled, the badge shows the icon configured in the Icon/Logo section instead of any text. Use this to show a logo rather than a label.
+
+*   **Styling:** All other badge properties work exactly as with any other badge type — configure the Background, Icon, and Text/Value sections to control how the badge looks when it appears.
+
+*   **Preview:** The canvas always shows the badge (using the display text or search term as a placeholder) so you can design its appearance regardless of whether a match exists. At render time, if the filename does not contain the search term, the badge is completely hidden.
+
+*   **Example uses:**
+    *   Search term `EXTENDED` — badge appears only on extended cut files
+    *   Search term `REMUX`, display text `REMUX` — styled badge visible only on remux files
+    *   Search term `x265` — badge visible only on x265 encodes, useful when the video codec badge doesn't distinguish x264 vs x265 source clearly
 
 ---
 

--- a/overlays/overlay_manager.py
+++ b/overlays/overlay_manager.py
@@ -152,13 +152,20 @@ class OverlayManager:
 
             # Pre-fetch best-quality data once so the skip check and later
             # _build_media_info_from_db both reuse it without a second DB query.
+            # Movies: scope to ms_item_id so split Plex items (unique ratingKey each)
+            # only aggregate quality across their own DB rows, not all versions of the
+            # same movie. This ensures each split item gets its own correct overlay.
             _item_type = item.get('type')
             _imdb_id   = item.get('imdb_id') or ''
+            _ms_id     = item.get('ms_item_id') or ''
             _best_data: Optional[Dict[str, Any]] = None
             if _item_type == 'episode' and _imdb_id:
                 _best_data = self._best_version(_imdb_id, 'episode')
-            elif _item_type == 'movie' and _imdb_id:
-                _best_data = self._best_version(_imdb_id, 'movie')
+            elif _item_type == 'movie':
+                if _ms_id:
+                    _best_data = self._best_version_by_ms_id(_ms_id, 'movie')
+                elif _imdb_id:
+                    _best_data = self._best_version(_imdb_id, 'movie')
 
             # Check if already processed (unless force=True).
             # Re-apply if: quality improved OR layout was updated since last apply.
@@ -719,6 +726,53 @@ class OverlayManager:
             self.logger.warning(f"Best-version query failed for imdb_id={imdb_id} type={item_type}: {e}")
         return None
 
+    def _best_version_by_ms_id(self, ms_item_id: str, item_type: str) -> Optional[Dict[str, Any]]:
+        """
+        Like _best_version but scoped to rows sharing the same ms_item_id rather
+        than the same imdb_id. Used for movies so that Plex split items (each with
+        a unique ratingKey / ms_item_id) only aggregate quality data across their
+        own DB rows, not across all versions of the same movie.
+        """
+        if not ms_item_id or item_type not in ('episode', 'movie'):
+            return None
+        try:
+            conn = _get_db_connection()
+            cursor = conn.cursor()
+            cursor.execute(f'''
+                SELECT ms_resolution, ms_hdr, ms_dolby_vision, ms_hdr_format,
+                       ms_audio_codec, ms_audio_channels,
+                       ms_video_codec, ms_media_container, ms_media_bitrate,
+                       filled_by_file, location_on_disk, location_basename
+                FROM media_items
+                WHERE ms_item_id = ?
+                  AND type = ?
+                  AND state IN ('Collected', 'Upgrading')
+                  AND ms_resolution IS NOT NULL
+                ORDER BY
+                    ({self._RES_RANK}) DESC,
+                    ({self._HDR_RANK}) DESC,
+                    ({self._AUD_RANK}) DESC,
+                    CAST(COALESCE(ms_audio_channels, '0') AS REAL) DESC
+            ''', (ms_item_id, item_type))
+            rows = cursor.fetchall()
+            conn.close()
+            if not rows:
+                return None
+            merged = dict(rows[0])
+            missing = [f for f in self._FILLABLE if not merged.get(f)]
+            if missing:
+                for row in rows[1:]:
+                    for field in list(missing):
+                        if row[field]:
+                            merged[field] = row[field]
+                            missing.remove(field)
+                    if not missing:
+                        break
+            return merged
+        except Exception as e:
+            self.logger.warning(f"Best-version-by-ms-id query failed for ms_item_id={ms_item_id}: {e}")
+        return None
+
     def _best_episode_data_for_show(self, imdb_id: str) -> Optional[Dict[str, Any]]:
         """Compatibility wrapper — delegates to _best_version."""
         return self._best_version(imdb_id, 'episode')
@@ -756,7 +810,16 @@ class OverlayManager:
         elif item_type == 'episode':
             best = self._best_version(item.get('imdb_id') or '', 'episode')
         elif item_type == 'movie':
-            best = self._best_version(item.get('imdb_id') or '', 'movie')
+            # For split Plex items (each with a unique ms_item_id), only aggregate
+            # quality data across DB rows that share the same ms_item_id (i.e. the
+            # same Plex item / truly merged). If this item has a unique ms_item_id,
+            # _best_version will only find one row and return its own data.
+            # Fall back to imdb_id scope if ms_item_id is not set.
+            _ms_id = item.get('ms_item_id')
+            if _ms_id:
+                best = self._best_version_by_ms_id(_ms_id, 'movie')
+            else:
+                best = self._best_version(item.get('imdb_id') or '', 'movie')
         else:
             best = None
 
@@ -839,10 +902,21 @@ class OverlayManager:
                     ")",
                     (imdb_id,))
             elif imdb_id:
-                _vc_cur.execute(
-                    "SELECT COUNT(*) FROM media_items "
-                    "WHERE imdb_id = ? AND type = 'movie' AND state IN ('Collected', 'Upgrading')",
-                    (imdb_id,))
+                # For movies, scope by ms_item_id so split Plex items (unique ratingKey
+                # per version) each show their own count rather than all versions of the
+                # same movie being counted together. Falls back to imdb_id count when
+                # ms_item_id is not set.
+                _ms_id = item.get('ms_item_id')
+                if _ms_id:
+                    _vc_cur.execute(
+                        "SELECT COUNT(*) FROM media_items "
+                        "WHERE ms_item_id = ? AND type = 'movie' AND state IN ('Collected', 'Upgrading')",
+                        (_ms_id,))
+                else:
+                    _vc_cur.execute(
+                        "SELECT COUNT(*) FROM media_items "
+                        "WHERE imdb_id = ? AND type = 'movie' AND state IN ('Collected', 'Upgrading')",
+                        (imdb_id,))
             else:
                 _vc_cur = None
             version_count = int(_vc_cur.fetchone()[0]) if _vc_cur else 1
@@ -1316,6 +1390,12 @@ class OverlayManager:
         filename), and imdb/tmdb/trakt ratings (from MDBList API).
         Called on both the Plex-metadata path and the DB-fallback path.
         """
+        # ── Carry file path fields into info so renderers (e.g. file_match badge)
+        # can access them directly from media_info without needing the item dict.
+        for _fp_field in ('filled_by_file', 'location_on_disk', 'location_basename'):
+            if not info.get(_fp_field) and item.get(_fp_field):
+                info[_fp_field] = item[_fp_field]
+
         # ── Release format + HDR from filename ───────────────────────────
         file_path = (item.get('filled_by_file') or item.get('location_on_disk')
                      or item.get('location_basename') or '').strip()
@@ -1486,10 +1566,19 @@ class OverlayManager:
                             ")",
                             (imdb_id,))
                 elif imdb_id:
-                    cur.execute(
-                        "SELECT COUNT(*) FROM media_items "
-                        "WHERE imdb_id = ? AND type = 'movie' AND state IN ('Collected', 'Upgrading')",
-                        (imdb_id,))
+                    # For movies, scope by ms_item_id so split Plex items each show
+                    # their own count. Falls back to imdb_id when ms_item_id not set.
+                    _ms_id = item.get('ms_item_id')
+                    if _ms_id:
+                        cur.execute(
+                            "SELECT COUNT(*) FROM media_items "
+                            "WHERE ms_item_id = ? AND type = 'movie' AND state IN ('Collected', 'Upgrading')",
+                            (_ms_id,))
+                    else:
+                        cur.execute(
+                            "SELECT COUNT(*) FROM media_items "
+                            "WHERE imdb_id = ? AND type = 'movie' AND state IN ('Collected', 'Upgrading')",
+                            (imdb_id,))
                 else:
                     cur = None
                 if cur:
@@ -1585,9 +1674,19 @@ class OverlayManager:
                     # ms_* fields), then overlay file-path fields from best DB
                     # version so format (filled_by_file) uses the ranked version.
                     # Reuse _best_data if already fetched by the caller.
+                    # Movies: scope to ms_item_id so split Plex items each use only
+                    # their own DB rows for file-path fields (filled_by_file etc).
                     enrich_item = dict(item)
                     imdb_id = item.get('imdb_id') or ''
-                    best_db = _best_data if _best_data is not None else (self._best_version(imdb_id, 'movie') if imdb_id else None)
+                    _mv_ms_id = item.get('ms_item_id') or ''
+                    if _best_data is not None:
+                        best_db = _best_data
+                    elif _mv_ms_id:
+                        best_db = self._best_version_by_ms_id(_mv_ms_id, 'movie')
+                    elif imdb_id:
+                        best_db = self._best_version(imdb_id, 'movie')
+                    else:
+                        best_db = None
                     if best_db:
                         for _f in ('filled_by_file', 'location_on_disk',
                                    'location_basename'):
@@ -1858,8 +1957,18 @@ class OverlayManager:
                 resp = _requests.get(tmdb_img_url, timeout=15)
                 resp.raise_for_status()
                 img = _Image.open(BytesIO(resp.content))
-                # Attach textless flag so generate_overlay_for_item can pass it to media_info
-                img._cli_textless = _is_textless_poster if '_is_textless_poster' in dir() else False
+                # Attach textless flag so generate_overlay_for_item can pass it to media_info.
+                # When served from cache, _is_textless_poster was set during the API call that
+                # populated the cache. Re-derive it: if the cached URL was stored under the
+                # textless cache key AND textless mode is on, treat it as textless.
+                if '_is_textless_poster' in dir():
+                    img._cli_textless = _is_textless_poster
+                elif _textless_pre and cached_url:
+                    # Cache hit in textless mode — the cached URL was chosen as the best
+                    # textless (null-language) poster when it was first stored. Treat as textless.
+                    img._cli_textless = True
+                else:
+                    img._cli_textless = False
                 self.logger.info(
                     f"Using TMDB poster for {item.get('title', plex_rating_key)} ({tmdb_img_url})")
                 return img

--- a/overlays/plex_client.py
+++ b/overlays/plex_client.py
@@ -705,6 +705,15 @@ class PlexClient:
                             elif gid.startswith('tmdb://'):
                                 tmdb_id = gid[7:]
 
+                        # Extract file paths from Media[].Part[].file so the sync
+                        # can match split Plex items to DB rows by location_on_disk.
+                        file_paths = []
+                        for media in item.get('Media', []):
+                            for part in media.get('Part', []):
+                                fp = part.get('file')
+                                if fp:
+                                    file_paths.append(fp)
+
                         results.append({
                             'ratingKey': rk,
                             'title': item.get('title', ''),
@@ -712,6 +721,7 @@ class PlexClient:
                             'imdb_id': imdb_id,
                             'tmdb_id': tmdb_id,
                             'grandparentRatingKey': str(item.get('grandparentRatingKey', '')) or None,
+                            'file_paths': file_paths,
                         })
 
                     fetched = container_start + len(items)

--- a/overlays/renderer.py
+++ b/overlays/renderer.py
@@ -208,6 +208,8 @@ class OverlayRenderer:
                         img = self._render_designed_badge(img, badge, media_info)
                     elif btype == 'title_logo':
                         img = self._render_title_logo(img, badge, media_info, width, height)
+                    elif btype == 'file_match':
+                        img = self._render_file_match_badge(img, badge, media_info, width, height)
                     else:
                         img = self.render_badge(img, badge, media_info, width, height)
                 except Exception as e:
@@ -913,6 +915,53 @@ class OverlayRenderer:
         except Exception as e:
             self.logger.error(f"Badge condition eval error '{condition}': {e}")
             return False
+
+    def _render_file_match_badge(self, base_img, badge, media_info, poster_width, poster_height):
+        """
+        Render a file_match badge — only displays when the item's filename contains
+        the user-specified search term (case-insensitive substring match).
+
+        If matched:
+          - useIcon=True  → render with icon only (text disabled)
+          - useIcon=False → render with displayText (or searchTerm if displayText is empty)
+        If not matched: returns base_img unchanged.
+        """
+        fm = badge.get('filenameMatch') or {}
+        search_term = (fm.get('searchTerm') or '').strip()
+        if not search_term:
+            return base_img  # no search term configured — skip
+
+        # Check filename: try filled_by_file, then location_on_disk, then location_basename
+        filename = (
+            media_info.get('filled_by_file') or
+            media_info.get('location_on_disk') or
+            media_info.get('location_basename') or
+            ''
+        )
+        if search_term.lower() not in filename.lower():
+            self.logger.debug(f"File match badge: '{search_term}' not found in '{filename}' — skipping")
+            return base_img
+
+        self.logger.debug(f"File match badge: '{search_term}' matched in '{filename}'")
+
+        use_icon = bool(fm.get('useIcon', False))
+        display_text = (fm.get('displayText') or '').strip() or search_term
+
+        # Build a modified badge copy for rendering via the standard render_badge path
+        import copy
+        render_badge = copy.deepcopy(badge)
+
+        if use_icon:
+            # Show icon only — disable text
+            render_badge['text']['enabled'] = False
+            render_badge['icon']['enabled'] = True
+        else:
+            # Show text — inject the resolved display text as a literal value
+            render_badge['text']['enabled'] = True
+            render_badge['text']['value'] = display_text
+            render_badge['text']['fallback'] = ''
+
+        return self.render_badge(base_img, render_badge, media_info, poster_width, poster_height)
 
     # Rating variable names that can be reformatted
     _RATING_VARS = frozenset({'imdbRating', 'tmdbRating', 'traktRating', 'rtCriticsScore', 'rtUserScore'})

--- a/overlays/scheduled_tasks.py
+++ b/overlays/scheduled_tasks.py
@@ -46,93 +46,178 @@ def _sync_library_keys_for_new_items(plex_url: str, plex_token: str) -> Dict[str
     """
     Auto-populate ms_item_id for Collected items that don't have one yet.
 
-    Runs a targeted Plex key match for any item in state='Collected' that is
-    missing a ms_item_id. This avoids requiring a manual "Sync Plex Library"
-    button press every time a new item is added.
+    DB-first approach: fetch only the rows that are missing ms_item_id, build
+    in-memory lookup dicts from a single Plex API call, resolve each missing row
+    in O(1), then write only the matched rows. This avoids iterating the entire
+    Plex library (4000+ items) for every row — previously caused 16+ minute
+    sync times when only 14 rows needed updating.
+
+    Also detects ms_item_id changes (e.g. after Plex split-apart) and resets
+    overlay state to pending so overlays are regenerated with the new key.
 
     Returns a dict with counts: {'movies': N, 'episodes': N, 'errors': N}
     """
     conn = _get_db_connection()
     cursor = conn.cursor()
 
-    # Fast check — if nothing is missing a key, skip entirely
+    # Fetch rows needing a key update — two categories:
+    # 1. Missing: ms_item_id is NULL/empty → first-time assignment
+    # 2. Candidates for split-detection: have ms_item_id AND location_on_disk
+    #    → Plex may have assigned a new ratingKey after split-apart
+    # Both are fetched upfront; the Plex lookup dicts resolve both in O(1).
     cursor.execute('''
-        SELECT COUNT(*) FROM media_items
+        SELECT id, type, imdb_id, tmdb_id, title, year, location_on_disk, ms_item_id
+        FROM media_items
         WHERE state IN ('Collected', 'Upgrading')
-          AND (ms_item_id IS NULL OR ms_item_id = '')
     ''')
-    missing_count = cursor.fetchone()[0]
+    all_rows = cursor.fetchall()
     conn.close()
 
-    if not missing_count:
+    missing_rows   = [dict(r) for r in all_rows if not (r['ms_item_id'] or '').strip()]
+    split_rows     = [dict(r) for r in all_rows
+                      if (r['ms_item_id'] or '').strip() and (r['location_on_disk'] or '').strip()]
+
+    missing_count = len(missing_rows)
+    split_candidate_count = len(split_rows)
+
+    if not missing_count and not split_candidate_count:
         return {'movies': 0, 'episodes': 0, 'errors': 0}
 
-    logger.info(f"Auto ms-key sync: {missing_count} Collected item(s) missing ms_item_id")
+    logger.info(
+        f"Auto ms-key sync: {missing_count} missing ms_item_id, "
+        f"{split_candidate_count} candidate(s) for split-apart detection"
+    )
 
     counts = {'movies': 0, 'episodes': 0, 'errors': 0}
+
+    # Group by type for separate Plex API calls
+    def _by_type(rows):
+        d = {'movie': [], 'episode': []}
+        for r in rows:
+            if r['type'] in d:
+                d[r['type']].append(r)
+        return d
+
+    missing_by_type = _by_type(missing_rows)
+    split_by_type   = _by_type(split_rows)
 
     try:
         from .plex_client import PlexClient
         client = PlexClient(plex_url, plex_token)
 
-        # Unified loop: plex_type=1 → movies, plex_type=2 → TV shows (episodes in DB)
-        for plex_type, db_type, count_key in (
-            (1, 'movie',   'movies'),
-            (2, 'episode', 'episodes'),
+        for db_type, count_key, plex_type in (
+            ('movie',   'movies',   1),
+            ('episode', 'episodes', 2),
         ):
+            rows_missing = missing_by_type[db_type]
+            rows_split   = split_by_type[db_type]
+
+            if not rows_missing and not rows_split:
+                continue
+
             try:
+                # Single Plex API call — build in-memory lookup dicts
                 plex_items = client.get_all_items_with_guids(plex_type=plex_type)
-                conn = _get_db_connection()
-                cursor = conn.cursor()
+
+                file_map:  dict = {}   # location_on_disk → ratingKey
+                imdb_map:  dict = {}   # imdb_id          → ratingKey
+                tmdb_map:  dict = {}   # tmdb_id (str)    → ratingKey
+                title_map: dict = {}   # (title_lower, year_str) → ratingKey
+
                 for pi in plex_items:
                     rk = pi.get('ratingKey')
-                    imdb_id = pi.get('imdb_id')
-                    tmdb_id = pi.get('tmdb_id')
                     if not rk:
                         continue
-                    updated = False
-                    if imdb_id:
-                        cursor.execute('''
-                            UPDATE media_items
-                            SET ms_item_id = ?
-                            WHERE type = ?
-                              AND imdb_id = ?
-                              AND state IN ('Collected', 'Upgrading')
-                              AND (ms_item_id IS NULL OR ms_item_id = ''
-                                   OR LENGTH(ms_item_id) >= 20)
-                        ''', (rk, db_type, imdb_id))
+                    for fp in (pi.get('file_paths') or []):
+                        if fp:
+                            file_map[fp] = rk
+                    if pi.get('imdb_id'):
+                        imdb_map[pi['imdb_id']] = rk
+                    if pi.get('tmdb_id'):
+                        tmdb_map[str(pi['tmdb_id'])] = rk
+                    if pi.get('title') and pi.get('year'):
+                        title_map[(pi['title'].lower(), str(pi['year']))] = rk
+
+                # resolved: list of (db_id, new_rk, old_rk)
+                resolved = []
+
+                # Pass 1: rows missing ms_item_id entirely
+                for row in rows_missing:
+                    db_id   = row['id']
+                    old_rk  = ''
+                    loc     = row['location_on_disk'] or ''
+                    imdb_id = row['imdb_id'] or ''
+                    tmdb_id = str(row['tmdb_id'] or '')
+                    title   = (row['title'] or '').lower()
+                    year    = str(row['year'] or '')
+
+                    new_rk = (
+                        file_map.get(loc)
+                        or (imdb_map.get(imdb_id) if imdb_id else None)
+                        or (tmdb_map.get(tmdb_id) if tmdb_id else None)
+                        or (title_map.get((title, year)) if title and year else None)
+                    )
+                    if new_rk:
+                        resolved.append((db_id, new_rk, old_rk))
+
+                # Pass 2: rows that have ms_item_id but Plex file-path now maps
+                # to a different ratingKey — these are split-apart items.
+                # Only file-path matching is reliable here; imdb_id would resolve
+                # to whichever split item Plex returns first.
+                for row in rows_split:
+                    db_id   = row['id']
+                    old_rk  = row['ms_item_id']
+                    loc     = row['location_on_disk']
+
+                    new_rk = file_map.get(loc)
+                    if new_rk and new_rk != old_rk:
+                        resolved.append((db_id, new_rk, old_rk))
+
+                if not resolved:
+                    continue
+
+                # Write all resolved matches in one short-lived transaction
+                conn = _get_db_connection()
+                try:
+                    cursor = conn.cursor()
+                    changed_item_ids = []
+
+                    for db_id, new_rk, old_rk in resolved:
+                        cursor.execute(
+                            'UPDATE media_items SET ms_item_id = ? WHERE id = ?',
+                            (new_rk, db_id))
                         if cursor.rowcount:
-                            counts[count_key] += cursor.rowcount
-                            updated = True
-                    if not updated and tmdb_id:
-                        cursor.execute('''
-                            UPDATE media_items
-                            SET ms_item_id = ?
-                            WHERE type = ?
-                              AND tmdb_id = ?
-                              AND state IN ('Collected', 'Upgrading')
-                              AND (ms_item_id IS NULL OR ms_item_id = ''
-                                   OR LENGTH(ms_item_id) >= 20)
-                        ''', (rk, db_type, tmdb_id))
+                            counts[count_key] += 1
+                            if old_rk and old_rk != new_rk:
+                                changed_item_ids.append(db_id)
+
+                    # Reset overlay state for split-apart items so overlays
+                    # are regenerated with the new unique ratingKey
+                    if changed_item_ids:
+                        placeholders = ','.join('?' * len(changed_item_ids))
+                        cursor.execute(
+                            f'UPDATE media_overlay_state '
+                            f'SET status = \'pending\', '
+                            f'reason = \'ms_item_id changed — overlay needs regeneration\', '
+                            f'updated_at = CURRENT_TIMESTAMP '
+                            f'WHERE media_item_id IN ({placeholders}) AND status = \'applied\'',
+                            changed_item_ids)
                         if cursor.rowcount:
-                            counts[count_key] += cursor.rowcount
-                            updated = True
-                    # Fallback: match by title + year, only for Plex items with no external IDs at all
-                    if not updated and not imdb_id and not tmdb_id and pi.get('title') and pi.get('year'):
-                        cursor.execute('''
-                            UPDATE media_items
-                            SET ms_item_id = ?
-                            WHERE type = ?
-                              AND LOWER(title) = LOWER(?)
-                              AND year = ?
-                              AND state IN ('Collected', 'Upgrading')
-                              AND (ms_item_id IS NULL OR ms_item_id = ''
-                                   OR LENGTH(ms_item_id) >= 20)
-                        ''', (rk, db_type, pi['title'], pi['year']))
-                        if cursor.rowcount:
-                            counts[count_key] += cursor.rowcount
-                conn.commit()
-                conn.close()
+                            logger.info(
+                                f"ms-key sync: reset {cursor.rowcount} overlay(s) to pending "
+                                f"(ms_item_id changed after Plex split-apart)")
+
+                    conn.commit()
+                except Exception as _we:
+                    logger.error(f"ms-key sync write failed ({db_type}): {_we}", exc_info=True)
+                    try:
+                        conn.rollback()
+                    except Exception:
+                        pass
+                    counts['errors'] += 1
+                finally:
+                    conn.close()
+
             except Exception as e:
                 label = 'movies' if plex_type == 1 else 'shows'
                 logger.error(f"Auto ms-key sync ({label}) failed: {e}", exc_info=True)
@@ -469,7 +554,9 @@ def _reset_quality_changed_items() -> int:
         # Pre-fetch best quality per show (ms_item_id) and per movie (imdb_id)
         # using efficient grouped queries rather than N+1 individual queries.
         show_keys  = list({r['ms_item_id'] for r in applied_rows if r['type'] == 'episode'})
-        movie_imdb = list({r['imdb_id'] for r in applied_rows if r['type'] == 'movie' and r['imdb_id']})
+        # Movies: scope by ms_item_id so split Plex items (unique ratingKey per version)
+        # each compare quality against their own DB rows, not all versions of the movie.
+        movie_ms_ids = list({r['ms_item_id'] for r in applied_rows if r['type'] == 'movie' and r['ms_item_id']})
 
         _RES = ("CASE lower(ms_resolution) WHEN '2160p' THEN 6 WHEN '4k' THEN 6 "
                 "WHEN '1440p' THEN 5 WHEN '1080p' THEN 4 WHEN '720p' THEN 3 "
@@ -512,27 +599,27 @@ def _reset_quality_changed_items() -> int:
             for r in cursor.fetchall():
                 show_best[r['ms_item_id']] = r
 
-        if movie_imdb:
-            placeholders = ','.join('?' * len(movie_imdb))
+        if movie_ms_ids:
+            placeholders = ','.join('?' * len(movie_ms_ids))
             cursor.execute(f'''
-                SELECT imdb_id,
+                SELECT ms_item_id,
                        ms_resolution, ms_hdr, ms_dolby_vision,
                        ms_audio_codec, ms_audio_channels, ms_video_codec
                 FROM (
                     SELECT *, ROW_NUMBER() OVER (
-                        PARTITION BY imdb_id
+                        PARTITION BY ms_item_id
                         ORDER BY ({_RES}) DESC, ({_HDR}) DESC, ({_AUD}) DESC,
                                  CAST(COALESCE(ms_audio_channels,'0') AS REAL) DESC
                     ) AS rn
                     FROM media_items
                     WHERE type = 'movie'
-                      AND imdb_id IN ({placeholders})
+                      AND ms_item_id IN ({placeholders})
                       AND state IN ('Collected','Upgrading')
                       AND ms_resolution IS NOT NULL
                 ) WHERE rn = 1
-            ''', movie_imdb)
+            ''', movie_ms_ids)
             for r in cursor.fetchall():
-                movie_best[r['imdb_id']] = r
+                movie_best[r['ms_item_id']] = r
 
         # Compare stored hash vs current quality hash; collect items to reset
         reset_ids = []
@@ -541,7 +628,7 @@ def _reset_quality_changed_items() -> int:
             if row['type'] == 'episode':
                 best = show_best.get(row['ms_item_id'])
             else:
-                best = movie_best.get(row['imdb_id'])
+                best = movie_best.get(row['ms_item_id'])
 
             if not best:
                 continue
@@ -741,15 +828,18 @@ def _reset_content_changed_items(batch_size: int = 200) -> int:
         ''')
         show_version_counts = {r['imdb_id']: r['cnt'] for r in cursor.fetchall()}
 
+        # Movies: scope by ms_item_id so split Plex items (unique ratingKey per version)
+        # each get their own count of 1 rather than being grouped with other versions
+        # of the same movie. Merged items (same ms_item_id) still get the correct count.
         cursor.execute('''
-            SELECT imdb_id, COUNT(*) AS cnt
+            SELECT ms_item_id, COUNT(*) AS cnt
             FROM media_items
             WHERE type = 'movie'
               AND state IN ('Collected', 'Upgrading')
-              AND imdb_id IS NOT NULL
-            GROUP BY imdb_id
+              AND ms_item_id IS NOT NULL AND ms_item_id != ''
+            GROUP BY ms_item_id
         ''')
-        movie_version_counts = {r['imdb_id']: r['cnt'] for r in cursor.fetchall()}
+        movie_version_counts = {r['ms_item_id']: r['cnt'] for r in cursor.fetchall()}
 
         # Pre-fetch show statuses using the same source and normalization as
         # overlay_manager._fetch_show_status so the hashes always agree.
@@ -993,13 +1083,16 @@ def _reset_content_changed_items(batch_size: int = 200) -> int:
             imdb_id = row['imdb_id'] or ''
             plex_key = row['ms_item_id'] or ''
 
-            # Version count — both shows and movies keyed by imdb_id to match overlay_manager.
-            # Shows: default 0 (OverlayManager uses COALESCE(SUM,0) which returns 0 for
-            # shows with no duplicate episodes — using 1 here causes a permanent hash
-            # mismatch and resets every non-duplicate show to pending on every sync run).
-            # Movies: default 1 (OverlayManager counts all movie files so single-file movies
-            # return 1 and will always be present in the dict anyway).
-            vc = show_version_counts.get(imdb_id, 0) if item_type == 'episode' else movie_version_counts.get(imdb_id, 1)
+            # Version count — shows keyed by imdb_id, movies keyed by ms_item_id.
+            # Shows: default 0 (no duplicate episodes).
+            # Movies: scope to ms_item_id so split Plex items (different ms_item_id)
+            # each get count=1 independently. Merged items (same ms_item_id, multiple
+            # DB rows) still get the correct count > 1. Falls back to 1 when ms_item_id
+            # is not set (item not yet synced).
+            if item_type == 'episode':
+                vc = show_version_counts.get(imdb_id, 0)
+            else:
+                vc = movie_version_counts.get(plex_key, 1) if plex_key else 1
 
             # Ratings: only fetch/use when this item is in the current batch OR
             # already in the in-process cache. If we have no ratings at all, skip

--- a/queues/upgrading_queue.py
+++ b/queues/upgrading_queue.py
@@ -30,9 +30,11 @@ class UpgradingQueue:
         self.upgrades_file = Path(db_content_dir) / "upgrades.pkl"
         self.failed_upgrades_file = Path(db_content_dir) / "failed_upgrades.pkl"
         self.upgrade_states_file = Path(db_content_dir) / "upgrade_states.pkl"
+        self.upgrade_times_file = Path(db_content_dir) / "upgrade_times.pkl"
         self.upgrades_data = self.load_upgrades_data()
         self.failed_upgrades = self.load_failed_upgrades()
         self.upgrade_states = self.load_upgrade_states()
+        self.upgrade_times = self.load_upgrade_times()
         self.currently_processing_item_id: Optional[str] = None
         # Track last run date for the daily delayed-upgrade pass
         self._last_delayed_upgrade_run_date = None
@@ -127,12 +129,26 @@ class UpgradingQueue:
         try:
             with open(self.upgrade_states_file, 'wb') as f:
                 pickle.dump(self.upgrade_states, f)
-            # Optional: Add a debug log here if needed, but maybe too verbose
-            # logging.debug(f"Successfully saved upgrade states to {self.upgrade_states_file}")
         except (IOError, pickle.PicklingError, EOFError) as e:
             logging.error(f"Failed to save upgrade states to {self.upgrade_states_file}: {str(e)}", exc_info=True)
-            # Depending on severity, you might want to raise the exception
-            # or implement a more robust backup/retry mechanism here.
+
+    def load_upgrade_times(self):
+        """Load persisted upgrade_times from disk so start_time survives restarts."""
+        try:
+            if self.upgrade_times_file.exists() and self.upgrade_times_file.stat().st_size > 0:
+                with open(self.upgrade_times_file, 'rb') as f:
+                    return pickle.load(f)
+        except (EOFError, pickle.UnpicklingError, Exception) as e:
+            logging.error(f"Error loading upgrade_times, starting fresh: {e}")
+        return {}
+
+    def save_upgrade_times(self):
+        """Persist upgrade_times to disk so start_time survives restarts."""
+        try:
+            with open(self.upgrade_times_file, 'wb') as f:
+                pickle.dump(self.upgrade_times, f)
+        except (IOError, pickle.PicklingError, EOFError) as e:
+            logging.error(f"Failed to save upgrade_times: {str(e)}", exc_info=True)
 
     def save_item_state(self, item: Dict[str, Any]):
         """Save complete item state before attempting an upgrade"""
@@ -281,16 +297,25 @@ class UpgradingQueue:
             self.items.sort(key=lambda x: 0 if x['id'] in _queued_magnets else 1)
         except Exception:
             pass
+        changed = False
         for item in self.items:
             if item['id'] not in self.upgrade_times:
-                # Use last_updated (when item was moved to Upgrading) for display
-                # rather than original_collected_at which could be years ago for hub items
+                # Use last_updated (when item was moved to Upgrading) as the queue-entry
+                # timestamp. Captured here on first registration and persisted to disk so
+                # it survives restarts without relying on the DB field (which gets
+                # overwritten by hourly update_media_item() calls).
                 _last_updated = item.get('last_updated')
-                display_time = _last_updated if _last_updated else (item.get('original_collected_at') or datetime.now())
+                if _last_updated:
+                    start_time = datetime.fromisoformat(_last_updated) if isinstance(_last_updated, str) else _last_updated
+                else:
+                    start_time = datetime.now()
                 self.upgrade_times[item['id']] = {
-                    'start_time': datetime.now(),
-                    'time_added': display_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(display_time, datetime) else str(display_time)
+                    'start_time': start_time,
+                    'time_added': start_time.strftime('%Y-%m-%d %H:%M:%S')
                 }
+                changed = True
+        if changed:
+            self.save_upgrade_times()
 
     def get_contents(self):
         contents = []
@@ -311,15 +336,19 @@ class UpgradingQueue:
 
     def add_item(self, item: Dict[str, Any]):
         self.items.append(item)
-        # Use last_updated (when item was moved to Upgrading) for display
-        # rather than original_collected_at which could be years ago for hub items
+        # Capture last_updated as the queue-entry timestamp before any subsequent
+        # update_media_item() calls reset it during hourly scrapes.
         _last_updated = item.get('last_updated')
-        display_time = _last_updated if _last_updated else item.get('original_collected_at', datetime.now())
-        logging.info(f"upgrading queue time_added: {display_time}")
+        if _last_updated:
+            start_time = datetime.fromisoformat(_last_updated) if isinstance(_last_updated, str) else _last_updated
+        else:
+            start_time = datetime.now()
+        logging.info(f"upgrading queue start_time: {start_time}")
         self.upgrade_times[item['id']] = {
-            'start_time': datetime.now(),
-            'time_added': display_time.strftime('%Y-%m-%d %H:%M:%S') if isinstance(display_time, datetime) else str(display_time)
+            'start_time': start_time,
+            'time_added': start_time.strftime('%Y-%m-%d %H:%M:%S')
         }
+        self.save_upgrade_times()
         self.last_scrape_times[item['id']] = datetime.now()
         self.upgrades_found[item['id']] = 0  # Initialize upgrades found count
         
@@ -342,17 +371,22 @@ class UpgradingQueue:
             self.save_upgrades_data()
 
     def clean_up_upgrade_times(self):
+        active_ids = {item['id'] for item in self.items}
+        changed = False
         for item_id in list(self.upgrade_times.keys()):
-            if item_id not in [item['id'] for item in self.items]:
+            if item_id not in active_ids:
                 del self.upgrade_times[item_id]
                 if item_id in self.last_scrape_times:
                     del self.last_scrape_times[item_id]
                 logging.debug(f"Cleaned up upgrade time for item ID: {item_id}")
+                changed = True
+        if changed:
+            self.save_upgrade_times()
         for item_id in list(self.upgrades_found.keys()):
-            if item_id not in [item['id'] for item in self.items]:
+            if item_id not in active_ids:
                 del self.upgrades_found[item_id]
         for item_id in list(self.upgrades_data.keys()):
-            if item_id not in [item['id'] for item in self.items]:
+            if item_id not in active_ids:
                 del self.upgrades_data[item_id]
         self.save_upgrades_data()
 
@@ -391,26 +425,26 @@ class UpgradingQueue:
 
                 upgrade_info = self.upgrade_times.get(item_id)
 
-                # If upgrade_info is missing (e.g. after a restart, in-memory dict was lost),
-                # synthesize it from the item's original_collected_at so the timeout check still runs.
+                # upgrade_times is now persisted to disk, so a missing entry here means
+                # the pkl was lost or this is a brand-new item that somehow bypassed
+                # add_item/update. Use current_time as a safe fallback — the item gets
+                # a fresh window which is acceptable for this rare edge case.
                 if not upgrade_info:
-                    self.upgrade_times[item_id] = {'start_time': current_time, 'time_added': current_time}
+                    logging.warning(f"[UpgradingQueue] No upgrade_times entry for {item_id} — synthesizing with current time.")
+                    self.upgrade_times[item_id] = {
+                        'start_time': current_time,
+                        'time_added': current_time.strftime('%Y-%m-%d %H:%M:%S')
+                    }
+                    self.save_upgrade_times()
                     upgrade_info = self.upgrade_times[item_id]
 
                 if upgrade_info:
-                    # For hub-queued items use last_updated (when they were moved to Upgrading)
-                    # rather than original_collected_at (which could be years ago).
-                    # For regular upgrading items, last_updated is also set at queue time so
-                    # this is safe to use universally.
-                    _last_updated = item.get('last_updated')
-                    if _last_updated:
-                        collected_at = datetime.fromisoformat(_last_updated) if isinstance(_last_updated, str) else _last_updated
-                    else:
-                        collected_at = datetime.fromisoformat(item['original_collected_at']) if isinstance(item.get('original_collected_at'), str) else item.get('original_collected_at')
-
-                    # Fall back to queue entry time if both are missing
-                    if collected_at is None:
-                        collected_at = upgrade_info.get('start_time', current_time)
+                    # Use start_time from upgrade_times — captured once when the item
+                    # first entered the queue (from last_updated at that moment).
+                    # We intentionally do NOT re-read last_updated from the item here
+                    # because update_media_item() resets last_updated on every hourly
+                    # scrape, which would make time_in_queue never exceed the timeout.
+                    collected_at = upgrade_info.get('start_time', current_time)
 
                     time_in_queue = current_time - collected_at
 

--- a/routes/overlay_routes.py
+++ b/routes/overlay_routes.py
@@ -1542,8 +1542,12 @@ def list_movies():
         conn = _get_db_connection()
         cursor = conn.cursor()
 
-        # Get movies with overlay status — one card per unique movie title/year,
-        # deduplicated by imdb_id/tmdb_id so multi-version movies show once.
+        # Get movies with overlay status.
+        # Group by ms_item_id when available so split Plex items (each with a unique
+        # ratingKey) appear as separate cards with their own overlays. Fall back to
+        # imdb_id/tmdb_id grouping only for items not yet synced (ms_item_id is NULL).
+        # Merged Plex items (multiple DB rows sharing the same ms_item_id) are still
+        # collapsed to one card and show a version_count badge.
         cursor.execute('''
             SELECT
                 MIN(m.id) AS id,
@@ -1551,7 +1555,7 @@ def list_movies():
                 m.year,
                 m.imdb_id,
                 m.tmdb_id,
-                MAX(m.ms_item_id) AS ms_item_id,
+                m.ms_item_id,
                 COUNT(*) AS version_count,
                 CASE
                     WHEN MAX(CASE WHEN o.status = 'applied'         THEN 1 ELSE 0 END) = 1 THEN 'applied'
@@ -1566,7 +1570,12 @@ def list_movies():
             LEFT JOIN media_overlay_state o ON m.id = o.media_item_id
             WHERE m.type = 'movie'
               AND m.state IN ('Collected', 'Upgrading')
-            GROUP BY COALESCE(NULLIF(m.imdb_id, ''), NULLIF(m.tmdb_id, ''), m.title || CAST(m.year AS TEXT))
+            GROUP BY
+                CASE
+                    WHEN m.ms_item_id IS NOT NULL AND m.ms_item_id != ''
+                    THEN m.ms_item_id
+                    ELSE COALESCE(NULLIF(m.imdb_id, ''), NULLIF(m.tmdb_id, ''), m.title || CAST(m.year AS TEXT))
+                END
             ORDER BY m.title
         ''')
 

--- a/static/js/layout_builder.js
+++ b/static/js/layout_builder.js
@@ -136,6 +136,14 @@ const BADGE_PRESETS = {
         background: { enabled: true, color: '#000000CC', width: 345, height: 140, borderRadius: 18 },
         icon: { enabled: false, type: 'image', path: '', width: 90, height: 90, side: 'left' },
         text: { enabled: true, value: 'Custom Text', font: 'DejaVuSans-Bold', size: 60, color: '#FFFFFF', align: 'center', fallback: '' }
+    },
+    file_match: {
+        label: 'File Match',
+        condition: '',
+        background: { enabled: true, color: '#000000CC', width: 300, height: 110, borderRadius: 14 },
+        icon: { enabled: false, type: 'image', path: '', width: 70, height: 70, side: 'left' },
+        text: { enabled: true, value: '', font: 'DejaVuSans-Bold', size: 60, color: '#FFFFFF', align: 'center', fallback: '' },
+        filenameMatch: { searchTerm: '', displayText: '', useIcon: false }
     }
 };
 
@@ -1455,6 +1463,19 @@ function populateBadgeProperties(badge) {
     if (puEl) puEl.checked = !!(badge.percentUnit);
     _updateRatingFormatVisibility();
     document.querySelectorAll('.properties-panel input[type="range"]').forEach(_syncRangeVal);
+
+    // File Match section — only visible for file_match type
+    const fmSection = document.getElementById('file-match-section');
+    if (fmSection) {
+        const isFileMatch = badge.type === 'file_match';
+        fmSection.style.display = isFileMatch ? '' : 'none';
+        if (isFileMatch) {
+            const fm = badge.filenameMatch || {};
+            document.getElementById('fm-search-term').value = fm.searchTerm || '';
+            document.getElementById('fm-display-text').value = fm.displayText || '';
+            document.getElementById('fm-use-icon').checked = !!fm.useIcon;
+        }
+    }
 }
 
 function populateSmartBadgeProperties(badge) {
@@ -1759,6 +1780,14 @@ function updateSelectedBadge() {
     const _puEl = document.getElementById('text-percent-unit');
     badge.percentUnit = _puEl ? _puEl.checked : false;
     // condition is kept from preset — not user-editable
+
+    // File Match properties
+    if (badge.type === 'file_match') {
+        if (!badge.filenameMatch) badge.filenameMatch = {};
+        badge.filenameMatch.searchTerm  = (document.getElementById('fm-search-term')?.value || '').trim();
+        badge.filenameMatch.displayText = (document.getElementById('fm-display-text')?.value || '').trim();
+        badge.filenameMatch.useIcon     = !!(document.getElementById('fm-use-icon')?.checked);
+    }
 
     updateBadgesList();
     renderCanvas();
@@ -2272,6 +2301,12 @@ function setupPropertyBindings() {
                 text: { ...preset.text },
                 x, y,
             });
+            // Include filenameMatch for file_match type
+            if (newType === 'file_match') {
+                badge.filenameMatch = preset.filenameMatch ? { ...preset.filenameMatch } : { searchTerm: '', displayText: '', useIcon: false };
+            } else {
+                delete badge.filenameMatch;
+            }
             updateBadgesList();
             populateBadgeProperties(badge);
             renderCanvas();
@@ -2315,6 +2350,12 @@ function setupPropertyBindings() {
 
     // Percent unit checkbox
     document.getElementById('text-percent-unit').addEventListener('change', updateSelectedBadge);
+
+    // File Match inputs
+    ['fm-search-term', 'fm-display-text'].forEach(id => {
+        document.getElementById(id)?.addEventListener('input', updateSelectedBadge);
+    });
+    document.getElementById('fm-use-icon')?.addEventListener('change', updateSelectedBadge);
 
     // Enable checkboxes
     const sectionMap = { 'bg-enabled': 'bg-body', 'icon-enabled': 'icon-body', 'text-enabled': 'text-body' };
@@ -2617,6 +2658,14 @@ function renderBadgeOnCanvas(ctx, badge, isSelected) {
     if (badge.type === 'title_logo') {
         renderTitleLogoOnCanvas(ctx, badge, isSelected);
         return;
+    }
+    // For file_match: inject the display text (or search term) so the preview
+    // shows how the badge will look when it matches. Style is controlled by the
+    // existing Text/Value section — only the match logic is in File Match section.
+    if (badge.type === 'file_match') {
+        const fm = badge.filenameMatch || {};
+        const previewText = fm.displayText || fm.searchTerm || 'Match';
+        badge = { ...badge, text: { ...badge.text, value: previewText } };
     }
     const { x, y, background: bg, icon, text } = badge;
     const pad = bg.padding ?? 8;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -150,8 +150,17 @@ export function updateSettings() {
 
         // Skip hidden inputs and inputs inside hidden containers
         // This prevents hidden duplicate fields from overwriting visible ones
-        // EXCEPTION: Always include inputs with data-section attribute (legitimate settings in collapsed sections)
-        if (input.offsetParent === null && input.type !== 'hidden' && !input.hasAttribute('data-section')) return;
+        // EXCEPTION: Include inputs with data-section attribute (legitimate settings in collapsed sections),
+        // BUT exclude inputs inside mode-switching panels that are currently display:none — these panels
+        // contain duplicate fields that would overwrite the visible counterparts (e.g. plex library fields
+        // duplicated across #plex-settings-in-file-management and .symlink-plex-setting).
+        if (input.offsetParent === null && input.type !== 'hidden') {
+            if (!input.hasAttribute('data-section')) return;
+            // Check if a nearest ancestor panel (not a collapsible settings-section-content) is display:none.
+            // Mode-switching panels are direct children of the form or have specific ids/classes.
+            const hiddenPanel = input.closest('#plex-settings-in-file-management, #jellyfin-settings-in-file-management, .symlink-plex-setting');
+            if (hiddenPanel && hiddenPanel.style.display === 'none') return;
+        }
         
         let value = input.value;
         

--- a/templates/layout_builder.html
+++ b/templates/layout_builder.html
@@ -1249,6 +1249,7 @@
                         </optgroup>
                         <optgroup label="Custom">
                             <option value="custom">Custom Badge</option>
+                            <option value="file_match">File Match</option>
                         </optgroup>
                     </select>
                 </div>
@@ -1476,6 +1477,24 @@
                         <input type="checkbox" id="text-percent-unit" style="width:auto; margin:0;">
                         <label for="text-percent-unit" style="margin:0; cursor:pointer; font-weight:600;">Add % unit</label>
                     </div>
+                </div>
+            </div>
+
+            <!-- File Match (only visible when badge type = file_match) -->
+            <div class="properties-section" id="file-match-section" style="display:none;">
+                <h4>File Match</h4>
+                <p class="var-help" style="margin-bottom:10px;">Badge only displays when the filename contains the search term (case-insensitive). Use the <strong>Text / Value</strong> and <strong>Background</strong> sections below to style the badge.</p>
+                <div class="form-group">
+                    <label>Search Term</label>
+                    <input type="text" id="fm-search-term" placeholder="e.g. REMUX, x265, DTS">
+                </div>
+                <div class="form-group">
+                    <label>Display Text <span style="font-weight:normal; color:#999;">(leave empty to use search term)</span></label>
+                    <input type="text" id="fm-display-text" placeholder="e.g. REMUX">
+                </div>
+                <div class="form-group" style="display:flex; align-items:center; gap:8px; flex-direction:row;">
+                    <input type="checkbox" id="fm-use-icon" style="width:auto; margin:0;">
+                    <label for="fm-use-icon" style="margin:0; cursor:pointer; font-weight:600;">Use icon instead of text</label>
                 </div>
             </div>
 

--- a/templates/manual_blacklist.html
+++ b/templates/manual_blacklist.html
@@ -46,7 +46,7 @@
                 <td>{{ item.media_type }}</td>
                 <td>
                     {% if item.media_type == 'episode' %}
-                        <form class="seasons-form" data-imdb-id="{{ imdb_id }}" data-selected-seasons="{{ item.seasons | tojson }}">
+                        <form class="seasons-form" data-imdb-id="{{ imdb_id }}" data-selected-seasons="{{ (item.seasons if item.seasons is defined else []) | tojson }}">
                             <div class="form-check mb-2 d-flex align-items-center">
                                 <input type="checkbox" class="form-check-input" id="all_seasons_{{ imdb_id }}" name="all_seasons" {% if not item.seasons %}checked{% endif %}>
                                 <label class="form-check-label ms-2" for="all_seasons_{{ imdb_id }}">All Seasons</label>

--- a/templates/settings_tabs/debug_tangerine.html
+++ b/templates/settings_tabs/debug_tangerine.html
@@ -37,7 +37,7 @@
     </div>
     <div class="settings-section-content">
         {# Advanced settings hidden: 'disable_initialization', 'auto_run_program' #}
-        {% for key in ['logging_level', 'timezone_override', 'enable_crash_test', 'enable_tracemalloc', 'tracemalloc_sample_rate', 'check_for_updates', 'use_symlinks_on_windows'] %}
+        {% for key in ['logging_level', 'timezone_override', 'enable_tracemalloc', 'tracemalloc_sample_rate', 'check_for_updates', 'use_symlinks_on_windows'] %}
             {% set value = settings_schema.Debug.get(key) %}
             {% if value %}
             <div class="settings-form-group">
@@ -157,7 +157,7 @@
         </div>
     </div>
     <div class="settings-section-content">
-        {% for key in ['disable_not_wanted_check', 'do_not_add_plex_watch_history_items_to_queue', 'item_process_delay_seconds', 'disable_content_source_caching', 'enable_granular_version_additions'] %}
+        {% for key in ['do_not_add_plex_watch_history_items_to_queue', 'item_process_delay_seconds', 'disable_content_source_caching', 'enable_granular_version_additions'] %}
             {% set value = settings_schema.Debug.get(key) %}
             {% if value %}
             <div class="settings-form-group">
@@ -621,6 +621,13 @@
                    value="{% set val = settings.get('Debug', {}).get('minimum_scrape_score', settings_schema.Debug.minimum_scrape_score.default) %}{{ val if val != None else '' }}" class="settings-input"
                    data-section="Debug" data-key="minimum_scrape_score">
             <p class="settings-description">Minimum scrape score to accept results above.</p>
+        </div>
+        <div class="settings-form-group">
+            <label for="debug-scale_final_scores" class="settings-title">Scale Final Scores:</label>
+            <input type="checkbox" id="debug-scale_final_scores" name="Debug.scale_final_scores"
+                   data-section="Debug" data-key="scale_final_scores"
+                   {% if settings.get('Debug', {}).get('scale_final_scores', settings_schema.Debug.scale_final_scores.default) == True %}checked{% endif %}>
+            <p class="settings-description">{{ settings_schema.Debug.scale_final_scores.description }}</p>
         </div>
     </div>
 </div>

--- a/utilities/deletion_manager.py
+++ b/utilities/deletion_manager.py
@@ -370,6 +370,19 @@ class DeletionManager:
                 result['deleted_symlinks'].append(symlink_path)
                 logging.info(f"Deleted symlink: {symlink_path}")
 
+                # Delete subtitle sidecar files left by Bazarr (if setting enabled)
+                subtitle_extensions = {'.srt', '.ass', '.sub', '.ssa', '.vtt', '.idx', '.sup'}
+                delete_subtitles = get_setting('Bazarr Integration', 'delete_subtitles_on_removal', fallback=True)
+                if delete_subtitles and parent_folder and os.path.exists(parent_folder):
+                    try:
+                        for fname in os.listdir(parent_folder):
+                            if os.path.splitext(fname)[1].lower() in subtitle_extensions:
+                                sub_path = os.path.join(parent_folder, fname)
+                                os.remove(sub_path)
+                                logging.info(f"[SYMLINK_DELETION] Deleted subtitle sidecar: {sub_path}")
+                    except Exception as e:
+                        logging.warning(f"[SYMLINK_DELETION] Error cleaning up subtitle files in {parent_folder}: {e}")
+
                 # Handle parent folder cleanup (with safety checks)
                 if parent_folder and os.path.exists(parent_folder) and is_safe_to_delete(parent_folder):
                     try:

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -2443,9 +2443,26 @@ def resync_symlinks_with_new_settings(
             norm_new_symlink = os.path.normpath(new_symlink_destination)
 
             if norm_db_symlink != norm_new_symlink:
+                old_parent = os.path.dirname(db_symlink_location) if db_symlink_location else None
+                new_parent = os.path.dirname(new_symlink_destination)
+
                 if db_symlink_location and os.path.lexists(db_symlink_location):
                     if os.path.islink(db_symlink_location): os.unlink(db_symlink_location)
-                
+
+                # Move any subtitle sidecar files from old folder to new folder
+                subtitle_extensions = {'.srt', '.ass', '.sub', '.ssa', '.vtt', '.idx', '.sup'}
+                if old_parent and old_parent != new_parent and os.path.exists(old_parent):
+                    try:
+                        os.makedirs(new_parent, exist_ok=True)
+                        for fname in os.listdir(old_parent):
+                            if os.path.splitext(fname)[1].lower() in subtitle_extensions:
+                                src = os.path.join(old_parent, fname)
+                                dst = os.path.join(new_parent, fname)
+                                shutil.move(src, dst)
+                                logging.info(f"[RESYNC] Moved subtitle sidecar: {src} -> {dst}")
+                    except Exception as e:
+                        logging.warning(f"[RESYNC] Error moving subtitle files from {old_parent} to {new_parent}: {e}")
+
                 symlink_created = create_symlink(actual_source_file_to_use, new_symlink_destination, item_id, skip_verification=True)
                 if symlink_created:
                     try:

--- a/utilities/plex_functions.py
+++ b/utilities/plex_functions.py
@@ -40,6 +40,8 @@ _SHOW_CACHE_TTL_HOURS = 6  # Refresh cache every 6 hours
 _plex_movie_cache: Dict[str, Any] = {}
 _plex_movie_cache_timestamp: Optional[float] = None
 _MOVIE_CACHE_TTL_HOURS = 6  # Refresh cache every 6 hours
+import threading as _threading
+_plex_movie_cache_lock = _threading.Lock()  # Prevents concurrent cache refreshes
 
 def normalize_plex_resolution(resolution: str) -> str:
     """
@@ -2512,10 +2514,28 @@ def refresh_plex_movie_cache():
     This method fetches ALL movies from movie libraries in one API call with includeGuids=1,
     which is much faster and more reliable than using guid__contains (which is broken).
 
+    A threading lock ensures only one refresh runs at a time — concurrent callers
+    (e.g. simultaneous Agregarr webhooks) wait for the first to complete and then
+    reuse the freshly-populated cache rather than each issuing a full Plex API call
+    and DB write, which caused SQLite lock contention.
+
     Returns:
         bool: True if cache was refreshed successfully, False otherwise
     """
     global _plex_movie_cache, _plex_movie_cache_timestamp
+
+    if not _plex_movie_cache_lock.acquire(blocking=True, timeout=60):
+        logger.warning("refresh_plex_movie_cache: could not acquire lock within 60s, skipping")
+        return False
+
+    try:
+        # Re-check staleness after acquiring lock — a concurrent caller may have
+        # already refreshed the cache while we were waiting.
+        if not is_plex_movie_cache_stale():
+            logger.debug("refresh_plex_movie_cache: cache refreshed by another thread while waiting — skipping")
+            return True
+    except Exception:
+        pass
 
     try:
         # Get Plex connection details
@@ -2591,6 +2611,8 @@ def refresh_plex_movie_cache():
     except Exception as e:
         logger.error(f"Error refreshing Plex movie cache: {e}", exc_info=True)
         return False
+    finally:
+        _plex_movie_cache_lock.release()
 
 
 def is_plex_movie_cache_stale() -> bool:

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -2245,6 +2245,11 @@ SETTINGS_SCHEMA = {
             "type": "string",
             "description": "Version number to report to Bazarr. Change only if Bazarr requires a specific version.",
             "default": "5.14.0.9383"
+        },
+        "delete_subtitles_on_removal": {
+            "type": "boolean",
+            "description": "When deleting media, also delete any subtitle files (.srt, .ass, .sub, etc.) left in the symlink folder by Bazarr. Disable this to keep subtitle files after deletion.",
+            "default": True
         }
     },
     "AI Assistant": {


### PR DESCRIPTION
- Added overlays handling plex split apart versions
- Added File Match badge type in the Layout Builder — badge shows only when the video filename contains a specified search term
- Fixed settings reverting after save for Plex library name fields in File Management
- Fixed duplicate "Disable Not Wanted Check" and "Enable Crash Test" entries in Advanced Settings (Tangerine theme)
- Fixed "Scale Final Scores" setting missing from Advanced Settings in Tangerine theme
- Fixed manual blacklist page throwing an error for users with older entries
- Fixed clearlogo not appearing on overlays after a Plex split-apart operation
- Fixed Plex library cache being refreshed multiple times simultaneously, causing database lock errors
- Fixed upgrading queue timeout not surviving app restarts correctly
- Fixed Zilean upgrade suggesting wrong episodes when multiple episodes share a torrent