### PR TITLE
fixes and improvements

### DIFF
--- a/database/collected_items.py
+++ b/database/collected_items.py
@@ -587,7 +587,8 @@ def add_collected_items(media_items_batch, recent=False, backfill=False, data_so
                                     location_on_disk = ?, upgraded = ?,
                                     resolution = COALESCE(?, resolution),
                                     size = COALESCE(?, size),
-                                    ms_item_id = COALESCE(?, ms_item_id)
+                                    ms_item_id = COALESCE(?, ms_item_id),
+                                    scrape_results = NULL
                                 WHERE id = ?
                             ''', (new_state, datetime.now(), collected_at, existing_collected_at,
                                   new_location, is_upgrade, item.get('resolution'), item.get('size_gb'),

--- a/database/nzb_upgrade.py
+++ b/database/nzb_upgrade.py
@@ -1,0 +1,616 @@
+"""
+NZB Upgrade Scanner — Upgrade Hub backend for Newznab indexers
+
+Fetches the latest NZBs from all enabled Newznab indexers (browse mode,
+up to 1000 per category per indexer) once per scan trigger, then matches
+candidates to library items using PTT-parsed title + year.
+
+Matching strategy (no IMDB ID in feed):
+  - PTT parses the NZB release name to extract title and year
+  - Match requires BOTH:
+      1. token_sort_ratio(query_title, nzb_title) >= 0.90
+      2. Year matches exactly OR nzb has no year (year-agnostic releases)
+  - For episodes: additionally filtered by season+episode numbers from PTT
+  - For season packs: additionally filtered to single-season packs
+
+This avoids false matches like "The Owl House" → "The Last Kingdom" because
+the year (2020 vs 2022) and strict title threshold would reject it.
+"""
+
+import logging
+import threading
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, List, Optional, Tuple
+
+from utilities.settings import load_config
+
+logger = logging.getLogger(__name__)
+
+_CAT_MOVIE = '2000,2030,2040,2045,2050,2060'
+_CAT_TV    = '5000,5010,5020,5030,5040,5045,5060,5070'
+
+# Per-scan in-memory pool — reset at start of each scan trigger
+_nzb_pool_lock = threading.Lock()
+_nzb_pool: Dict[str, List[Dict]] = {}  # 'movie' | 'tv' -> results
+_nzb_pool_ready = False
+
+
+def _reset_pool() -> None:
+    global _nzb_pool, _nzb_pool_ready
+    with _nzb_pool_lock:
+        _nzb_pool = {}
+        _nzb_pool_ready = False
+
+
+def get_newznab_scrapers() -> List[Tuple[str, Dict]]:
+    """Return list of (instance_name, settings) for all enabled Newznab scrapers."""
+    config = load_config()
+    scrapers = []
+    for instance, settings in config.get('Scrapers', {}).items():
+        if not isinstance(settings, dict):
+            continue
+        if settings.get('type') == 'Newznab' and settings.get('enabled') and settings.get('url'):
+            scrapers.append((instance, settings))
+    return scrapers
+
+
+def _fetch_browse_page(url: str, api_key: str, cats: str, limit: int,
+                        offset: int, timeout: int = 30) -> Tuple[List[ET.Element], int]:
+    """Fetch one browse page. Returns (items, total)."""
+    from routes.api_tracker import api as _api
+    try:
+        r = _api.get(f'{url}/api', params={
+            'apikey': api_key, 't': 'search', 'q': '',
+            'cat': cats, 'limit': limit, 'offset': offset,
+        }, timeout=timeout)
+        if r.status_code != 200:
+            return [], 0
+        root = ET.fromstring(r.text)
+        channel = root.find('channel')
+        if channel is None:
+            return [], 0
+        ns = 'http://www.newznab.com/DTD/2010/feeds/attributes/'
+        total = 0
+        resp_el = channel.find(f'{{{ns}}}response')
+        if resp_el is not None:
+            try:
+                total = int(resp_el.get('total', 0))
+            except (ValueError, TypeError):
+                pass
+        return channel.findall('item'), total
+    except Exception as e:
+        logger.warning(f'[NZB_UPGRADE] Browse error {url}: {e}')
+        return [], 0
+
+
+def _parse_items(items: List[ET.Element], instance: str) -> List[Dict]:
+    """Parse Newznab XML items into result dicts with PTT-parsed info."""
+    from PTT import parse_title as ptt_parse
+    ns = {'newznab': 'http://www.newznab.com/DTD/2010/feeds/attributes/'}
+    results = []
+    for item in items:
+        title_el = item.find('title')
+        if title_el is None or not title_el.text:
+            continue
+        title = title_el.text.strip()
+
+        enclosure_el = item.find('enclosure')
+        link_el = item.find('link')
+        nzb_url = None
+        if enclosure_el is not None:
+            nzb_url = enclosure_el.get('url', '')
+        if not nzb_url and link_el is not None:
+            nzb_url = (link_el.text or '').strip()
+        if not nzb_url:
+            continue
+
+        guid_el = item.find('guid')
+        guid = guid_el.text.strip() if guid_el is not None and guid_el.text else nzb_url
+
+        size_bytes = 0
+        if enclosure_el is not None:
+            try:
+                size_bytes = int(enclosure_el.get('length', 0))
+            except (ValueError, TypeError):
+                pass
+        if not size_bytes:
+            for attr in item.findall('newznab:attr', ns):
+                if attr.get('name') == 'size':
+                    try:
+                        size_bytes = int(attr.get('value', 0))
+                    except (ValueError, TypeError):
+                        pass
+                    break
+
+        pub_date_el = item.find('pubDate')
+        pub_date = pub_date_el.text.strip() if pub_date_el is not None and pub_date_el.text else ''
+        size_gb = round(size_bytes / (1024 ** 3), 2) if size_bytes else 0.0
+
+        try:
+            ptt = ptt_parse(title)
+        except Exception:
+            ptt = {}
+
+        parsed_info = {
+            'guid': guid,
+            'protocol': 'nzb',
+            'publish_date': pub_date,
+            'source_instance': instance,
+            'title': ptt.get('title', title),
+            'year': ptt.get('year'),
+            'resolution': ptt.get('resolution'),
+            'source': ptt.get('quality'),
+            'audio': ptt.get('audio', []),
+            'codec': ptt.get('codec'),
+            'group': ptt.get('group'),
+            'season': ptt.get('seasons', [None])[0] if ptt.get('seasons') else None,
+            'seasons': ptt.get('seasons', []),
+            'episode': ptt.get('episodes', [None])[0] if ptt.get('episodes') else None,
+            'episodes': ptt.get('episodes', []),
+            'hdr': ptt.get('hdr', []),
+            'is_hdr': bool(ptt.get('hdr')),
+            'trash': ptt.get('trash', False),
+            'original_title': title,
+        }
+
+        results.append({
+            'title': title,
+            'original_title': title,
+            'size': size_gb,
+            'source': f'NZB-{instance}',
+            'seeders': 0,
+            'hash': '',
+            'magnet': nzb_url,
+            'nzb_url': nzb_url,
+            'protocol': 'nzb',
+            'ingested_at': pub_date,
+            'parsed_info': parsed_info,
+        })
+    return results
+
+
+def _fetch_instance_category(instance: str, settings: Dict, cats: str,
+                              max_items: int = 1000) -> List[Dict]:
+    """Fetch up to max_items NZBs from one indexer for one category, paginating as needed."""
+    url = settings.get('url', '').rstrip('/')
+    api_key = settings.get('api_key', '').strip()
+    if not url or not api_key:
+        return []
+
+    page_limit = min(int(settings.get('browse_limit', 100)), 1000)
+    all_results: List[Dict] = []
+    offset = 0
+
+    while len(all_results) < max_items:
+        fetch_size = min(page_limit, max_items - len(all_results))
+        items, total = _fetch_browse_page(url, api_key, cats, fetch_size, offset)
+        if not items:
+            break
+        all_results.extend(_parse_items(items, instance))
+        offset += len(items)
+        if offset >= min(total, max_items) or len(items) < fetch_size:
+            break
+
+    logger.info(f'[NZB_UPGRADE] {instance} ({cats[:4]}…): fetched {len(all_results)} NZBs')
+    return all_results
+
+
+def fetch_nzb_pool(scrapers: List[Tuple[str, Dict]], max_items: int = 1000) -> Dict[str, List[Dict]]:
+    """Fetch latest NZBs from all indexers in parallel. Returns {'movie': [...], 'tv': [...]}."""
+    global _nzb_pool, _nzb_pool_ready
+    _reset_pool()
+
+    if not scrapers:
+        return {'movie': [], 'tv': []}
+
+    tasks = [(inst, cfg, 'movie', _CAT_MOVIE) for inst, cfg in scrapers] + \
+            [(inst, cfg, 'tv', _CAT_TV)    for inst, cfg in scrapers]
+
+    raw: Dict[str, List[Dict]] = {'movie': [], 'tv': []}
+    with ThreadPoolExecutor(max_workers=min(len(tasks), 8)) as pool:
+        future_map = {
+            pool.submit(_fetch_instance_category, inst, cfg, cats, max_items): cat
+            for inst, cfg, cat, cats in tasks
+        }
+        for fut in as_completed(future_map):
+            cat = future_map[fut]
+            try:
+                raw[cat].extend(fut.result())
+            except Exception as e:
+                logger.warning(f'[NZB_UPGRADE] Pool fetch error: {e}')
+
+    # Deduplicate by guid across indexers
+    deduped: Dict[str, List[Dict]] = {}
+    for cat, results in raw.items():
+        seen: set = set()
+        unique = []
+        for r in results:
+            guid = (r.get('parsed_info') or {}).get('guid') or r.get('nzb_url', '')
+            if guid and guid not in seen:
+                seen.add(guid)
+                unique.append(r)
+            elif not guid:
+                unique.append(r)
+        deduped[cat] = unique
+        logger.info(f'[NZB_UPGRADE] Pool ready: {len(unique)} unique {cat} NZBs')
+
+    with _nzb_pool_lock:
+        _nzb_pool = deduped
+        _nzb_pool_ready = True
+
+    return deduped
+
+
+# ---------------------------------------------------------------------------
+# Title + year matching against pool
+# ---------------------------------------------------------------------------
+
+import re as _re
+_NORM_RE = _re.compile(r'[^a-z0-9\s]')
+
+
+def _norm(s: str) -> str:
+    return _NORM_RE.sub('', (s or '').lower()).strip()
+
+
+def _filter_pool_for_item(pool: List[Dict], title: str, year: Optional[int],
+                           title_threshold: float = 0.90) -> List[Dict]:
+    """
+    Filter pool to candidates matching title + year.
+
+    Requires:
+      1. token_sort_ratio(query_title, nzb_ptt_title) >= title_threshold
+      2. Year matches exactly OR nzb has no parsed year (year-agnostic)
+
+    token_sort_ratio handles word-order differences and is strict enough at
+    0.90 to reject unrelated titles that share only common words like "The".
+    """
+    from rapidfuzz import fuzz as _fuzz
+    norm_query = _norm(title)
+    candidates = []
+    for r in pool:
+        pi = r.get('parsed_info') or {}
+        nzb_title = pi.get('title') or r.get('title', '')
+        nzb_year  = pi.get('year')
+
+        # Year gate: reject if both have a year and they don't match
+        if year and nzb_year and abs(int(nzb_year) - int(year)) > 1:
+            continue
+
+        sim = _fuzz.token_sort_ratio(_norm(nzb_title), norm_query) / 100.0
+        if sim >= title_threshold:
+            candidates.append(r)
+
+    return candidates
+
+
+def _filter_pool_for_episode(pool: List[Dict], season: int, episode: int) -> List[Dict]:
+    """Keep only NZBs whose PTT-parsed seasons/episodes include the target."""
+    result = []
+    for r in pool:
+        pi = r.get('parsed_info') or {}
+        seasons  = pi.get('seasons', [])
+        episodes = pi.get('episodes', [])
+        if season in seasons and (not episodes or episode in episodes):
+            result.append(r)
+    return result
+
+
+def _filter_pool_for_pack(pool: List[Dict], season: int) -> List[Dict]:
+    """Keep only NZBs that are single-season packs for the given season."""
+    from database.zilean_upgrade import _is_single_season_pack
+    result = []
+    for r in pool:
+        pi = r.get('parsed_info') or {}
+        seasons  = pi.get('seasons', [])
+        episodes = pi.get('episodes', [])
+        if season in seasons and not episodes:
+            if _is_single_season_pack(r.get('title', ''), season):
+                result.append(r)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Per-item scan workers
+# ---------------------------------------------------------------------------
+
+def scan_nzb_movie(item: Dict, pool_movie: List[Dict],
+                   threshold: float, default_version: str,
+                   not_wanted_hashes: Optional[frozenset] = None) -> Optional[Dict]:
+    from database.zilean_upgrade import (
+        _get_version_settings, _score_results_with_current,
+        _item_size_gb, _item_filename, _is_upgrade,
+    )
+    current_filename = _item_filename(item)
+    if not current_filename:
+        return None
+
+    version = (item.get('version') or default_version).rstrip('*').strip()
+    vs = _get_version_settings(version)
+
+    candidates = _filter_pool_for_item(pool_movie, item['title'], item.get('year'))
+    if not candidates:
+        return None
+
+    current_score, candidate_scored = _score_results_with_current(
+        current_filename, candidates,
+        item['title'], item.get('year'), None, None, 'movie', False, vs,
+        size_bytes=_item_size_gb(item),
+        genres_raw=item.get('genres') or '',
+    )
+    if not candidate_scored:
+        return None
+
+    candidate_scored = [(s, r) for s, r in candidate_scored
+                        if not (r.get('title', '') or '').lower().startswith('www')]
+    if not_wanted_hashes:
+        from database.not_wanted_magnets import get_base_filename as _gh, normalize_title as _nt
+        candidate_scored = [(s, r) for s, r in candidate_scored
+                            if _gh(r.get('nzb_url', '') or r.get('magnet', '')) not in not_wanted_hashes
+                            and _nt(r.get('title', '')) not in not_wanted_hashes]
+    if not candidate_scored:
+        return None
+
+    current_size_gb = round(_item_size_gb(item), 2)
+    if current_size_gb > 0:
+        candidate_scored = [(s, r) for s, r in candidate_scored
+                            if float(r.get('size') or 0) >= current_size_gb]
+    if not candidate_scored:
+        return None
+
+    best_score, best_result = candidate_scored[0]
+    if not _is_upgrade(best_score, current_score, threshold):
+        return None
+
+    qualifying = [(s, r) for s, r in candidate_scored if _is_upgrade(s, current_score, threshold)][:3]
+    return {
+        'type': 'movie', 'item_id': item['id'], 'imdb_id': item['imdb_id'],
+        'title': item['title'], 'year': item.get('year'), 'version': version,
+        'current_score': round(current_score, 2), 'new_score': round(best_score, 2),
+        'improvement_pct': round((best_score - current_score) / max(abs(current_score), 1) * 100, 1),
+        'current_file': current_filename,
+        'current_protocol': 'nzb' if str(item.get('filled_by_torrent_id') or '').startswith('nzb:') else 'torrent',
+        'current_size_gb': current_size_gb,
+        'new_title': best_result.get('title', ''), 'new_size_gb': best_result.get('size', 0),
+        'new_magnet': best_result.get('nzb_url', '') or best_result.get('magnet', ''),
+        'protocol': 'nzb',
+        '_alts': qualifying,
+        '_phalanx_only': False,
+    }
+
+
+def scan_nzb_episode(item: Dict, pool_tv: List[Dict],
+                     threshold: float, default_version: str,
+                     not_wanted_hashes: Optional[frozenset] = None) -> Optional[Dict]:
+    from database.zilean_upgrade import (
+        _get_version_settings, _score_results_with_current,
+        _item_size_gb, _item_filename, _is_upgrade,
+    )
+    current_filename = _item_filename(item)
+    if not current_filename:
+        return None
+
+    version = (item.get('version') or default_version).rstrip('*').strip()
+    vs = _get_version_settings(version)
+    season, episode = item.get('season_number'), item.get('episode_number')
+    if season is None or episode is None:
+        return None
+
+    title_candidates = _filter_pool_for_item(pool_tv, item['title'], item.get('year'))
+    candidates = _filter_pool_for_episode(title_candidates, season, episode)
+    if not candidates:
+        return None
+
+    current_score, candidate_scored = _score_results_with_current(
+        current_filename, candidates,
+        item['title'], item.get('year'), season, episode, 'episode', False, vs,
+        size_bytes=_item_size_gb(item),
+        genres_raw=item.get('genres') or '',
+    )
+    if not candidate_scored:
+        return None
+
+    candidate_scored = [
+        (s, r) for s, r in candidate_scored
+        if (r.get('parsed_info') or {}).get('episodes')
+        and episode in (r.get('parsed_info') or {}).get('episodes', [])
+    ]
+    if not candidate_scored:
+        return None
+
+    candidate_scored = [(s, r) for s, r in candidate_scored
+                        if not (r.get('title', '') or '').lower().startswith('www')]
+    if not_wanted_hashes:
+        from database.not_wanted_magnets import get_base_filename as _gh, normalize_title as _nt
+        candidate_scored = [(s, r) for s, r in candidate_scored
+                            if _gh(r.get('nzb_url', '') or r.get('magnet', '')) not in not_wanted_hashes
+                            and _nt(r.get('title', '')) not in not_wanted_hashes]
+    if not candidate_scored:
+        return None
+
+    current_size_gb = round(_item_size_gb(item), 2)
+    if current_size_gb > 0:
+        candidate_scored = [(s, r) for s, r in candidate_scored
+                            if float(r.get('size') or 0) >= current_size_gb]
+    if not candidate_scored:
+        return None
+
+    best_score, best_result = candidate_scored[0]
+    if not _is_upgrade(best_score, current_score, threshold):
+        return None
+
+    qualifying = [(s, r) for s, r in candidate_scored if _is_upgrade(s, current_score, threshold)][:3]
+    return {
+        'type': 'episode', 'item_id': item['id'], 'imdb_id': item['imdb_id'],
+        'title': item['title'], 'year': item.get('year'),
+        'season': season, 'episode': episode, 'version': version,
+        'current_score': round(current_score, 2), 'new_score': round(best_score, 2),
+        'improvement_pct': round((best_score - current_score) / max(abs(current_score), 1) * 100, 1),
+        'current_file': current_filename,
+        'current_protocol': 'nzb' if str(item.get('filled_by_torrent_id') or '').startswith('nzb:') else 'torrent',
+        'current_size_gb': current_size_gb,
+        'new_title': best_result.get('title', ''), 'new_size_gb': best_result.get('size', 0),
+        'new_magnet': best_result.get('nzb_url', '') or best_result.get('magnet', ''),
+        'protocol': 'nzb',
+        '_alts': qualifying,
+        '_phalanx_only': False,
+    }
+
+
+def scan_nzb_season_pack(imdb_id: str, season_num: int, season_eps: List[Dict],
+                          pool_tv: List[Dict], pack_threshold: float,
+                          default_version: str,
+                          not_wanted_hashes: Optional[frozenset] = None) -> Optional[Dict]:
+    from database.zilean_upgrade import (
+        _get_version_settings, _score_results_with_current,
+        _item_size_gb, _item_filename, _is_upgrade, _is_single_season_pack,
+    )
+    from database.core import get_db_connection
+
+    conn = get_db_connection()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM media_items WHERE imdb_id=? AND season_number=? AND type='episode'",
+            (imdb_id, season_num),
+        ).fetchone()
+        total_in_db = row[0] if row else 0
+    finally:
+        conn.close()
+    if total_in_db == 0:
+        return None
+    ratio = len(season_eps) / total_in_db
+    if ratio < pack_threshold:
+        return None
+
+    sample = season_eps[0]
+    current_filename = _item_filename(sample)
+    if not current_filename:
+        return None
+
+    version = (sample.get('version') or default_version).rstrip('*').strip()
+    vs = _get_version_settings(version)
+
+    title_candidates = _filter_pool_for_item(pool_tv, sample['title'], sample.get('year'))
+    pack_results = _filter_pool_for_pack(title_candidates, season_num)
+    if not pack_results:
+        return None
+
+    current_score, scored_candidates = _score_results_with_current(
+        current_filename, pack_results,
+        sample['title'], sample.get('year'),
+        season_num, None, 'episode', True, vs,
+        size_bytes=_item_size_gb(sample),
+        genres_raw=sample.get('genres') or '',
+    )
+    if not scored_candidates:
+        return None
+
+    scored_candidates = [(s, r) for s, r in scored_candidates
+                         if _is_single_season_pack(r.get('title', ''), season_num)]
+    scored_candidates = [(s, r) for s, r in scored_candidates
+                         if not (r.get('title', '') or '').lower().startswith('www')]
+    if not_wanted_hashes:
+        from database.not_wanted_magnets import get_base_filename as _gh, normalize_title as _nt
+        scored_candidates = [(s, r) for s, r in scored_candidates
+                             if _gh(r.get('nzb_url', '') or r.get('magnet', '')) not in not_wanted_hashes
+                             and _nt(r.get('title', '')) not in not_wanted_hashes]
+    if not scored_candidates:
+        return None
+
+    best_score, best_result = scored_candidates[0]
+    improvement_pct = round((best_score - current_score) / max(abs(current_score), 1) * 100, 1)
+    return {
+        'type': 'season_pack', 'imdb_id': imdb_id,
+        'title': sample['title'], 'year': sample.get('year'),
+        'season': season_num, 'collected_count': len(season_eps),
+        'total_count': total_in_db, 'ratio_pct': round(ratio * 100, 1),
+        'item_ids': [ep['id'] for ep in season_eps], 'version': version,
+        'current_score': round(current_score, 2), 'best_score': round(best_score, 2),
+        'improvement_pct': improvement_pct,
+        'current_size_gb': round(sum(_item_size_gb(ep) for ep in season_eps), 2),
+        'current_protocol': 'nzb' if str(sample.get('filled_by_torrent_id') or '').startswith('nzb:') else 'torrent',
+        'new_title': best_result.get('title', ''), 'new_size_gb': best_result.get('size', 0),
+        'new_magnet': best_result.get('nzb_url', '') or best_result.get('magnet', ''),
+        'protocol': 'nzb',
+        '_alts': scored_candidates[:3],
+        '_phalanx_only': False,
+        'current_files': sorted([
+            {'ep': ep.get('episode_number') or ep.get('episode') or 0,
+             'file': _item_filename(ep)}
+            for ep in season_eps
+        ], key=lambda x: x['ep']),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main NZB scan entry point
+# ---------------------------------------------------------------------------
+
+def scan_nzb_upgrades(
+    movies: List[Dict],
+    episodes: List[Dict],
+    season_groups: Dict,
+    threshold: float,
+    pack_threshold: float,
+    default_version: str,
+    not_wanted_hashes: frozenset,
+    max_workers: int = 20,
+    progress_callback=None,
+) -> Tuple[List[Dict], List[Dict]]:
+    """
+    Fetch latest NZBs once (bulk pool), then score each library item against
+    matching candidates using title+year filtering.
+    """
+    scrapers = get_newznab_scrapers()
+    if not scrapers:
+        logger.info('[NZB_UPGRADE] No enabled Newznab scrapers — skipping NZB scan')
+        return [], []
+
+    logger.info(f'[NZB_UPGRADE] Fetching NZB pool from {len(scrapers)} indexer(s)…')
+    pool = fetch_nzb_pool(scrapers, max_items=1000)
+    pool_movie = pool.get('movie', [])
+    pool_tv    = pool.get('tv', [])
+
+    if not pool_movie and not pool_tv:
+        logger.info('[NZB_UPGRADE] NZB pool empty — skipping NZB scan')
+        return [], []
+
+    upgrade_candidates: List[Dict] = []
+    pack_candidates:    List[Dict] = []
+    total = len(movies) + len(episodes) + len(season_groups)
+    futures: Dict = {}
+
+    with ThreadPoolExecutor(max_workers=min(max_workers, max(1, total))) as pool_ex:
+        for m in movies:
+            f = pool_ex.submit(scan_nzb_movie, m, pool_movie, threshold,
+                               default_version, not_wanted_hashes)
+            futures[f] = ('movie', m)
+        for ep in episodes:
+            f = pool_ex.submit(scan_nzb_episode, ep, pool_tv, threshold,
+                               default_version, not_wanted_hashes)
+            futures[f] = ('episode', ep)
+        for (imdb_id, season_num), eps in season_groups.items():
+            f = pool_ex.submit(scan_nzb_season_pack, imdb_id, season_num, eps,
+                               pool_tv, pack_threshold, default_version, not_wanted_hashes)
+            futures[f] = ('pack', (imdb_id, season_num))
+
+        done = 0
+        for future in as_completed(futures):
+            ftype, item = futures[future]
+            try:
+                r = future.result()
+                if r:
+                    if ftype == 'pack':
+                        pack_candidates.append(r)
+                    else:
+                        upgrade_candidates.append(r)
+            except Exception as e:
+                logger.debug(f'[NZB_UPGRADE] Worker error ({ftype}): {e}')
+            done += 1
+            if progress_callback:
+                progress_callback(done, total)
+
+    logger.info(f'[NZB_UPGRADE] Scan complete: {len(upgrade_candidates)} upgrade(s), '
+                f'{len(pack_candidates)} pack(s)')
+    return upgrade_candidates, pack_candidates

--- a/database/plex_collections.py
+++ b/database/plex_collections.py
@@ -32,6 +32,9 @@ logger = logging.getLogger(__name__)
 # ── State file ────────────────────────────────────────────────────────────────
 _STATE_FILE = os.path.join(os.environ.get('USER_CONFIG', '/user/config'), 'plex_collection_state.json')
 _state_lock = threading.Lock()
+# Serialises DB writes from concurrent collection-sync threads so SQLite's
+# exclusive write lock is never contested by two threads simultaneously.
+_db_write_lock = threading.Lock()
 
 # ── In-process caches ─────────────────────────────────────────────────────────
 _machine_id_cache: Optional[str] = None
@@ -601,19 +604,20 @@ def _get_sync_state(source_id: str) -> dict:
 
 
 def _save_sync_state(source_id: str, movie_rk: Optional[str], show_rk: Optional[str], fingerprint: str, sort_option: str = 'default') -> None:
-    conn = get_db_connection()
-    try:
-        conn.execute(
-            """INSERT OR REPLACE INTO plex_collection_sync
-               (source_id, movie_collection_ratingkey, show_collection_ratingkey, last_fingerprint, last_synced_at, sort_option)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (source_id, movie_rk, show_rk, fingerprint,
-             datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
-             sort_option)
-        )
-        conn.commit()
-    finally:
-        conn.close()
+    with _db_write_lock:
+        conn = get_db_connection()
+        try:
+            conn.execute(
+                """INSERT OR REPLACE INTO plex_collection_sync
+                   (source_id, movie_collection_ratingkey, show_collection_ratingkey, last_fingerprint, last_synced_at, sort_option)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (source_id, movie_rk, show_rk, fingerprint,
+                 datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
+                 sort_option)
+            )
+            conn.commit()
+        finally:
+            conn.close()
 
 
 def _get_ratingkey_for_section(source_id: str, section_key: str, lib_type: str) -> Optional[str]:
@@ -629,15 +633,16 @@ def _get_ratingkey_for_section(source_id: str, section_key: str, lib_type: str) 
 
 
 def _save_ratingkey_for_section(source_id: str, section_key: str, lib_type: str, ratingkey: Optional[str]) -> None:
-    conn = get_db_connection()
-    try:
-        conn.execute(
-            "INSERT OR REPLACE INTO plex_collection_sync_libraries (source_id, section_key, lib_type, ratingkey) VALUES (?,?,?,?)",
-            (source_id, section_key, lib_type, ratingkey)
-        )
-        conn.commit()
-    finally:
-        conn.close()
+    with _db_write_lock:
+        conn = get_db_connection()
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO plex_collection_sync_libraries (source_id, section_key, lib_type, ratingkey) VALUES (?,?,?,?)",
+                (source_id, section_key, lib_type, ratingkey)
+            )
+            conn.commit()
+        finally:
+            conn.close()
 
 
 # ── Main sync ─────────────────────────────────────────────────────────────────

--- a/database/plex_smart_collections.py
+++ b/database/plex_smart_collections.py
@@ -184,8 +184,10 @@ def apply_smart_collection_posters() -> None:
             )
 
             if poster_bytes:
-                upload_collection_poster(plex_url, plex_token, rk, poster_bytes)
+                upload_hash = upload_collection_poster(plex_url, plex_token, rk, poster_bytes)
                 any_uploaded = True
+                if upload_hash:
+                    state.setdefault('plex_upload_hashes', {})[rk] = upload_hash
                 logger.info(f"[SmartCollections] Poster applied for '{collection_name}' (rk={rk})")
             else:
                 logger.warning(f"[SmartCollections] Poster render returned None for '{collection_name}'")
@@ -258,6 +260,7 @@ def reapply_single_collection_poster(rating_key: str) -> dict:
         # Force re-render on next task run by clearing shared hash
         state = _migrate_state(_load_state())
         state.setdefault('shared', {})['poster_hash'] = ''
+        state.setdefault('plex_upload_hashes', {})[rating_key] = upload_hash
         _save_state(state)
         logger.info(f"[SmartCollections] Force-reapplied poster for '{collection_name}' (rk={rating_key})")
         return {'success': True, 'message': f"Poster applied for '{collection_name}'"}

--- a/database/schema_management.py
+++ b/database/schema_management.py
@@ -780,6 +780,40 @@ def migrate_schema():
             )
         ''')
 
+        # ── One-time cleanup: clear scrape_results for terminal states ──────────
+        # scrape_results is only needed while an item is being added/checked.
+        # For Collected/Blacklisted/Ghostlisted/Unreleased items it accumulates
+        # indefinitely and can grow to several GB. Clear it once and prevent
+        # future growth via collected_items.py (scrape_results = NULL on collect).
+        try:
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_cleanup_flags'")
+            if not cursor.fetchone():
+                conn.execute('''
+                    CREATE TABLE schema_cleanup_flags (
+                        flag TEXT PRIMARY KEY,
+                        applied_at TEXT NOT NULL
+                    )
+                ''')
+            cursor.execute("SELECT 1 FROM schema_cleanup_flags WHERE flag='clear_scrape_results_terminal_states'")
+            if not cursor.fetchone():
+                logging.info("[Migration] Clearing scrape_results for terminal-state items (one-time cleanup)...")
+                cur = conn.execute("""
+                    UPDATE media_items SET scrape_results = NULL
+                    WHERE scrape_results IS NOT NULL
+                      AND scrape_results != ''
+                      AND state IN ('Collected', 'Blacklisted', 'Ghostlisted', 'Unreleased')
+                """)
+                logging.info(f"[Migration] Cleared scrape_results for {cur.rowcount} items.")
+                conn.execute(
+                    "INSERT INTO schema_cleanup_flags (flag, applied_at) VALUES ('clear_scrape_results_terminal_states', datetime('now'))"
+                )
+                conn.commit()
+                logging.info("[Migration] Running VACUUM to reclaim disk space...")
+                conn.execute("VACUUM")
+                logging.info("[Migration] VACUUM complete.")
+        except Exception as _ce:
+            logging.warning(f"[Migration] scrape_results cleanup failed: {_ce}")
+
         logging.info("Attempting to commit schema migrations...")
         conn.commit()
         logging.info("Schema migrations committed successfully.")

--- a/database/zilean_upgrade.py
+++ b/database/zilean_upgrade.py
@@ -420,6 +420,11 @@ def _get_db_config(zilean_settings: Dict) -> Optional[Dict]:
     }
 
 
+def _item_filename(item: Dict) -> str:
+    """Return the best available filename for an item, falling back to location_basename."""
+    return (item.get('filled_by_file') or item.get('location_basename') or '')
+
+
 def _item_size_gb(item: Dict) -> float:
     """Return item size in GB: DB value if set, else stat location_on_disk, else 0."""
     db_size = float(item.get('size') or 0)
@@ -652,6 +657,19 @@ def _score_results_with_current(
     # rank_result_key() and are intentionally not hard gates.
     candidates = _apply_version_hard_filters(list(candidates), version_settings)
 
+    # Reject candidates that are the same release as the current file.
+    # Normalize by lowercasing and stripping non-alphanumeric chars so that
+    # minor formatting differences (dots vs spaces, .mkv suffix) don't create
+    # false upgrades against the exact same encode.
+    if filename:
+        import re as _re2
+        _strip = _re2.compile(r'[^a-z0-9]')
+        _norm_current = _strip.sub('', filename.lower())
+        candidates = [
+            r for r in candidates
+            if _strip.sub('', (r.get('title') or r.get('original_title') or '').lower()) != _norm_current
+        ]
+
     current_result = _make_current_result(filename, title, size_bytes=size_bytes,
                                           genres_raw=genres_raw) if filename else None
     pool = ([current_result] if current_result else []) + list(candidates)
@@ -736,12 +754,18 @@ def _pick_best_alt(alts: List[Tuple[float, Dict]], recent_days: int = 90) -> Tup
         if iat_str:
             try:
                 iat = datetime.fromisoformat(iat_str.replace('Z', '+00:00'))
-                if iat.tzinfo is None:
-                    iat = iat.replace(tzinfo=timezone.utc)
-                if iat >= cutoff:
-                    recent.append((s, r))
+            except (ValueError, TypeError):
+                try:
+                    from email.utils import parsedate_to_datetime as _p2dt
+                    iat = _p2dt(iat_str)
+                except Exception:
+                    continue
             except Exception:
-                pass
+                continue
+            if iat.tzinfo is None:
+                iat = iat.replace(tzinfo=timezone.utc)
+            if iat >= cutoff:
+                recent.append((s, r))
     if recent:
         best = max(recent, key=lambda x: x[0])
         return best[0], best[1], True
@@ -1042,9 +1066,12 @@ def _scan_movie(item: Dict, zilean_instance: str, zilean_settings: Dict,
             phalanx_only = True
     if not results:
         return None
+    current_filename = _item_filename(item)
+    if not current_filename:
+        return None  # no baseline to score against — skip to avoid false upgrades
     # Score current file and all candidates in the same pool with the same version settings.
     current_score, candidate_scored = _score_results_with_current(
-        item.get('filled_by_file') or '', results,
+        current_filename, results,
         item['title'], item.get('year'), None, None, 'movie', False, vs,
         size_bytes=_item_size_gb(item),
         genres_raw=item.get('genres') or '',
@@ -1077,7 +1104,8 @@ def _scan_movie(item: Dict, zilean_instance: str, zilean_settings: Dict,
         'title': item['title'], 'year': item.get('year'), 'version': version,
         'current_score': round(current_score, 2), 'new_score': round(best_score, 2),
         'improvement_pct': round((best_score - current_score) / max(abs(current_score), 1) * 100, 1),
-        'current_file': item.get('filled_by_file') or '',
+        'current_file': _item_filename(item),
+        'current_protocol': 'nzb' if str(item.get('filled_by_torrent_id') or '').startswith('nzb:') else 'torrent',
         'current_size_gb': current_size_gb,
         'new_title': best_result.get('title', ''), 'new_size_gb': best_result.get('size', 0),
         'new_magnet': best_result.get('magnet', ''),
@@ -1114,9 +1142,12 @@ def _scan_episode(item: Dict, zilean_instance: str, zilean_settings: Dict,
             phalanx_only = True
     if not results:
         return None
+    current_filename = _item_filename(item)
+    if not current_filename:
+        return None  # no baseline to score against — skip to avoid false upgrades
     # Score current file and all candidates in the same pool with the same version settings.
     current_score, candidate_scored = _score_results_with_current(
-        item.get('filled_by_file') or '', results,
+        current_filename, results,
         item['title'], item.get('year'), season, episode, 'episode', False, vs,
         size_bytes=_item_size_gb(item),
         genres_raw=item.get('genres') or '',
@@ -1160,7 +1191,8 @@ def _scan_episode(item: Dict, zilean_instance: str, zilean_settings: Dict,
         'season': season, 'episode': episode, 'version': version,
         'current_score': round(current_score, 2), 'new_score': round(best_score, 2),
         'improvement_pct': round((best_score - current_score) / max(abs(current_score), 1) * 100, 1),
-        'current_file': item.get('filled_by_file') or '',
+        'current_file': _item_filename(item),
+        'current_protocol': 'nzb' if str(item.get('filled_by_torrent_id') or '').startswith('nzb:') else 'torrent',
         'current_size_gb': current_size_gb,
         'new_title': best_result.get('title', ''), 'new_size_gb': best_result.get('size', 0),
         'new_magnet': best_result.get('magnet', ''),
@@ -1215,7 +1247,7 @@ def _scan_season_pack(imdb_id: str, season_num: int, season_eps: List[Dict],
     # Score sample episode's current file alongside pack candidates in the same pool,
     # so current_score is computed consistently (not read from stale DB column).
     current_score, scored_candidates = _score_results_with_current(
-        sample.get('filled_by_file') or '', pack_results,
+        _item_filename(sample), pack_results,
         sample['title'], sample.get('year'),
         season_num, None, 'episode', True, vs,
         size_bytes=_item_size_gb(sample),
@@ -1248,13 +1280,14 @@ def _scan_season_pack(imdb_id: str, season_num: int, season_eps: List[Dict],
         'current_score': round(current_score, 2), 'best_score': round(best_score, 2),
         'improvement_pct': improvement_pct,
         'current_size_gb': round(sum(_item_size_gb(ep) for ep in season_eps), 2),
+        'current_protocol': 'nzb' if str(sample.get('filled_by_torrent_id') or '').startswith('nzb:') else 'torrent',
         'new_title': best_result.get('title', ''), 'new_size_gb': best_result.get('size', 0),
         'new_magnet': best_result.get('magnet', ''),
         '_alts': scored_candidates[:3],
         '_phalanx_only': phalanx_only,
         'current_files': sorted([
             {'ep': ep.get('episode_number') or ep.get('episode') or 0,
-             'file': ep.get('filled_by_file') or ''}
+             'file': _item_filename(ep)}
             for ep in season_eps
         ], key=lambda x: x['ep']),
     }
@@ -1315,6 +1348,10 @@ def scan_for_upgrades(max_workers: int = 20, scan_limit: Optional[int] = None,
         threshold = float(get_setting('Scraping', 'upgrading_percentage_threshold', 0.1))
         pack_threshold = float(get_setting('Debug', 'zilean_pack_threshold', 0.5))
         default_version = get_default_version()
+        upgrade_source = get_setting('Upgrade Hub', 'upgrade_source', 'both') or 'both'
+        use_zilean = upgrade_source in ('both', 'zilean_only')
+        use_nzb    = upgrade_source in ('both', 'nzb_only')
+        logger.info(f'[UPGRADE_HUB] Upgrade source: {upgrade_source} (zilean={use_zilean}, nzb={use_nzb})')
 
         # Compute after_date if show_recent_only is enabled
         after_date = None
@@ -1326,8 +1363,8 @@ def scan_for_upgrades(max_workers: int = 20, scan_limit: Optional[int] = None,
 
         columns = ['id', 'type', 'imdb_id', 'title', 'year',
                    'season_number', 'episode_number', 'version',
-                   'current_score', 'filled_by_file', 'location_on_disk', 'state', 'genres', 'size',
-                   'filled_by_torrent_id']
+                   'current_score', 'filled_by_file', 'location_on_disk', 'location_basename',
+                   'state', 'genres', 'size', 'filled_by_torrent_id']
         all_collected = [
             dict(row) for row in get_all_media_items(state='Collected', columns=columns)
             if row['imdb_id']
@@ -1409,12 +1446,14 @@ def scan_for_upgrades(max_workers: int = 20, scan_limit: Optional[int] = None,
         unique_seasons = list(season_groups.items())
 
         # ── DB pre-fetch phase (single connection, bulk queries) ──────────────
+        if not use_zilean:
+            logger.info('[UPGRADE_HUB] Zilean disabled by upgrade_source setting — skipping Zilean phases')
         # All Zilean data is loaded before workers start. Workers receive
         # pre-built lists and do zero DB access → fully parallel scoring.
         movie_prefetch: Optional[Dict[str, List[Dict]]] = None   # imdb_id → results
         show_prefetch:  Optional[Dict[str, List[tuple]]] = None  # imdb_id → raw rows
 
-        if db_cfg:
+        if use_zilean and db_cfg:
             db_conn = None
             try:
                 import psycopg2
@@ -1461,7 +1500,7 @@ def scan_for_upgrades(max_workers: int = 20, scan_limit: Optional[int] = None,
         # Persistent cache: responses saved to SQLite, reused across restarts.
         # Smart invalidation: only re-fetch seasons where Zilean has new content.
         rest_season_cache: Dict[Tuple, List[Dict]] = {}
-        if not used_db and episodes:
+        if use_zilean and not used_db and episodes:
             # Load persisted REST cache from SQLite
             sqlite_rest_cache = _load_rest_cache_from_db(zilean_url)
             rest_season_cache = dict(sqlite_rest_cache)
@@ -1572,7 +1611,7 @@ def scan_for_upgrades(max_workers: int = 20, scan_limit: Optional[int] = None,
         # Separate from movies so their instant completion isn't mixed into
         # the REST-bound movie rate, which would corrupt the ETA.
         ep_pack_total = len(episodes) + len(unique_seasons)
-        if ep_pack_total > 0:
+        if use_zilean and ep_pack_total > 0:
             _scan_progress.update({'phase': 'scoring', 'done': 0, 'total': ep_pack_total})
             logger.info(f"[UPGRADE_HUB] Scoring {len(episodes)} episodes, "
                         f"{len(unique_seasons)} packs (CPU-only)…")
@@ -1628,7 +1667,7 @@ def scan_for_upgrades(max_workers: int = 20, scan_limit: Optional[int] = None,
 
         # ── Phase B: Scan movies (REST calls, I/O-bound) ──────────────────────
         # Separate phase so the ETA reflects only movie REST call speed.
-        if movies:
+        if use_zilean and movies:
             _scan_progress.update({'phase': 'scanning', 'done': 0, 'total': len(movies)})
             logger.info(f"[UPGRADE_HUB] Scanning {len(movies)} movies "
                         f"(DB={'yes' if used_db else 'no'}, workers={max_workers})…")
@@ -1651,6 +1690,64 @@ def scan_for_upgrades(max_workers: int = 20, scan_limit: Optional[int] = None,
                     with _state_lock:
                         _scan_progress['done'] = _scan_progress.get('done', 0) + 1
                         _scan_progress['errors'] = len(errors)
+
+        # ── Phase C: NZB indexer scan (all collected items vs latest NZBs) ──────
+        # Fetches latest NZBs from enabled Newznab indexers in browse mode,
+        # scores them with the same pipeline, and merges results.
+        # Runs for ALL collected items (both debrid and NZB items) so cross-
+        # protocol upgrades are possible (debrid→NZB and NZB→debrid via Zilean).
+        try:
+            from database.nzb_upgrade import scan_nzb_upgrades, get_newznab_scrapers
+            if use_nzb and get_newznab_scrapers():
+                logger.info('[UPGRADE_HUB] Starting NZB indexer scan phase…')
+                _scan_progress.update({'phase': 'nzb_scan', 'done': 0, 'total': len(movies) + len(episodes) + len(season_groups)})
+
+                def _nzb_progress(done, total):
+                    with _state_lock:
+                        _scan_progress['done'] = done
+
+                nzb_upgrades, nzb_packs = scan_nzb_upgrades(
+                    movies=movies,
+                    episodes=episodes,
+                    season_groups=dict(season_groups),
+                    threshold=threshold,
+                    pack_threshold=pack_threshold,
+                    default_version=default_version,
+                    not_wanted_hashes=_not_wanted_hashes,
+                    max_workers=max_workers,
+                    progress_callback=_nzb_progress,
+                )
+                # Merge: prefer whichever source gives the higher improvement_pct
+                # for the same item_id. New items with no Zilean result are added directly.
+                zilean_by_item = {c['item_id']: c for c in upgrade_candidates if 'item_id' in c}
+                for c in nzb_upgrades:
+                    iid = c.get('item_id')
+                    existing = zilean_by_item.get(iid)
+                    if existing is None:
+                        upgrade_candidates.append(c)
+                    elif c.get('improvement_pct', 0) > existing.get('improvement_pct', 0):
+                        upgrade_candidates.remove(existing)
+                        upgrade_candidates.append(c)
+
+                zilean_packs_by_key = {(p['imdb_id'], p['season']): p for p in pack_candidates}
+                for p in nzb_packs:
+                    key = (p.get('imdb_id'), p.get('season'))
+                    existing = zilean_packs_by_key.get(key)
+                    if existing is None:
+                        pack_candidates.append(p)
+                    elif p.get('improvement_pct', 0) > existing.get('improvement_pct', 0):
+                        pack_candidates.remove(existing)
+                        pack_candidates.append(p)
+
+                logger.info(f'[UPGRADE_HUB] After NZB merge: {len(upgrade_candidates)} upgrades, '
+                            f'{len(pack_candidates)} packs')
+        except Exception as _nzb_e:
+            logger.warning(f'[UPGRADE_HUB] NZB scan phase failed: {_nzb_e}', exc_info=True)
+
+        # Tag protocol on all candidates so the UI can show NZB/Debrid badges
+        for c in upgrade_candidates + pack_candidates:
+            if 'protocol' not in c:
+                c['protocol'] = 'torrent'
 
         upgrade_candidates.sort(key=lambda x: -x.get('improvement_pct', 0))
         pack_candidates.sort(key=lambda x: -x.get('ratio_pct', 0))

--- a/debrid/__init__.py
+++ b/debrid/__init__.py
@@ -50,15 +50,21 @@ def _instantiate_provider(provider_name_raw: str, api_key: Optional[str] = None)
     return p
 
 
-def get_debrid_provider() -> DebridProvider:
-    """Return the primary configured debrid provider (singleton, backward-compatible)."""
+def get_debrid_provider() -> Optional[DebridProvider]:
+    """Return the primary configured debrid provider (singleton, backward-compatible).
+    Returns None if no debrid provider is configured (usenet-only setup)."""
     global _provider_instance
     if _provider_instance is not None:
         return _provider_instance
     ensure_settings_file()
     provider_name_raw = get_setting("Debrid Provider", "provider", "")
-    _provider_instance = _instantiate_provider(provider_name_raw)
-    return _provider_instance
+    if not provider_name_raw or not provider_name_raw.strip():
+        return None
+    try:
+        _provider_instance = _instantiate_provider(provider_name_raw)
+        return _provider_instance
+    except ValueError:
+        return None
 
 
 def get_debrid_providers() -> List[DebridProvider]:

--- a/overlays/scheduled_tasks.py
+++ b/overlays/scheduled_tasks.py
@@ -2754,6 +2754,28 @@ def task_overlay_cleanup(triggered_by: str = 'scheduled'):
                     _plex_token = _gs('Plex', 'token', '')
                     if _plex_url and _plex_token:
                         _headers = {'X-Plex-Token': _plex_token, 'Accept': 'application/json'}
+
+                        # Build a protected set from state files — these hashes must never
+                        # be deleted even if Plex has reset its selected poster back to its
+                        # own auto-generated one (which causes false-positive deletion of
+                        # our still-valid uploaded poster).
+                        _state_protected_hashes = set()
+                        try:
+                            import json as _cpjson
+                            _cp_state_path = os.path.join(
+                                os.environ.get('USER_CONFIG', '/user/config'), 'plex_collection_state.json'
+                            )
+                            if os.path.exists(_cp_state_path):
+                                with open(_cp_state_path, 'r') as _cpf:
+                                    _cp_state = _cpjson.load(_cpf)
+                                for _cpe in _cp_state.values():
+                                    if isinstance(_cpe, dict):
+                                        for _cph in _cpe.get('plex_upload_hashes', {}).values():
+                                            if _cph:
+                                                _state_protected_hashes.add(_cph)
+                        except Exception as _csp_e:
+                            logger.debug(f"Collection poster cleanup: state file read error: {_csp_e}")
+
                         _cconn = _get_coll_db()
                         _rks = []
                         try:
@@ -2802,6 +2824,11 @@ def task_overlay_cleanup(triggered_by: str = 'scheduled'):
                                     # Skip if this hash is the selected poster for any other ratingKey
                                     if _chash in _selected_hashes:
                                         continue
+                                    # Skip if this hash is tracked in the state file — Plex may have
+                                    # temporarily reset to its own poster but our upload is still valid
+                                    if _chash in _state_protected_hashes:
+                                        logger.debug(f"Collection poster cleanup: skipping state-protected hash {_chash} (rk={_rk})")
+                                        continue
                                     # Delete via filesystem — same approach as media overlay cleanup
                                     _cpat = os.path.join(
                                         _coll_plex_data, 'Metadata', '*', '*', '*.bundle',
@@ -2837,6 +2864,9 @@ def task_overlay_cleanup(triggered_by: str = 'scheduled'):
                     _sc_collections = _sc_state.get('collections', {})
                     _sc_plex_url = get_setting('Plex', 'url', '').rstrip('/')
                     _sc_token = get_setting('Plex', 'token', '')
+                    # Hashes stored when posters were last uploaded — never delete these
+                    _sc_protected_hashes = set(_sc_state.get('plex_upload_hashes', {}).values())
+
                     if _sc_plex_url and _sc_token and _sc_collections:
                         _sc_headers = {'X-Plex-Token': _sc_token, 'Accept': 'application/json'}
                         import glob as _scglob
@@ -2854,6 +2884,9 @@ def task_overlay_cleanup(triggered_by: str = 'scheduled'):
                                         continue
                                     _schash = _scpk[len('upload://posters/'):]
                                     if not _schash:
+                                        continue
+                                    if _schash in _sc_protected_hashes:
+                                        logger.debug(f"Smart collection poster cleanup: skipping state-protected hash {_schash} (rk={_sc_rk})")
                                         continue
                                     _scpat = os.path.join(
                                         _sc_plex_data, 'Metadata', '*', '*', '*.bundle',

--- a/queues/adding_queue.py
+++ b/queues/adding_queue.py
@@ -20,13 +20,12 @@ class AddingQueue:
     
     def __init__(self):
         """Initialize the queue manager"""
-        self.debrid_provider = get_debrid_provider()
+        self.debrid_provider = get_debrid_provider()  # May be None for usenet-only setups
         self.torrent_processor = TorrentProcessor(self.debrid_provider)
         self.media_matcher = MediaMatcher(relaxed_matching=get_setting('Matching', 'relaxed_matching', False))
         self.items: List[Dict] = []
         self.last_process_time = {}
-        # logging.info("Initialized AddingQueue")
-        
+
     def reinitialize_provider(self):
         """Reinitialize the debrid provider and processors"""
         self.debrid_provider = get_debrid_provider()

--- a/queues/checking_queue.py
+++ b/queues/checking_queue.py
@@ -75,7 +75,7 @@ class CheckingQueue:
             cls._instance.items = []
             cls._instance.checking_queue_times = {}
             cls._instance.progress_checks = {}
-            cls._instance.debrid_provider = get_debrid_provider()
+            cls._instance.debrid_provider = get_debrid_provider()  # May be None for usenet-only setups
             cls._instance.uncached_torrents = {}  # Dict of {torrent_hash: {last_check_time, item_ids[]}}
             cls._instance.unknown_strikes = {} # Tracks consecutive unknown states for torrents
         return cls._instance
@@ -83,7 +83,7 @@ class CheckingQueue:
     def __init__(self):
         # __init__ will be called every time, but instance is already created
         self.items = []
-        self.debrid_provider = get_debrid_provider()
+        self.debrid_provider = get_debrid_provider()  # May be None for usenet-only setups
         self.checking_times = {}
         self.last_check_time = datetime.now()
         self.last_report_time = datetime.now()

--- a/queues/pending_uncached_queue.py
+++ b/queues/pending_uncached_queue.py
@@ -12,7 +12,7 @@ from .media_matcher import MediaMatcher
 class PendingUncachedQueue:
     def __init__(self):
         self.items = []
-        self.debrid_provider = get_debrid_provider()
+        self.debrid_provider = get_debrid_provider()  # May be None for usenet-only setups
         self.adding_queue = AddingQueue()
         self.torrent_processor = TorrentProcessor(self.debrid_provider)
         self.media_matcher = MediaMatcher()

--- a/queues/upgrading_queue.py
+++ b/queues/upgrading_queue.py
@@ -779,11 +779,17 @@ class UpgradingQueue:
                         logging.info(f"[{item_identifier}] Hub candidate score: stored={pre_candidate.get('new_score', 0):.2f} recalc={_recalc:.2f} using={_hub_new_score:.2f}")
                 except Exception as _e:
                     logging.debug(f"[{item_identifier}] Hub candidate score recalc failed: {_e}")
-                results = [{
+                _cand_protocol = pre_candidate.get('protocol', 'torrent')
+                _cand_magnet   = pre_candidate.get('new_magnet', '')
+                _cand_result = {
                     'title': pre_candidate.get('new_title', ''),
-                    'magnet': pre_candidate.get('new_magnet', ''),
+                    'magnet': _cand_magnet,
                     'score_breakdown': {'total_score': _hub_new_score},
-                }]
+                }
+                if _cand_protocol == 'nzb':
+                    _cand_result['protocol'] = 'nzb'
+                    _cand_result['nzb_url']  = _cand_magnet
+                results = [_cand_result]
                 filtered_out = []
                 # Hub-queued items bypass not_wanted check — user explicitly chose this torrent
                 _skip_not_wanted = True
@@ -964,6 +970,15 @@ class UpgradingQueue:
                 # We might want to pass the best_result score explicitly if AddingQueue needs it immediately
                 # For now, assume AddingQueue recalculates or uses scrape_results
 
+                # If the current item was collected via NZB, clear filled_by_torrent_id
+                # before passing to AddingQueue. Otherwise the health check loop in
+                # adding_queue sees the old nzb:<job_id>, finds it complete in Decypharr,
+                # and moves straight to Checking without ever submitting the new NZB.
+                _original_torrent_id = str(item.get('filled_by_torrent_id') or '')
+                if _original_torrent_id.startswith('nzb:'):
+                    from database.database_writing import update_media_item as _umi
+                    _umi(item['id'], filled_by_torrent_id=None)
+
                 update_media_item_state(item['id'], **update_data)
                 updated_item = get_media_item_by_id(item['id']) # Reload item with updated state
 
@@ -992,15 +1007,51 @@ class UpgradingQueue:
                 # Check final state after AddingQueue processing
                 from database.core import get_db_connection
                 conn = get_db_connection()
-                cursor = conn.execute('SELECT state FROM media_items WHERE id = ?', (item['id'],))
-                current_state_after_add = cursor.fetchone()['state']
+                row = conn.execute('SELECT state, filled_by_torrent_id FROM media_items WHERE id = ?', (item['id'],)).fetchone()
+                current_state_after_add = row['state']
+                _new_torrent_id = str(row['filled_by_torrent_id'] or '')
+                # A NEW NZB job was submitted if the torrent ID changed to a new nzb: value
+                # (covers both: previously torrent item now upgrading via NZB, and
+                #  previously NZB item upgrading to a different NZB job)
+                _nzb_submitted = (
+                    _new_torrent_id.startswith('nzb:') and
+                    _new_torrent_id != _original_torrent_id
+                )
                 conn.close()
 
-                if current_state_after_add == 'Checking':
-                    logging.info(f"Successfully initiated upgrade for item {item_identifier}. Item moved to Checking.")
+                # Success conditions:
+                #   Debrid: state moves to 'Checking' (torrent added to debrid service)
+                #   NZB:    state stays 'Adding' while Decypharr polls, but filled_by_torrent_id
+                #           changed to a new 'nzb:<job_id>' confirming the job was submitted
+                _upgrade_succeeded = (
+                    current_state_after_add == 'Checking' or
+                    (current_state_after_add == 'Adding' and _nzb_submitted)
+                )
+                if _upgrade_succeeded:
+                    logging.info(f"Successfully initiated upgrade for item {item_identifier}. Item moved to {current_state_after_add}.")
 
-                    # Update item data with the successful upgrade details, including the NEW score
-                    self.update_item_with_upgrade(item, adding_queue, best_result) # Pass best_result to get score
+                    # For NZB upgrades the adding_queue already set the correct state ('Adding'),
+                    # filled_by_torrent_id ('nzb:<job_id>'), and filled_by_file (nzb job name).
+                    # update_item_with_upgrade would overwrite state to 'Checking' and clobber
+                    # those values — skip it and just record upgrading_from + score directly.
+                    if _nzb_submitted:
+                        try:
+                            new_score = best_result.get('score_breakdown', {}).get('total_score', 0)
+                            upgrading_from = item.get('filled_by_file') or ''
+                            conn2 = get_db_connection()
+                            conn2.execute(
+                                "UPDATE media_items SET upgrading_from=?, current_score=?, upgraded=1, upgrading=0, upgrading_from_torrent_id=?, upgrading_from_version=? WHERE id=?",
+                                (upgrading_from, new_score, item.get('filled_by_torrent_id'), item.get('version'), item['id'])
+                            )
+                            conn2.commit()
+                            conn2.close()
+                            item['upgrading_from'] = upgrading_from
+                            item['current_score'] = new_score
+                        except Exception as _ue:
+                            logging.warning(f"[{item_identifier}] NZB upgrade DB update failed: {_ue}")
+                    else:
+                        # Update item data with the successful upgrade details, including the NEW score
+                        self.update_item_with_upgrade(item, adding_queue, best_result)
 
                     # Log success, record tracking etc. (combine logic from original code)
                     self.log_upgrade(item, adding_queue) # Needs updated item dict after update_item_with_upgrade?
@@ -1083,9 +1134,10 @@ class UpgradingQueue:
                     self.remove_item(item)
 
                 else:
+                    _protocol_label = 'NZB' if best_result.get('protocol') == 'nzb' else 'Torrent'
                     _failure_reason = (updated_item.get('_upgrade_failure_reason') or
                                        item.get('_upgrade_failure_reason') or
-                                       f'Torrent not added — tried: {best_result.get("title", "?")} (state: {current_state_after_add})')
+                                       f'{_protocol_label} not added — tried: {best_result.get("title", "?")} (state: {current_state_after_add})')
                     logging.warning(f"Failed to upgrade item {item_identifier} - {_failure_reason}")
                     from routes.notifications import send_upgrade_failed_notification
                     notification_data = {

--- a/routes/api_tracker.py
+++ b/routes/api_tracker.py
@@ -148,7 +148,7 @@ class APITracker:
         self.current_url = None
         self._args = None
         self.rate_limiter = APIRateLimiter()
-        self.monitored_domains = {'api.real-debrid.com', 'api.alldebrid.com', 'api.trakt.tv', 'torrentio.strem.fun'}
+        self.monitored_domains = {'api.real-debrid.com', 'api.alldebrid.com', 'api.trakt.tv', 'torrentio.strem.fun', 'api.themoviedb.org'}
 
     @property
     def args(self):

--- a/routes/debrid_manager_routes.py
+++ b/routes/debrid_manager_routes.py
@@ -567,6 +567,39 @@ def api_plex_trash_items():
         elif stable is None and rd_is_loading:
             rd_library_status = 'loading'
 
+        # ── NZB / Usenet — DB lookup (must run before all_files pops) ──────────
+        _usenet_candidates = {}
+        try:
+            import json as _srj2
+            from database.core import get_db_connection as _get_dbc2
+            _uconn2 = _get_dbc2()
+            for _item in unique_items:
+                _lt = (_item.get('show_title') or _item.get('title', '')).strip()
+                _urow = _uconn2.execute(
+                    "SELECT id, filled_by_torrent_id, filled_by_title, scrape_results "
+                    "FROM media_items WHERE title = ? AND filled_by_torrent_id LIKE 'nzb:%' "
+                    "ORDER BY rowid DESC LIMIT 1", (_lt,)
+                ).fetchone()
+                if _urow:
+                    _uid, _ufbt, _ufbt_title, _usr = _urow
+                    _ujob_id = _ufbt[4:] if _ufbt and _ufbt.startswith('nzb:') else ''
+                    _unzb_url = ''
+                    if _usr:
+                        try:
+                            _usl = _srj2.loads(_usr) if isinstance(_usr, str) else _usr
+                            if _usl:
+                                _unzb_url = _usl[0].get('nzb_url') or _usl[0].get('magnet', '')
+                        except Exception:
+                            pass
+                    _item['nzb_job_id'] = _ujob_id
+                    _item['nzb_title'] = _ufbt_title or ''
+                    _item['nzb_url'] = _unzb_url
+                    _item['nzb_item_id'] = _uid
+                    _usenet_candidates[_item['rating_key']] = _item
+            _uconn2.close()
+        except Exception as _upe:
+            logging.debug(f"[PlexTrash] Usenet pre-match error: {_upe}")
+
         in_rd = []
         not_in_rd = []
         if stable:
@@ -677,6 +710,57 @@ def api_plex_trash_items():
             for item in not_in_rd:
                 item.pop('all_files', None)
 
+            # Good/bad file detection for usenet items — same logic as debrid in_rd
+            # Metadata fetch for single-file usenet items to discover additional versions
+            for _ui in list(_usenet_candidates.values()):
+                if len(_ui.get('all_files') or []) <= 1 and _ui.get('rating_key'):
+                    try:
+                        _mr2 = requests.get(
+                            f'{plex_url}/library/metadata/{_ui["rating_key"]}',
+                            headers=headers, timeout=5
+                        )
+                        _meta2 = ET.fromstring(_mr2.text)
+                        _existing2 = set(_ui.get('all_files') or [])
+                        for _mv2 in _meta2.iter('Video'):
+                            for _me2 in _mv2.findall('Media'):
+                                _mid2 = _me2.get('id', '')
+                                for _pe2 in _me2.findall('Part'):
+                                    _fp2 = _pe2.get('file', '')
+                                    if _fp2 and _fp2 not in _existing2:
+                                        _ui.setdefault('all_files', []).append(_fp2)
+                                        _existing2.add(_fp2)
+                                        _bn2 = _os.path.basename(_fp2)
+                                        _pid2 = _pe2.get('id', '')
+                                        if _mid2 and _pid2 and _bn2 not in _ui.get('part_ids', {}):
+                                            _ui.setdefault('part_ids', {})[_bn2] = {'media_id': _mid2, 'part_id': _pid2}
+                    except Exception:
+                        pass
+
+            # Classify good/bad files for usenet items using same logic as debrid
+            for _ui in list(_usenet_candidates.values()):
+                _uall = _ui.pop('all_files', [])
+                _udel_set = set(_ui.pop('deleted_at_files', []))
+                if len(_uall) <= 1:
+                    continue
+                _uunmatched, _umatched = [], []
+                if _udel_set:
+                    for _ufp in _uall:
+                        (_uunmatched if _ufp in _udel_set else _umatched).append(_ufp)
+                else:
+                    # Fallback: the old file's folder won't match the new nzb_title
+                    _new_title_norm = _norm(_ui.get('nzb_title', ''))
+                    for _ufp in _uall:
+                        _ufn = _norm(_folder_from_path(_ufp))
+                        if _new_title_norm and _ufn and (_ufn in _new_title_norm or _new_title_norm.startswith(_ufn)):
+                            _umatched.append(_ufp)
+                        else:
+                            _uunmatched.append(_ufp)
+                if _uunmatched and _umatched:
+                    _ui['bad_file'] = _os.path.basename(_uunmatched[0])
+                    _ui['has_good_file'] = True
+                    _ui['good_file'] = _os.path.basename(_umatched[0])
+                    _ui['bad_file_orphaned'] = bool(_udel_set and _uunmatched[0] in _udel_set)
+
             # Title match count: how many RD entries share the same title+year
             for item in in_rd + not_in_rd:
                 title_norm = _norm(item.get('title', ''))
@@ -729,7 +813,24 @@ def api_plex_trash_items():
             except Exception as _me:
                 logging.debug(f"[PlexTrash] Magnet lookup error: {_me}")
 
-        result = {'in_rd': in_rd, 'not_in_rd': not_in_rd}
+        # ── NZB / Usenet — split into in/not lists, remove from debrid lists ────
+        # Usenet items must not appear in in_rd/not_in_rd — remove them and put
+        # them in the usenet-specific lists instead.
+        in_usenet = []
+        not_in_usenet = []
+        _usenet_rks = set(_usenet_candidates.keys())
+        # Only keep debrid-matched items in in_rd (usenet items should not appear there,
+        # but guard just in case a title matches both)
+        in_rd = [i for i in in_rd if i['rating_key'] not in _usenet_rks]
+        # Remove usenet items from not_in_rd so they don't show in the debrid tab
+        not_in_rd = [i for i in not_in_rd if i['rating_key'] not in _usenet_rks]
+        for _uitem in _usenet_candidates.values():
+            if _uitem.get('nzb_job_id'):
+                in_usenet.append(_uitem)
+            else:
+                not_in_usenet.append(_uitem)
+
+        result = {'in_rd': in_rd, 'not_in_rd': not_in_rd, 'in_usenet': in_usenet, 'not_in_usenet': not_in_usenet}
         _plex_trash_items_cache['items'] = result
         _plex_trash_items_cache['ts'] = time.time()
         return jsonify({'success': True, 'cached': False, 'rd_library_status': rd_library_status, **result})
@@ -1118,6 +1219,109 @@ def api_reinsert_torrent(torrent_id):
         return jsonify({'success': True, 'new_id': new_id})
     except Exception as e:
         logging.error(f"Debrid Manager reinsert error for {torrent_id}: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@debrid_manager_bp.route('/api/nzb/reinsert', methods=['POST'])
+@admin_required
+def api_nzb_reinsert():
+    """
+    Re-submit a Plex-trashed NZB item to Decypharr.
+
+    Step 1 — try the stored NZB URL from scrape_results.
+    Step 2 — if that fails, run a targeted re-scrape and submit the best result.
+
+    Body: { item_id: int, nzb_url: str, nzb_title: str, rating_key: str }
+    """
+    try:
+        data = request.get_json(force=True) or {}
+        item_id = data.get('item_id')
+        nzb_url = (data.get('nzb_url') or '').strip()
+        nzb_title = (data.get('nzb_title') or '').strip()
+        rating_key = data.get('rating_key', '')
+
+        if not item_id:
+            return jsonify({'success': False, 'error': 'item_id required'}), 400
+
+        from database.core import get_db_connection as _gdbc
+        conn = _gdbc()
+        row = conn.execute(
+            "SELECT id, title, year, type, imdb_id, tmdb_id, season_number, "
+            "episode_number, version, genres, filled_by_torrent_id, scrape_results "
+            "FROM media_items WHERE id = ?", (item_id,)
+        ).fetchone()
+        conn.close()
+        if not row:
+            return jsonify({'success': False, 'error': 'Item not found in database'}), 404
+
+        item = dict(zip(
+            ['id', 'title', 'year', 'type', 'imdb_id', 'tmdb_id', 'season_number',
+             'episode_number', 'version', 'genres', 'filled_by_torrent_id', 'scrape_results'],
+            row
+        ))
+
+        from usenet.decypharr_client import get_decypharr_client, reset_decypharr_client
+        reset_decypharr_client()
+        client = get_decypharr_client()
+
+        new_job_id = None
+        used_url = None
+        method = None
+        new_release_title = nzb_title  # updated if rescrape finds a different release
+
+        # ── Step 1: try stored NZB URL ──────────────────────────────────────
+        if nzb_url:
+            try:
+                import requests as _req
+                resp = _req.get(nzb_url, timeout=15, allow_redirects=True,
+                                headers={'User-Agent': 'Sabnzbd/3.0.0'})
+                if resp.status_code == 200 and '<nzb' in resp.text.lower():
+                    new_job_id = client.add_nzb_content(
+                        nzb_content=resp.text,
+                        title=nzb_title or item['title']
+                    )
+                    if new_job_id:
+                        used_url = nzb_url
+                        method = 'url'
+                        logging.info(f"[ReNZB] item={item_id} re-submitted via stored URL, job={new_job_id}")
+            except Exception as _e1:
+                logging.warning(f"[ReNZB] item={item_id} Step 1 failed: {_e1}")
+
+        # ── Step 2: fallback — re-scrape and submit best result ─────────────
+        if not new_job_id:
+            logging.info(f"[ReNZB] item={item_id} falling back to re-scrape")
+            try:
+                from usenet.repair_engine import _scrape_for_replacement, _submit_replacement, _update_db_for_repair
+                results = _scrape_for_replacement(item, broken_nzb_title=nzb_title)
+                if results:
+                    best = results[0]
+                    new_job_id = _submit_replacement(best, item['title'])
+                    if new_job_id:
+                        method = 'rescrape'
+                        new_release_title = best.get('title') or nzb_title
+                        used_url = best.get('nzb_url') or ''
+                        logging.info(f"[ReNZB] item={item_id} re-scraped and submitted, job={new_job_id}")
+                        _update_db_for_repair(item, new_job_id, best, results)
+                        _plex_trash_items_cache['items'] = None
+                        return jsonify({'success': True, 'job_id': new_job_id, 'method': method, 'new_release_title': new_release_title})
+            except Exception as _e2:
+                logging.error(f"[ReNZB] item={item_id} Step 2 failed: {_e2}", exc_info=True)
+
+        if not new_job_id:
+            return jsonify({'success': False, 'error': 'Failed to re-submit NZB — URL expired and re-scrape found no results'}), 502
+
+        # Update DB with new job ID (URL path — state stays Collected, just refresh torrent ID)
+        try:
+            from database.database_writing import update_media_item as _umi
+            _umi(item_id, filled_by_torrent_id=f'nzb:{new_job_id}', fall_back_to_single_scraper=False)
+        except Exception as _dbe:
+            logging.warning(f"[ReNZB] DB update failed for item {item_id}: {_dbe}")
+
+        _plex_trash_items_cache['items'] = None
+        return jsonify({'success': True, 'job_id': new_job_id, 'method': method, 'new_release_title': new_release_title})
+
+    except Exception as e:
+        logging.error(f"[ReNZB] Unexpected error: {e}", exc_info=True)
         return jsonify({'success': False, 'error': str(e)}), 500
 
 

--- a/routes/discover_routes.py
+++ b/routes/discover_routes.py
@@ -813,6 +813,7 @@ def trending():
         if entry and datetime.now() < entry['expires']:
             logging.debug(f"[Trending] Serving from cache ({cache_key})")
             return jsonify({'results': entry['data'], 'total_results': len(entry['data']), 'cached': True})
+        stale_entry = entry  # keep reference to serve as fallback on TMDB failure
 
         results = []
 
@@ -912,9 +913,12 @@ def trending():
             'total_results': len(results)
         })
 
-    except requests.exceptions.RequestException as e:
+    except (requests.exceptions.RequestException, ValueError) as e:
         logging.error(f"TMDB trending API error: {e}")
-        return jsonify({'error': 'Failed to fetch trending content'}), 500
+        if stale_entry:
+            logging.warning(f"[Trending] Serving stale cache for {cache_key} due to TMDB error")
+            return jsonify({'results': stale_entry['data'], 'total_results': len(stale_entry['data']), 'cached': True, 'stale': True})
+        return jsonify({'error': 'Failed to fetch trending content'}), 503
     except Exception as e:
         logging.error(f"Discover trending error: {e}")
         return jsonify({'error': 'Internal server error'}), 500

--- a/routes/library_routes.py
+++ b/routes/library_routes.py
@@ -1285,7 +1285,7 @@ def show_detail_data(media_id):
                         logging.info(f"Fetching TMDB ratings for show {tmdb_id} (to supplement Battery data)")
                     else:
                         logging.info(f"Fetching TMDB metadata for show {tmdb_id} (Battery unavailable)")
-                    details_response = requests.get(details_url)
+                    details_response = requests.get(details_url, timeout=15, headers={'Accept-Encoding': 'identity'})
                     details_response.raise_for_status()
                     details_data = details_response.json()
 
@@ -4553,7 +4553,7 @@ def movie_detail_data(media_id):
                 try:
                     details_url = f"https://api.themoviedb.org/3/movie/{tmdb_id}?api_key={tmdb_api_key}&language=en-US"
                     logging.info(f"Fetching TMDB metadata for movie {tmdb_id} (Battery fallback)")
-                    details_response = requests.get(details_url)
+                    details_response = requests.get(details_url, timeout=15, headers={'Accept-Encoding': 'identity'})
                     details_response.raise_for_status()
                     details_data = details_response.json()
 

--- a/routes/program_operation_routes.py
+++ b/routes/program_operation_routes.py
@@ -432,49 +432,86 @@ def check_service_connectivity():
             services_reachable = False
             failed_services_details.append({"service": "Plex", "type": "CONNECTION_ERROR", "status_code": None, "message": error_msg})
 
-    # Check Debrid Provider connectivity using provider interface
-    try:
-        from debrid import get_debrid_provider
-        provider = get_debrid_provider()
-        if hasattr(provider, 'check_connectivity'):
-            ok, error_detail = provider.check_connectivity()
-            if not ok:
-                services_reachable = False
-                failed_services_details.append(error_detail or {"service": "Debrid Provider API", "type": "CONNECTION_ERROR", "status_code": None, "message": "Connectivity check failed"})
-        else:
-            logging.info("Provider does not implement connectivity check; skipping provider connectivity validation.")
+    # Check provider connectivity — requires at least debrid OR usenet (Decypharr) to be configured
+    debrid_configured = bool(debrid_provider and debrid_api_key)
+    usenet_enabled = get_setting('Usenet Provider', 'enabled', False)
+    usenet_url = get_setting('Usenet Provider', 'url', '')
 
-        # Verify subscription days remaining > 0
+    if not debrid_configured and not usenet_enabled:
+        services_reachable = False
+        failed_services_details.append({
+            "service": "Provider",
+            "type": "NO_PROVIDER_CONFIGURED",
+            "message": "No provider configured — set up a Debrid provider or a Usenet provider (Decypharr) to continue"
+        })
+    elif debrid_configured:
+        # Check Debrid Provider connectivity
         try:
-            subscription_info = None
-            if hasattr(provider, 'get_subscription_status'):
-                subscription_info = provider.get_subscription_status()
-            if subscription_info is not None:
-                days_remaining = subscription_info.get('days_remaining')
-                premium = subscription_info.get('premium')
-                expiration = subscription_info.get('expiration')
-                logging.info(f"Debrid subscription status: days_remaining={days_remaining}, premium={premium}, expiration={expiration}")
-                if days_remaining is None or not isinstance(days_remaining, (int, float)) or days_remaining <= 0:
+            from debrid import get_debrid_provider
+            provider = get_debrid_provider()
+            if provider and hasattr(provider, 'check_connectivity'):
+                ok, error_detail = provider.check_connectivity()
+                if not ok:
                     services_reachable = False
-                    failed_services_details.append({
-                        "service": "Debrid Subscription",
-                        "type": "SUBSCRIPTION_EXPIRED",
-                        "message": f"Debrid subscription expired or invalid. days_remaining={days_remaining}, premium={premium}, expiration={expiration}"
-                    })
+                    failed_services_details.append(error_detail or {"service": "Debrid Provider API", "type": "CONNECTION_ERROR", "status_code": None, "message": "Connectivity check failed"})
             else:
-                logging.warning("Debrid subscription status unavailable from provider; skipping days remaining check")
-        except Exception as sub_err:
-            logging.error(f"Error checking Debrid subscription status: {sub_err}")
+                logging.info("Provider does not implement connectivity check; skipping provider connectivity validation.")
+
+            # Verify subscription days remaining > 0
+            try:
+                subscription_info = None
+                if provider and hasattr(provider, 'get_subscription_status'):
+                    subscription_info = provider.get_subscription_status()
+                if subscription_info is not None:
+                    days_remaining = subscription_info.get('days_remaining')
+                    premium = subscription_info.get('premium')
+                    expiration = subscription_info.get('expiration')
+                    logging.info(f"Debrid subscription status: days_remaining={days_remaining}, premium={premium}, expiration={expiration}")
+                    if days_remaining is None or not isinstance(days_remaining, (int, float)) or days_remaining <= 0:
+                        services_reachable = False
+                        failed_services_details.append({
+                            "service": "Debrid Subscription",
+                            "type": "SUBSCRIPTION_EXPIRED",
+                            "message": f"Debrid subscription expired or invalid. days_remaining={days_remaining}, premium={premium}, expiration={expiration}"
+                        })
+                else:
+                    logging.warning("Debrid subscription status unavailable from provider; skipping days remaining check")
+            except Exception as sub_err:
+                logging.error(f"Error checking Debrid subscription status: {sub_err}")
+                services_reachable = False
+                failed_services_details.append({
+                    "service": "Debrid Subscription",
+                    "type": "SUBSCRIPTION_CHECK_ERROR",
+                    "message": str(sub_err)
+                })
+        except Exception as e:
+            logging.error(f"Failed to perform provider connectivity check: {e}")
+            services_reachable = False
+            failed_services_details.append({"service": "Debrid Provider API", "type": "CONNECTION_ERROR", "status_code": None, "message": str(e)})
+
+    if usenet_enabled and usenet_url:
+        # Check Usenet (Decypharr) connectivity
+        try:
+            from routes.api_tracker import api as _usenet_api
+            _r = _usenet_api.get(f"{usenet_url.rstrip('/')}/version", timeout=10)
+            if _r.status_code != 200:
+                services_reachable = False
+                failed_services_details.append({
+                    "service": "Usenet Provider (Decypharr)",
+                    "type": "CONNECTION_ERROR",
+                    "status_code": _r.status_code,
+                    "message": f"Cannot reach Decypharr at {usenet_url} (HTTP {_r.status_code})"
+                })
+            else:
+                logging.info(f"Usenet provider (Decypharr) reachable at {usenet_url}")
+        except Exception as _ue:
             services_reachable = False
             failed_services_details.append({
-                "service": "Debrid Subscription",
-                "type": "SUBSCRIPTION_CHECK_ERROR",
-                "message": str(sub_err)
+                "service": "Usenet Provider (Decypharr)",
+                "type": "CONNECTION_ERROR",
+                "status_code": None,
+                "message": f"Cannot reach Decypharr at {usenet_url}: {_ue}"
             })
-    except Exception as e:
-        logging.error(f"Failed to perform provider connectivity check: {e}")
-        services_reachable = False
-        failed_services_details.append({"service": "Debrid Provider API", "type": "CONNECTION_ERROR", "status_code": None, "message": str(e)})
 
     # Check Metadata Battery connectivity and Trakt authorization
     try:
@@ -872,17 +909,21 @@ def check_program_conditions():
     required_settings = [
         ('Plex', 'url'),
         ('Plex', 'token'),
-        ('Debrid Provider', 'provider'),
-        ('Debrid Provider', 'api_key'),
         ('Metadata Battery', 'url')
     ]
-    
+
     missing_fields = []
     for category, key in required_settings:
         value = get_setting(category, key)
         if not value:
             missing_fields.append(f"{category}.{key}")
-    
+
+    # Require at least one of: Debrid Provider OR Usenet Provider (Decypharr)
+    debrid_ok = bool(get_setting('Debrid Provider', 'provider') and get_setting('Debrid Provider', 'api_key'))
+    usenet_ok = bool(get_setting('Usenet Provider', 'enabled') and get_setting('Usenet Provider', 'url'))
+    if not debrid_ok and not usenet_ok:
+        missing_fields.append("Debrid Provider or Usenet Provider")
+
     required_settings_complete = len(missing_fields) == 0
 
     return jsonify({

--- a/routes/scraper_routes.py
+++ b/routes/scraper_routes.py
@@ -486,10 +486,26 @@ def add_torrent_to_debrid():
             logging.error(error_message)
             return jsonify({'error': error_message}), 500
 
-        # Process the content
+        # Process the content — if files are empty (provider hasn't resolved yet),
+        # retry a few times before giving up. Debrid-Link in particular can return
+        # an empty files list immediately after add while it's still resolving the magnet.
         processor = ContentProcessor()
         success, message = processor.process_content(torrent_info)
-        
+
+        if not success and 'No files found' in message:
+            for _retry in range(4):
+                import time as _time
+                _time.sleep(3)
+                try:
+                    torrent_info = debrid_provider.get_torrent_info(torrent_id)
+                except Exception:
+                    pass
+                if torrent_info and torrent_info.get('files'):
+                    success, message = processor.process_content(torrent_info)
+                    if success:
+                        logging.info(f"Torrent files resolved on retry {_retry + 1}")
+                        break
+
         if not success:
             logging.error(f"Failed to process torrent content: {message}")
             return jsonify({'error': message}), 400

--- a/routes/upgrade_hub_routes.py
+++ b/routes/upgrade_hub_routes.py
@@ -43,8 +43,11 @@ def index():
 @admin_required
 def status():
     from database.zilean_upgrade import get_scan_status, get_last_results, get_zilean_config
+    from database.nzb_upgrade import get_newznab_scrapers
     s = get_scan_status()
     s['zilean_configured'] = get_zilean_config() is not None
+    s['nzb_configured'] = len(get_newznab_scrapers()) > 0
+    s['any_source_configured'] = s['zilean_configured'] or s['nzb_configured']
     results = get_last_results()
     if results and 'error' not in results:
         try:
@@ -67,13 +70,24 @@ def status():
 @admin_required
 def start_scan():
     from database.zilean_upgrade import scan_for_upgrades, get_scan_status, get_zilean_config
+    from database.nzb_upgrade import get_newznab_scrapers
 
     if get_scan_status()['in_progress']:
         return jsonify({'success': False, 'error': 'Scan already in progress'}), 409
 
-    if not get_zilean_config():
+    upgrade_source = get_setting('Upgrade Hub', 'upgrade_source', 'both') or 'both'
+    use_zilean = upgrade_source in ('both', 'zilean_only')
+    use_nzb    = upgrade_source in ('both', 'nzb_only')
+
+    if use_zilean and not use_nzb and not get_zilean_config():
         return jsonify({'success': False,
                         'error': 'Zilean scraper not enabled or URL not configured in Settings → Scrapers'}), 400
+    if use_nzb and not use_zilean and not get_newznab_scrapers():
+        return jsonify({'success': False,
+                        'error': 'No enabled Newznab indexers configured in Settings → Scrapers'}), 400
+    if not get_zilean_config() and not get_newznab_scrapers():
+        return jsonify({'success': False,
+                        'error': 'No upgrade sources configured. Enable Zilean or a Newznab indexer in Settings → Scrapers'}), 400
 
     scan_limit = get_setting('Upgrade Hub', 'scan_limit', None)
     if scan_limit is not None:
@@ -226,6 +240,7 @@ _SETTINGS_KEYS = {
     'recent_threshold_days': int,
     'excluded_genres': str,
     'exclude_nas_items': bool,
+    'upgrade_source': str,
 }
 _SETTINGS_DEFAULTS = {
     'min_improvement_threshold': 0,
@@ -238,6 +253,7 @@ _SETTINGS_DEFAULTS = {
     'recent_threshold_days': 90,
     'excluded_genres': '',
     'exclude_nas_items': False,
+    'upgrade_source': 'both',
 }
 
 

--- a/scraper/newznab.py
+++ b/scraper/newznab.py
@@ -1,5 +1,8 @@
+import hashlib
 import logging
 import re
+import threading
+import time
 import xml.etree.ElementTree as ET
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -11,10 +14,39 @@ from PTT import parse_title as ptt_parse
 from rapidfuzz import fuzz as _fuzz
 
 # Newznab category IDs
-_CAT_MOVIE = '2000'
-_CAT_TV    = '5000,5010,5020'  # TV All, TV Foreign, TV SD
+# Explicit subcategories are required — many indexers do not return subcategory
+# items when querying only the parent (e.g. 2000 won't return 2030/HD results
+# on all indexers). Include all common subcategories to maximise coverage.
+_CAT_MOVIE = '2000,2030,2040,2045,2050,2060'  # Movie All + HD, SD, UHD, BluRay, Foreign
+_CAT_TV    = '5000,5010,5020,5030,5040,5045,5060,5070'  # TV All + Foreign, SD, SD, HD, UHD, BluRay, Sport
 
-_SANITIZE_RE = re.compile(r'[!?:&,;"()\[\]{}]')
+_SANITIZE_RE = re.compile(r"[!?:&,;\"'()\[\]{}]")
+
+# Query result cache — reduces API hits for duplicate searches within TTL window
+_NZB_CACHE: Dict[str, tuple] = {}   # key -> (timestamp, results)
+_NZB_CACHE_LOCK = threading.Lock()
+_NZB_CACHE_TTL = 600  # 10 minutes
+
+
+def _cache_key(endpoint: str, params: dict) -> str:
+    params_no_key = {k: v for k, v in params.items() if k != 'apikey'}
+    stable = f"{endpoint}|{sorted(params_no_key.items())}"
+    return hashlib.sha256(stable.encode()).hexdigest()
+
+
+def _cache_get(key: str) -> Optional[List]:
+    with _NZB_CACHE_LOCK:
+        entry = _NZB_CACHE.get(key)
+        if entry and (time.monotonic() - entry[0]) < _NZB_CACHE_TTL:
+            return entry[1]
+        if entry:
+            del _NZB_CACHE[key]
+    return None
+
+
+def _cache_set(key: str, results: List) -> None:
+    with _NZB_CACHE_LOCK:
+        _NZB_CACHE[key] = (time.monotonic(), results)
 
 
 def _build_params_list(
@@ -106,13 +138,21 @@ def scrape_newznab_instance(
     )
 
     def _fetch(params):
+        ck = _cache_key(endpoint, params)
+        cached = _cache_get(ck)
+        if cached is not None:
+            logging.info(f"Newznab '{instance}' cache hit for {params.get('t')} query")
+            return cached
         try:
             r = api.get(endpoint, params=params, timeout=timeout)
             logging.info(f"Newznab '{instance}' full request URL: {r.url}")
             if r.status_code != 200:
                 logging.error(f"Newznab '{instance}' HTTP {r.status_code}: {r.text[:200]}")
                 return []
-            return _parse_newznab_xml(r.text, instance)
+            results = _parse_newznab_xml(r.text, instance)
+            if results:
+                _cache_set(ck, results)
+            return results
         except Exception as exc:
             logging.error(f"Newznab '{instance}' request error: {exc}")
             return []
@@ -126,6 +166,26 @@ def scrape_newznab_instance(
             futures = [ex.submit(_fetch, p) for p in params_list]
             for f in as_completed(futures):
                 all_results.extend(f.result())
+
+    # For movie searches that return nothing, retry across TV categories too.
+    # Some content (UFC/WWE/boxing PPVs, sports events) is typed as movie in
+    # TMDB/Plex but indexed under TV categories (5000) on NZB indexers.
+    if not all_results and content_type.lower() == 'movie':
+        tv_params_list = _build_params_list(
+            api_key, clean_imdb, title, year, 'search', season, episode, multi
+        )
+        logging.info(f"Newznab '{instance}': 0 movie results — retrying with cross-category search (movie+TV)")
+        retry_results: List[Dict[str, Any]] = []
+        if len(tv_params_list) == 1:
+            retry_results = _fetch(tv_params_list[0])
+        else:
+            with ThreadPoolExecutor(max_workers=2) as ex:
+                futures = [ex.submit(_fetch, p) for p in tv_params_list]
+                for f in as_completed(futures):
+                    retry_results.extend(f.result())
+        if retry_results:
+            logging.info(f"Newznab '{instance}': cross-category retry found {len(retry_results)} results")
+        all_results = retry_results
 
     # Deduplicate by GUID — ID search and title search may return the same NZB
     seen_guids = set()
@@ -291,29 +351,45 @@ def scrape_newznab_season_aggregate(
         api_key = cfg.get('api_key', '').strip()
         if not url or not api_key:
             return []
-        endpoint = f'{url}/api'
+        ep_endpoint = f'{url}/api'
         results = []
         # ID-based tvsearch first
         if clean_imdb:
+            id_params = {
+                'apikey': api_key, 't': 'tvsearch', 'imdbid': clean_imdb,
+                'season': season, 'ep': ep_num, 'cat': cats, 'limit': 20,
+            }
+            ck = _cache_key(ep_endpoint, id_params)
+            cached = _cache_get(ck)
+            if cached is not None:
+                results.extend(cached)
+            else:
+                try:
+                    r = api.get(ep_endpoint, params=id_params, timeout=timeout)
+                    if r.status_code == 200:
+                        parsed = _parse_newznab_xml(r.text, instance)
+                        if parsed:
+                            _cache_set(ck, parsed)
+                        results.extend(parsed)
+                except Exception:
+                    pass
+        # Title text search
+        q = _SANITIZE_RE.sub('', f'{title} S{season:02d}E{ep_num:02d}').strip()
+        txt_params = {'apikey': api_key, 't': 'search', 'q': q, 'cat': cats, 'limit': 20}
+        ck = _cache_key(ep_endpoint, txt_params)
+        cached = _cache_get(ck)
+        if cached is not None:
+            results.extend(cached)
+        else:
             try:
-                r = api.get(endpoint, params={
-                    'apikey': api_key, 't': 'tvsearch', 'imdbid': clean_imdb,
-                    'season': season, 'ep': ep_num, 'cat': cats, 'limit': 20,
-                }, timeout=timeout)
+                r = api.get(ep_endpoint, params=txt_params, timeout=timeout)
                 if r.status_code == 200:
-                    results.extend(_parse_newznab_xml(r.text, instance))
+                    parsed = _parse_newznab_xml(r.text, instance)
+                    if parsed:
+                        _cache_set(ck, parsed)
+                    results.extend(parsed)
             except Exception:
                 pass
-        # Title text search
-        try:
-            q = _SANITIZE_RE.sub('', f'{title} S{season:02d}E{ep_num:02d}').strip()
-            r = api.get(endpoint, params={
-                'apikey': api_key, 't': 'search', 'q': q, 'cat': cats, 'limit': 20,
-            }, timeout=timeout)
-            if r.status_code == 200:
-                results.extend(_parse_newznab_xml(r.text, instance))
-        except Exception:
-            pass
         # Deduplicate by guid
         seen, deduped = set(), []
         for res in results:

--- a/scraper/prowlarr.py
+++ b/scraper/prowlarr.py
@@ -1,5 +1,8 @@
 from routes.api_tracker import api
+import hashlib
 import logging
+import threading
+import time
 from typing import List, Dict, Any, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from utilities.settings import get_setting
@@ -7,6 +10,31 @@ from urllib.parse import urlencode, quote_plus
 import re
 import json
 from scraper.functions.common import trim_magnet
+
+# Query result cache — reduces API hits for duplicate NZB searches within TTL window
+_NZB_CACHE: Dict[str, tuple] = {}   # key -> (timestamp, results)
+_NZB_CACHE_LOCK = threading.Lock()
+_NZB_CACHE_TTL = 600  # 10 minutes
+
+
+def _cache_key(endpoint: str, params: dict) -> str:
+    stable = f"{endpoint}|{sorted(params.items())}"
+    return hashlib.sha256(stable.encode()).hexdigest()
+
+
+def _cache_get(key: str) -> Optional[List]:
+    with _NZB_CACHE_LOCK:
+        entry = _NZB_CACHE.get(key)
+        if entry and (time.monotonic() - entry[0]) < _NZB_CACHE_TTL:
+            return entry[1]
+        if entry:
+            del _NZB_CACHE[key]
+    return None
+
+
+def _cache_set(key: str, results: List) -> None:
+    with _NZB_CACHE_LOCK:
+        _NZB_CACHE[key] = (time.monotonic(), results)
 
 
 def _build_prowlarr_params_list(
@@ -107,13 +135,21 @@ def scrape_prowlarr_instance(
     )
 
     def _fetch(query_params):
+        ck = _cache_key(search_endpoint, query_params)
+        cached = _cache_get(ck)
+        if cached is not None:
+            logging.info(f"Prowlarr '{instance}' cache hit for {query_params.get('type')} query")
+            return cached
         try:
             logging.debug(f"Prowlarr '{instance}' query: {query_params}")
             response = api.get(search_endpoint, headers=headers, params=query_params, timeout=timeout)
             if response.status_code == 200:
                 data = response.json()
                 if isinstance(data, list):
-                    return parse_prowlarr_results(data, instance, seeders_only)
+                    results = parse_prowlarr_results(data, instance, seeders_only)
+                    if results:
+                        _cache_set(ck, results)
+                    return results
                 logging.error(f"Prowlarr '{instance}' unexpected response type: {type(data)}")
             else:
                 logging.error(f"Prowlarr '{instance}' HTTP {response.status_code}: {response.text[:300]}")

--- a/static/css/debrid_manager.css
+++ b/static/css/debrid_manager.css
@@ -1620,6 +1620,34 @@
     white-space: nowrap;
 }
 
+.dm-pt-badge-nzb-url {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: rgba(74, 222, 128, 0.15);
+    color: #4ade80;
+    border: 1px solid rgba(74, 222, 128, 0.35);
+    vertical-align: middle;
+    white-space: nowrap;
+    margin-left: 5px;
+}
+
+.dm-pt-badge-nzb-nourl {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: rgba(251, 191, 36, 0.15);
+    color: #fbbf24;
+    border: 1px solid rgba(251, 191, 36, 0.35);
+    vertical-align: middle;
+    white-space: nowrap;
+    margin-left: 5px;
+}
+
 .dm-orphaned-badge {
     display: inline-block;
     font-size: 0.65rem;

--- a/static/css/tangerine/tangerine_upgrade_hub.css
+++ b/static/css/tangerine/tangerine_upgrade_hub.css
@@ -216,6 +216,32 @@ body[data-theme="tangerine"] .uh-cache-bypass {
     border: 1px solid rgba(192, 132, 252, 0.25);
     cursor: help;
 }
+body[data-theme="tangerine"] .uh-proto-nzb {
+    background: rgba(192, 132, 252, 0.1);
+    color: #fc9784;
+    border: 1px solid rgba(192, 132, 252, 0.25);
+    display: inline-block;
+    font-size: 0.5rem;
+    font-weight: 700;
+    padding: 1px 6px;
+    border-radius: 4px;
+    margin-top: 3px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+body[data-theme="tangerine"] .uh-proto-debrid {
+    background: rgba(192, 132, 252, 0.1);
+    color: #c084fc;
+    border: 1px solid rgba(192, 132, 252, 0.25);
+    display: inline-block;
+    font-size: 0.5rem;
+    font-weight: 700;
+    padding: 1px 6px;
+    border-radius: 4px;
+    margin-top: 3px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
 
 /* ── Progress ─────────────────────────────────────────────────────────────── */
 body[data-theme="tangerine"] .uh-progress-wrap {

--- a/static/css/upgrade_hub.css
+++ b/static/css/upgrade_hub.css
@@ -196,6 +196,27 @@
     color: #EF9A9A;
     border: 1px solid #6a2a2a;
 }
+.uh-proto-badge {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 1px 5px;
+    border-radius: 3px;
+    margin-left: 4px;
+    vertical-align: middle;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+.uh-proto-nzb {
+    background: #1a2a3a;
+    color: #80CBC4;
+    border: 1px solid #2a5a55;
+}
+.uh-proto-debrid {
+    background: #2a1a3a;
+    color: #CE93D8;
+    border: 1px solid #5a2a7a;
+}
 
 /* ── Progress ───────────────────────────────────────────────────────────── */
 .uh-progress-wrap {

--- a/static/js/discover.js
+++ b/static/js/discover.js
@@ -78,7 +78,8 @@ window.discoverState = {
     discoverSettings: {
         hide_no_rating: false,
         hide_no_poster: false,
-        only_show_missing: false
+        only_show_missing: false,
+        hide_specials: true
     }
 };
 
@@ -253,7 +254,8 @@ async function loadDiscoverSettings() {
             hide_no_rating: discoverSettings.hide_no_rating || false,
             hide_no_poster: discoverSettings.hide_no_poster || false,
             only_show_missing: discoverSettings.only_show_missing || false,
-            tv_show_episode_view: discoverSettings.tv_show_episode_view || 'discover'
+            tv_show_episode_view: discoverSettings.tv_show_episode_view || 'discover',
+            hide_specials: discoverSettings.hide_specials !== false
         };
     } catch (error) {
         console.error('[Discover] Error loading settings:', error);

--- a/static/js/discover_details.js
+++ b/static/js/discover_details.js
@@ -10,6 +10,26 @@ document.addEventListener('DOMContentLoaded', function() {
 let contentData = null;
 let discoverVersions = [];
 
+async function loadDiscoverSettings() {
+    if (window.discoverState && window.discoverState.discoverSettings) return;
+    try {
+        const response = await fetch('/settings/api/config');
+        if (!response.ok) return;
+        const config = await response.json();
+        const s = config['Discover Settings'] || {};
+        if (!window.discoverState) window.discoverState = {};
+        window.discoverState.discoverSettings = {
+            hide_no_rating: s.hide_no_rating || false,
+            hide_no_poster: s.hide_no_poster || false,
+            only_show_missing: s.only_show_missing || false,
+            tv_show_episode_view: s.tv_show_episode_view || 'discover',
+            hide_specials: s.hide_specials !== false
+        };
+    } catch (e) {
+        console.warn('[Discover Details] Could not load settings, using defaults:', e);
+    }
+}
+
 async function initDiscoverDetails() {
     const container = document.querySelector('.movie-container');
     if (!container) return;
@@ -28,6 +48,9 @@ async function initDiscoverDetails() {
     } catch (e) {
         console.warn('Modal initialization failed:', e);
     }
+
+    // Load settings before content so season filtering uses saved preferences
+    await loadDiscoverSettings();
 
     // Fetch available versions in background (don't block page load)
     fetchVersions().catch(e => console.warn('Failed to fetch versions:', e));
@@ -382,9 +405,12 @@ async function loadAndDisplaySeasons(data) {
 
     if (!seasonsContainer || !tabsNav || !tabsContent) return;
 
-    // Filter out specials (season 0) and sort by season number
+    // Filter out specials (season 0) based on setting — default true matches previous hardcoded behaviour
+    const hideSpecials = (window.discoverState && window.discoverState.discoverSettings)
+        ? window.discoverState.discoverSettings.hide_specials !== false
+        : true;
     const regularSeasons = data.seasons
-        .filter(s => s.season_number > 0)
+        .filter(s => hideSpecials ? s.season_number > 0 : true)
         .sort((a, b) => a.season_number - b.season_number);
 
     if (regularSeasons.length === 0) return;
@@ -932,7 +958,10 @@ function showVersionModal(data) {
             const list = document.createElement('div');
             list.className = 'seasons-list';
             seasonSelectionContainer.appendChild(list);
-            data.seasons.filter(s => s.season_number > 0).forEach(season => {
+            const _hideSpecials2 = (window.discoverState && window.discoverState.discoverSettings)
+                ? window.discoverState.discoverSettings.hide_specials !== false
+                : true;
+            data.seasons.filter(s => _hideSpecials2 ? s.season_number > 0 : true).forEach(season => {
                 const row = document.createElement('div');
                 row.className = 'option-row';
                 row.dataset.value = String(season.season_number);

--- a/static/js/discover_settings_modal.js
+++ b/static/js/discover_settings_modal.js
@@ -32,7 +32,7 @@
     loadThemeCSS();
 
     let modal, overlay, closeBtn, cancelBtn, saveBtn;
-    let hideNoRatingInput, hideNoPosterInput, onlyShowMissingInput, discoverEpisodeViewSelect;
+    let hideNoRatingInput, hideNoPosterInput, onlyShowMissingInput, discoverEpisodeViewSelect, hideSpecialsInput;
     let currentSettings = null;
 
     // Initialize elements after DOM is ready
@@ -52,6 +52,7 @@
         hideNoPosterInput = document.getElementById('discoverHideNoPoster');
         onlyShowMissingInput = document.getElementById('discoverOnlyShowMissing');
         discoverEpisodeViewSelect = document.getElementById('discoverEpisodeView');
+        hideSpecialsInput = document.getElementById('discoverHideSpecials');
 
         return true;
     }
@@ -93,6 +94,11 @@
 
             if (discoverEpisodeViewSelect) {
                 discoverEpisodeViewSelect.value = discoverSettings.tv_show_episode_view || 'discover';
+            }
+
+            if (hideSpecialsInput) {
+                // Default true — matches the previous hardcoded behaviour
+                hideSpecialsInput.checked = discoverSettings.hide_specials !== false;
             }
 
             // Show modal
@@ -142,6 +148,9 @@
             updatedSettings['Discover Settings'].hide_no_poster = hideNoPosterInput.checked;
             updatedSettings['Discover Settings'].only_show_missing = onlyShowMissingInput.checked;
             updatedSettings['Discover Settings'].tv_show_episode_view = discoverEpisodeViewSelect.value;
+            if (hideSpecialsInput) {
+                updatedSettings['Discover Settings'].hide_specials = hideSpecialsInput.checked;
+            }
 
             // Send to same API endpoint as settings page
             const response = await fetch('/settings/api/settings', {

--- a/static/js/scraper.js
+++ b/static/js/scraper.js
@@ -4424,6 +4424,7 @@ function checkCacheStatusInBackground(hashes, results) {
     // Count only first 5 non-NZB (debrid) items for cache checking
     let debridChecked = 0;
     const MAX_DEBRID_CHECKS = 5;
+    const MAX_PARALLEL_REQUESTS = 2;
     let totalCount = Math.min(5, results.length);
     let processingItems = new Set(); // Track items currently being processed
 
@@ -4552,12 +4553,12 @@ function checkCacheStatusInBackground(hashes, results) {
 
         const result = results[index];
 
-        // NZB items don't need cache checking — skip but extend totalCount to find next debrid item
+        // NZB items don't need cache checking — skip and extend window to find debrid items
         const isNzb = result.protocol === 'nzb' || (!!result.nzb_url && !result.magnet_link && !result.torrent_url);
         if (isNzb) {
             processingItems.delete(index);
-            // Extend window to include one more item beyond current total, up to results length
-            if (totalCount < results.length && debridChecked < MAX_DEBRID_CHECKS) {
+            // Always extend the window when skipping an NZB so we still check MAX_DEBRID_CHECKS debrid items
+            if (totalCount < results.length) {
                 totalCount = Math.min(totalCount + 1, results.length);
             }
             processedCount++;

--- a/templates/base.html
+++ b/templates/base.html
@@ -1955,6 +1955,14 @@
                 </div>
 
                 <div class="discover-setting-group">
+                    <label for="discoverHideSpecials">
+                        <input type="checkbox" id="discoverHideSpecials" class="discover-setting-checkbox">
+                        Hide TV specials (Season 0)
+                    </label>
+                    <p class="discover-setting-description">Hide Season 0 (specials) from the season list on TV show detail pages.</p>
+                </div>
+
+                <div class="discover-setting-group">
                     <label for="discoverEpisodeView">TV Show Episode View</label>
                     <select id="discoverEpisodeView" class="discover-setting-select">
                         <option value="discover">Discover</option>

--- a/templates/debrid_manager.html
+++ b/templates/debrid_manager.html
@@ -738,97 +738,206 @@
         <div id="pt-error" class="dm-error" style="display:none"></div>
         <div id="pt-content" style="display:none">
 
-            <!-- In Real-Debrid group -->
-            <div class="dm-pt-group">
-                <div class="dm-pt-group-header">
-                    <div class="dm-pt-group-title">
-                        <span class="dm-pt-group-dot dm-pt-dot-in"></span>
-                        In {{ debrid_provider_name }}
-                        <span class="dm-pt-group-count" id="pt-in-rd-count">0</span>
-                    </div>
-                    <div class="dm-pt-group-actions">
-                        <button class="dm-btn dm-btn-secondary dm-btn-sm" id="pt-select-in-rd">Select All</button>
-                    </div>
-                </div>
-                <p class="dm-pt-group-desc">These items are still in your {{ debrid_provider_name }} library. You may want to remove them from {{ debrid_provider_name }} first before purging from Plex.</p>
-                <div class="dm-pt-bulk-bar">
-                    <button class="dm-pt-bulk-btn dm-pt-bulk-scan" id="pt-bulk-scan-all" title="Trigger Plex directory scan on all in-{{ debrid_provider_name }} items">
-                        <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
-                        Scan All
-                    </button>
-                    <button class="dm-pt-bulk-btn dm-pt-bulk-reinsert" id="pt-bulk-reinsert-good" title="Re-add all matched torrents to {{ debrid_provider_name }}">
-                        <svg viewBox="0 0 20 20" fill="currentColor"><path d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z"/></svg>
-                        Reinsert All Good
-                    </button>
-                    <button class="dm-pt-bulk-btn dm-pt-bulk-del" id="pt-bulk-del-bad" title="Delete all Plex items with an orphaned bad file">
-                        <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-                        Delete All Bad
-                    </button>
-                    <button class="dm-pt-bulk-btn dm-pt-bulk-del" id="pt-bulk-del-good" title="Delete all Plex items that have a matching good file">
-                        <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-                        Delete All Good
-                    </button>
-                </div>
-                <div class="dm-table-wrap">
-                    <table class="dm-table dm-pt-table">
-                        <thead>
-                            <tr>
-                                <th class="dm-col-check"><input type="checkbox" id="pt-in-rd-select-all" title="Select all in-RD"></th>
-                                <th class="dm-pt-col-title">Title</th>
-                                <th class="dm-pt-col-type">Type</th>
-                                <th class="dm-pt-col-files-hdr">Files</th>
-                                <th class="dm-col-actions">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody id="pt-in-rd-tbody">
-                            <tr class="dm-empty-row"><td colspan="5">Loading…</td></tr>
-                        </tbody>
-                    </table>
-                </div>
+            <!-- Sub-tab bar -->
+            <div class="dm-rc-tab-bar">
+                <button class="dm-rc-tab dm-pt-subtab dm-rc-tab-active" data-pt-group="debrid">
+                    <span class="dm-rc-tab-name">{{ debrid_provider_name }}</span>
+                    <span class="dm-rc-tab-count" id="pt-subtab-debrid-count">0</span>
+                </button>
+                <button class="dm-rc-tab dm-pt-subtab" data-pt-group="usenet">
+                    <span class="dm-rc-tab-name">Usenet</span>
+                    <span class="dm-rc-tab-count" id="pt-subtab-usenet-count">0</span>
+                </button>
             </div>
 
-            <!-- Not in Real-Debrid group -->
-            <div class="dm-pt-group">
-                <div class="dm-pt-group-header">
-                    <div class="dm-pt-group-title">
-                        <span class="dm-pt-group-dot dm-pt-dot-out"></span>
-                        Not in {{ debrid_provider_name }}
-                        <span class="dm-pt-group-count" id="pt-not-in-rd-count">0</span>
+            <!-- Debrid panel -->
+            <div id="pt-panel-debrid">
+                <!-- In Real-Debrid group -->
+                <div class="dm-pt-group">
+                    <div class="dm-pt-group-header">
+                        <div class="dm-pt-group-title">
+                            <span class="dm-pt-group-dot dm-pt-dot-in"></span>
+                            In {{ debrid_provider_name }}
+                            <span class="dm-pt-group-count" id="pt-in-rd-count">0</span>
+                        </div>
+                        <div class="dm-pt-group-actions">
+                            <button class="dm-btn dm-btn-secondary dm-btn-sm" id="pt-select-in-rd">Select All</button>
+                        </div>
                     </div>
-                    <div class="dm-pt-group-actions">
-                        <button class="dm-btn dm-btn-secondary dm-btn-sm" id="pt-select-not-in-rd">Select All</button>
+                    <p class="dm-pt-group-desc">These items are still in your {{ debrid_provider_name }} library. You may want to remove them from {{ debrid_provider_name }} first before purging from Plex.</p>
+                    <div class="dm-pt-bulk-bar">
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-scan" id="pt-bulk-scan-all" title="Trigger Plex directory scan on all in-{{ debrid_provider_name }} items">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
+                            Scan All
+                        </button>
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-reinsert" id="pt-bulk-reinsert-good" title="Re-add all matched torrents to {{ debrid_provider_name }}">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z"/></svg>
+                            Reinsert All Good
+                        </button>
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-del" id="pt-bulk-del-bad" title="Delete all Plex items with an orphaned bad file">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                            Delete All Bad
+                        </button>
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-del" id="pt-bulk-del-good" title="Delete all Plex items that have a matching good file">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                            Delete All Good
+                        </button>
+                    </div>
+                    <div class="dm-table-wrap">
+                        <table class="dm-table dm-pt-table">
+                            <thead>
+                                <tr>
+                                    <th class="dm-col-check"><input type="checkbox" id="pt-in-rd-select-all" title="Select all in-RD"></th>
+                                    <th class="dm-pt-col-title">Title</th>
+                                    <th class="dm-pt-col-type">Type</th>
+                                    <th class="dm-pt-col-files-hdr">Files</th>
+                                    <th class="dm-col-actions">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody id="pt-in-rd-tbody">
+                                <tr class="dm-empty-row"><td colspan="5">Loading…</td></tr>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
-                <p class="dm-pt-group-desc">These items are not found in {{ debrid_provider_name }}. Safe to permanently delete from Plex.</p>
-                <div class="dm-pt-bulk-bar">
-                    <button class="dm-pt-bulk-btn dm-pt-bulk-reinsert" id="pt-bulk-reinsert-notrd" title="Re-add all items with a known magnet hash to {{ debrid_provider_name }}">
-                        <svg viewBox="0 0 20 20" fill="currentColor"><path d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z"/></svg>
-                        Reinsert All
-                    </button>
-                    <button class="dm-pt-bulk-btn dm-pt-bulk-del" id="pt-bulk-del-notrd" title="Permanently delete all not-in-RD items from Plex">
-                        <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-                        Delete All
-                    </button>
+
+                <!-- Not in Real-Debrid group -->
+                <div class="dm-pt-group">
+                    <div class="dm-pt-group-header">
+                        <div class="dm-pt-group-title">
+                            <span class="dm-pt-group-dot dm-pt-dot-out"></span>
+                            Not in {{ debrid_provider_name }}
+                            <span class="dm-pt-group-count" id="pt-not-in-rd-count">0</span>
+                        </div>
+                        <div class="dm-pt-group-actions">
+                            <button class="dm-btn dm-btn-secondary dm-btn-sm" id="pt-select-not-in-rd">Select All</button>
+                        </div>
+                    </div>
+                    <p class="dm-pt-group-desc">These items are not found in {{ debrid_provider_name }}. Safe to permanently delete from Plex.</p>
+                    <div class="dm-pt-bulk-bar">
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-reinsert" id="pt-bulk-reinsert-notrd" title="Re-add all items with a known magnet hash to {{ debrid_provider_name }}">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z"/></svg>
+                            Reinsert All
+                        </button>
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-del" id="pt-bulk-del-notrd" title="Permanently delete all not-in-RD items from Plex">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                            Delete All
+                        </button>
+                    </div>
+                    <div class="dm-table-wrap">
+                        <table class="dm-table dm-pt-table">
+                            <thead>
+                                <tr>
+                                    <th class="dm-col-check"><input type="checkbox" id="pt-not-in-rd-select-all" title="Select all not-in-RD"></th>
+                                    <th class="dm-pt-col-title">Title</th>
+                                    <th class="dm-pt-col-type">Type</th>
+                                    <th class="dm-pt-col-files-hdr">Files</th>
+                                    <th class="dm-col-actions">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody id="pt-not-in-rd-tbody">
+                                <tr class="dm-empty-row"><td colspan="5">Loading…</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-                <div class="dm-table-wrap">
-                    <table class="dm-table dm-pt-table">
-                        <thead>
-                            <tr>
-                                <th class="dm-col-check"><input type="checkbox" id="pt-not-in-rd-select-all" title="Select all not-in-RD"></th>
-                                <th class="dm-pt-col-title">Title</th>
-                                <th class="dm-pt-col-type">Type</th>
-                                <th class="dm-pt-col-files-hdr">Files</th>
-                                <th class="dm-col-actions">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody id="pt-not-in-rd-tbody">
-                            <tr class="dm-empty-row"><td colspan="5">Loading…</td></tr>
-                        </tbody>
-                    </table>
+            </div><!-- /#pt-panel-debrid -->
+
+            <!-- Usenet panel -->
+            <div id="pt-panel-usenet" style="display:none">
+                <!-- In Usenet (NZB) group -->
+                <div class="dm-pt-group">
+                    <div class="dm-pt-group-header">
+                        <div class="dm-pt-group-title">
+                            <span class="dm-pt-group-dot dm-pt-dot-in"></span>
+                            In Usenet
+                            <span class="dm-pt-group-count" id="pt-in-usenet-count">0</span>
+                        </div>
+                        <div class="dm-pt-group-actions">
+                            <button class="dm-btn dm-btn-secondary dm-btn-sm" id="pt-select-in-usenet">Select All</button>
+                        </div>
+                    </div>
+                    <p class="dm-pt-group-desc">These items were downloaded via Usenet and are tracked by Decypharr. Use Re-NZB to resubmit the original download or find a replacement.</p>
+                    <div class="dm-pt-bulk-bar">
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-scan" id="pt-bulk-scan-in-usenet" title="Trigger Plex directory scan on all in-Usenet items">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
+                            Scan All
+                        </button>
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-reinsert" id="pt-bulk-renzb-in" title="Re-submit all in-Usenet items to Decypharr">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z"/></svg>
+                            Re-NZB All
+                        </button>
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-del" id="pt-bulk-del-in-usenet" title="Delete all in-Usenet items from Plex">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                            Delete All
+                        </button>
+                    </div>
+                    <div class="dm-table-wrap">
+                        <table class="dm-table dm-pt-table">
+                            <thead>
+                                <tr>
+                                    <th class="dm-col-check"><input type="checkbox" id="pt-in-usenet-select-all" title="Select all"></th>
+                                    <th class="dm-pt-col-title">Title</th>
+                                    <th class="dm-pt-col-type">Type</th>
+                                    <th class="dm-pt-col-files-hdr">Release</th>
+                                    <th class="dm-col-actions">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody id="pt-in-usenet-tbody">
+                                <tr class="dm-empty-row"><td colspan="5">Loading…</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-            </div>
-        </div>
-    </div>
+
+                <!-- Not in Usenet group -->
+                <div class="dm-pt-group">
+                    <div class="dm-pt-group-header">
+                        <div class="dm-pt-group-title">
+                            <span class="dm-pt-group-dot dm-pt-dot-out"></span>
+                            Not in Usenet
+                            <span class="dm-pt-group-count" id="pt-not-usenet-count">0</span>
+                        </div>
+                        <div class="dm-pt-group-actions">
+                            <button class="dm-btn dm-btn-secondary dm-btn-sm" id="pt-select-not-usenet">Select All</button>
+                        </div>
+                    </div>
+                    <p class="dm-pt-group-desc">These Plex trash items were originally downloaded via Usenet but have no active job ID. Use Re-NZB to find a new download.</p>
+                    <div class="dm-pt-bulk-bar">
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-scan" id="pt-bulk-scan-not-usenet" title="Trigger Plex directory scan on all not-in-Usenet items">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
+                            Scan All
+                        </button>
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-reinsert" id="pt-bulk-renzb-not" title="Re-scrape and re-submit all not-in-Usenet items to Decypharr">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z"/></svg>
+                            Re-NZB All
+                        </button>
+                        <button class="dm-pt-bulk-btn dm-pt-bulk-del" id="pt-bulk-del-not-usenet" title="Delete all not-in-Usenet items from Plex">
+                            <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                            Delete All
+                        </button>
+                    </div>
+                    <div class="dm-table-wrap">
+                        <table class="dm-table dm-pt-table">
+                            <thead>
+                                <tr>
+                                    <th class="dm-col-check"><input type="checkbox" id="pt-not-usenet-select-all" title="Select all"></th>
+                                    <th class="dm-pt-col-title">Title</th>
+                                    <th class="dm-pt-col-type">Type</th>
+                                    <th class="dm-pt-col-files-hdr">Release</th>
+                                    <th class="dm-col-actions">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody id="pt-not-usenet-tbody">
+                                <tr class="dm-empty-row"><td colspan="5">Loading…</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div><!-- /#pt-panel-usenet -->
+
+        </div><!-- /#pt-content -->
+    </div><!-- /#plex-trash-tab -->
     {% endif %}
 
     <!-- ── RECONCILE TAB ── -->
@@ -4344,6 +4453,22 @@ let _ptSelected = new Set();
 let _ptInRd = [];
 let _ptNotInRd = [];
 let _ptLoaded = false;
+let _ptActiveSubtab = 'debrid';
+
+function _ptSwitchSubtab(group) {
+    _ptActiveSubtab = group;
+    document.querySelectorAll('.dm-pt-subtab').forEach(btn => {
+        btn.classList.toggle('dm-rc-tab-active', btn.dataset.ptGroup === group);
+    });
+    const debridPanel = document.getElementById('pt-panel-debrid');
+    const usenetPanel = document.getElementById('pt-panel-usenet');
+    if (debridPanel) debridPanel.style.display = group === 'debrid' ? '' : 'none';
+    if (usenetPanel) usenetPanel.style.display = group === 'usenet' ? '' : 'none';
+}
+
+document.querySelectorAll('.dm-pt-subtab').forEach(btn => {
+    btn.addEventListener('click', () => _ptSwitchSubtab(btn.dataset.ptGroup));
+});
 
 function _ptUpdatePurgeBtn() {
     const btn = document.getElementById('pt-purge-btn');
@@ -4571,12 +4696,18 @@ function _ptUpdateCounts() {
     const inCount = document.getElementById('pt-in-rd-count');
     const outCount = document.getElementById('pt-not-in-rd-count');
     const tabCount = document.getElementById('plex-trash-tab-count');
-    const total = _ptInRd.length + _ptNotInRd.length;
+    const debridTotal = _ptInRd.length + _ptNotInRd.length;
     if (inCount) inCount.textContent = _ptInRd.length;
     if (outCount) outCount.textContent = _ptNotInRd.length;
-    if (tabCount) tabCount.textContent = total ? total : '';
+    // Update debrid sub-tab badge
+    const debridSubtabBadge = document.getElementById('pt-subtab-debrid-count');
+    if (debridSubtabBadge) debridSubtabBadge.textContent = debridTotal || '';
+    // Total tab badge = all items across both sub-tabs
+    const usenetTotal = _ptInUsenet.length + _ptNotUsenet.length;
+    const grand = debridTotal + usenetTotal;
+    if (tabCount) tabCount.textContent = grand ? grand : '';
     const info = document.getElementById('pt-info-text');
-    if (info) info.textContent = total ? `${total} item${total !== 1 ? 's' : ''} in Plex Trash` : '';
+    if (info) info.textContent = grand ? `${grand} item${grand !== 1 ? 's' : ''} in Plex Trash` : '';
 }
 
 async function loadPlexTrash(force) {
@@ -4594,14 +4725,24 @@ async function loadPlexTrash(force) {
         if (!data.success) throw new Error(data.error || 'Failed to load');
         _ptInRd = data.in_rd || [];
         _ptNotInRd = data.not_in_rd || [];
+        _ptInUsenet = data.in_usenet || [];
+        _ptNotUsenet = data.not_in_usenet || [];
         _ptSelected.clear();
         _ptRenderGroup('pt-in-rd-tbody', _ptInRd, 'in_rd');
         _ptRenderGroup('pt-not-in-rd-tbody', _ptNotInRd, 'not_in_rd');
+        _ptRenderUsenetGroup('pt-in-usenet-tbody', _ptInUsenet);
+        _ptRenderUsenetGroup('pt-not-usenet-tbody', _ptNotUsenet);
         _ptUpdateCounts();
+        _ptUpdateUsenetCounts();
         _ptUpdatePurgeBtn();
         loading.style.display = 'none';
         content.style.display = '';
         _ptLoaded = true;
+        // Auto-switch to usenet tab if there are usenet items but no debrid items
+        const hasDebrid = (_ptInRd.length + _ptNotInRd.length) > 0;
+        const hasUsenet = (_ptInUsenet.length + _ptNotUsenet.length) > 0;
+        if (!hasDebrid && hasUsenet) _ptSwitchSubtab('usenet');
+        else _ptSwitchSubtab(_ptActiveSubtab);
         // If RD library was not ready, show a notice and auto-refresh in 15s
         const rdBanner = document.getElementById('pt-rd-loading-banner');
         if (data.rd_library_status === 'loading') {
@@ -4860,6 +5001,324 @@ document.querySelectorAll('.dm-tab[data-tab="plex-trash"]').forEach(btn => {
     btn.addEventListener('click', () => { if (!_ptLoaded) loadPlexTrash(false); });
 });
 if (_dmActiveTab === 'plex-trash') loadPlexTrash(false);
+
+// ── USENET (NZB) SECTION ───────────────────────────────────────────────────
+let _ptInUsenet = [];
+let _ptNotUsenet = [];
+
+function _ptRenderUsenetGroup(tbodyId, items) {
+    const tbody = document.getElementById(tbodyId);
+    if (!tbody) return;
+    if (!items.length) {
+        tbody.innerHTML = '<tr class="dm-empty-row"><td colspan="5">None</td></tr>';
+        return;
+    }
+    tbody.innerHTML = items.map((item, idx) => {
+        const checked = _ptSelected.has(item.rating_key) ? 'checked' : '';
+        const typeLabel = item.media_type === 'show'
+            ? '<span class="dm-type-badge dm-type-tv">Show</span>'
+            : '<span class="dm-type-badge dm-type-movie">Movie</span>';
+        const year = item.year ? ` (${item.year})` : '';
+        const rk = escHtml(item.rating_key);
+        const _shorten = (s, n) => s && s.length > n ? s.substring(0, n) + '…' : (s || '');
+
+        // Build Files column — mirrors debrid _ptRenderGroup logic exactly
+        let filesHtml = '';
+        if (item.bad_file && item.has_good_file) {
+            const goodName = item.good_file || item.nzb_title || item.folder_name || '';
+            const _pids = item.part_ids || {};
+            const badPart = _pids[item.bad_file] || {};
+            const goodPart = _pids[goodName] || {};
+            const badMid = escHtml(badPart.media_id || '');
+            const badPid = escHtml(badPart.part_id || '');
+            const goodMid = escHtml(goodPart.media_id || '');
+            const goodPid = escHtml(goodPart.part_id || '');
+            const orphanLabel = item.bad_file_orphaned ? `<span class="dm-pt-badge-orphaned">Orphaned</span>` : '';
+            // Bad file row: Re-NZB disabled (no point reinserting the broken file) + Delete
+            const badBtns = `<span class="dm-pt-file-btns">`
+                + `<button class="dm-btn dm-btn-xs dm-pt-fbtn" data-faction="renzb-file" data-idx="${idx}" data-tbody="${tbodyId}" disabled title="Use Re-NZB button to resubmit">Re-NZB</button>`
+                + `<button class="dm-btn dm-btn-xs dm-pt-fbtn dm-pt-fbtn-del" data-faction="delete-part" data-rk="${rk}" data-mid="${badMid}" data-pid="${badPid}" data-protected="1" title="Remove this file from Plex">Delete</button>`
+                + `</span>`;
+            // Good file row: Re-NZB enabled + Delete
+            const goodBtns = `<span class="dm-pt-file-btns">`
+                + `<button class="dm-btn dm-btn-xs dm-pt-fbtn" data-faction="renzb-file" data-idx="${idx}" data-tbody="${tbodyId}" title="Re-submit this item to Decypharr">Re-NZB</button>`
+                + `<button class="dm-btn dm-btn-xs dm-pt-fbtn dm-pt-fbtn-del" data-faction="delete-part" data-rk="${rk}" data-mid="${goodMid}" data-pid="${goodPid}" data-protected="1" title="Remove this file from Plex">Delete</button>`
+                + `</span>`;
+            filesHtml = `<div class="dm-pt-file-row"><span class="dm-pt-file-bad" title="${escHtml(item.bad_file)}">${escHtml(item.bad_file)}</span>${orphanLabel}${badBtns}</div>`
+                      + `<div class="dm-pt-file-row"><span class="dm-pt-file-good" title="${escHtml(goodName)}">${escHtml(goodName)}</span>${goodBtns}</div>`;
+        } else if (item.bad_file) {
+            filesHtml = `<div class="dm-pt-file-row"><span class="dm-pt-file-bad" title="${escHtml(item.bad_file)}">${escHtml(item.bad_file)}</span></div>`;
+        } else {
+            const releaseTitle = escHtml(item.nzb_title || item.folder_name || '');
+            const hasUrl = !!(item.nzb_url);
+            const urlBadge = hasUrl
+                ? '<span class="dm-pt-badge-nzb-url" title="Original NZB URL available">URL</span>'
+                : '<span class="dm-pt-badge-nzb-nourl" title="No stored NZB URL — will re-scrape">Re-scrape</span>';
+            filesHtml = `<div class="dm-pt-file-row"><span class="dm-pt-folder" title="${releaseTitle}">${releaseTitle}</span>${urlBadge}</div>`;
+        }
+
+        const action = `<button class="dm-btn dm-btn-secondary dm-btn-sm dm-pt-action-btn" data-action="renzb" data-idx="${idx}" data-group="${tbodyId}" title="Re-submit to Decypharr">Re-NZB</button>`;
+        return `<tr>
+            <td class="dm-col-check"><input type="checkbox" data-rk="${rk}" data-group="usenet" ${checked}></td>
+            <td><span class="dm-pt-title">${escHtml(item.title)}${escHtml(year)}</span></td>
+            <td class="dm-pt-col-type">${typeLabel}</td>
+            <td class="dm-pt-col-files">${filesHtml}</td>
+            <td class="dm-col-actions">${action}</td>
+        </tr>`;
+    }).join('');
+
+    tbody.querySelectorAll('input[type=checkbox][data-rk]').forEach(cb => {
+        cb.addEventListener('change', () => {
+            if (cb.checked) _ptSelected.add(cb.dataset.rk);
+            else _ptSelected.delete(cb.dataset.rk);
+            _ptUpdatePurgeBtn();
+        });
+    });
+
+    tbody.querySelectorAll('.dm-pt-action-btn[data-action="renzb"]').forEach(btn => {
+        btn.addEventListener('click', async () => {
+            const idx = parseInt(btn.dataset.idx);
+            const isIn = btn.dataset.group === 'pt-in-usenet-tbody';
+            const item = isIn ? _ptInUsenet[idx] : _ptNotUsenet[idx];
+            if (!item) return;
+            const origHtml = btn.innerHTML;
+            btn.disabled = true;
+            btn.textContent = 'Submitting…';
+            try {
+                const r = await fetch('/debrid_manager/api/nzb/reinsert', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        item_id: item.nzb_item_id,
+                        nzb_url: item.nzb_url || '',
+                        nzb_title: item.nzb_title || '',
+                        rating_key: item.rating_key,
+                    }),
+                });
+                const data = await r.json();
+                if (data.success) {
+                    const methodLabel = data.method === 'rescrape' ? 'Re-scraped & submitted' : 'Re-submitted';
+                    // Update item's nzb_title with new release so Scan All uses the right path
+                    if (data.new_release_title) item.nzb_title = data.new_release_title;
+                    btn.textContent = 'Done';
+                    btn.classList.add('dm-pt-action-ok');
+                    showPopup({ type: 'success', title: 'Re-NZB', message: `${methodLabel} — job ID: ${data.job_id}`, autoClose: 5000 });
+                    // Auto-scan the new path
+                    const parentDir = item.file_dir ? item.file_dir.substring(0, item.file_dir.lastIndexOf('/')) : '';
+                    const newPath = (parentDir && item.nzb_title) ? `${parentDir}/${item.nzb_title}` : '';
+                    if (newPath) {
+                        fetch('/debrid_manager/api/plex_force_scan', {
+                            method: 'POST', headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({paths: [newPath], empty_trash: false}),
+                        }).catch(() => {});
+                    }
+                    setTimeout(() => { btn.innerHTML = origHtml; btn.classList.remove('dm-pt-action-ok'); btn.disabled = false; }, 4000);
+                } else {
+                    showPopup({ type: 'error', title: 'Re-NZB Failed', message: data.error || 'Unknown error', autoClose: 6000 });
+                    btn.innerHTML = origHtml; btn.disabled = false;
+                }
+            } catch(e) {
+                showPopup({ type: 'error', title: 'Re-NZB Failed', message: e.message, autoClose: 5000 });
+                btn.innerHTML = origHtml; btn.disabled = false;
+            }
+        });
+    });
+
+    // Per-file inline button handlers (renzb-file and delete-part)
+    tbody.querySelectorAll('.dm-pt-fbtn').forEach(btn => {
+        btn.addEventListener('click', async () => {
+            const faction = btn.dataset.faction;
+            const origHtml = btn.innerHTML;
+            if (btn.disabled) return;
+            btn.disabled = true;
+            if (faction === 'renzb-file') {
+                const idx = parseInt(btn.dataset.idx);
+                const isIn = btn.dataset.tbody === 'pt-in-usenet-tbody';
+                const item = isIn ? _ptInUsenet[idx] : _ptNotUsenet[idx];
+                if (!item) { btn.disabled = false; return; }
+                btn.textContent = 'Submitting…';
+                try {
+                    const r = await fetch('/debrid_manager/api/nzb/reinsert', {
+                        method: 'POST', headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({ item_id: item.nzb_item_id, nzb_url: item.nzb_url || '', nzb_title: item.nzb_title || '', rating_key: item.rating_key }),
+                    });
+                    const data = await r.json();
+                    if (data.success) {
+                        if (data.new_release_title) item.nzb_title = data.new_release_title;
+                        btn.textContent = 'Done';
+                        btn.classList.add('dm-pt-action-ok');
+                        setTimeout(() => { btn.innerHTML = origHtml; btn.classList.remove('dm-pt-action-ok'); btn.disabled = false; }, 3000);
+                    } else {
+                        showPopup({ type: 'error', title: 'Re-NZB Failed', message: data.error || 'Unknown error', autoClose: 6000 });
+                        btn.innerHTML = origHtml; btn.disabled = false;
+                    }
+                } catch(e) { showPopup({ type: 'error', title: 'Re-NZB Failed', message: e.message, autoClose: 5000 }); btn.innerHTML = origHtml; btn.disabled = false; }
+            } else if (faction === 'delete-part') {
+                const ratingKey = btn.dataset.rk;
+                const mediaId = btn.dataset.mid;
+                const partId = btn.dataset.pid;
+                showPopup({
+                    type: 'confirm', title: 'Remove File', message: 'Remove this file from Plex? This cannot be undone.',
+                    confirmText: 'Remove', cancelText: 'Cancel',
+                    onConfirm: async function() {
+                        btn.textContent = 'Deleting…';
+                        try {
+                            const scanItem = [..._ptInUsenet, ..._ptNotUsenet].find(i => i.rating_key === ratingKey);
+                            const r = await fetch('/debrid_manager/api/plex_delete_part', {
+                                method: 'POST', headers: {'Content-Type': 'application/json'},
+                                body: JSON.stringify({ rating_key: ratingKey, media_id: mediaId, part_id: partId }),
+                            });
+                            const data = await r.json();
+                            if (!data.success) { showPopup({ type: 'error', title: 'Error', message: 'Delete failed: ' + (data.error || 'unknown'), autoClose: 5000 }); btn.innerHTML = origHtml; btn.disabled = false; return; }
+                            const inItem = _ptInUsenet.find(i => i.rating_key === ratingKey);
+                            if (inItem?.has_good_file) {
+                                inItem.bad_file = null; inItem.has_good_file = false; inItem.bad_file_orphaned = false;
+                                _ptRenderUsenetGroup('pt-in-usenet-tbody', _ptInUsenet);
+                            } else {
+                                _ptInUsenet = _ptInUsenet.filter(i => i.rating_key !== ratingKey);
+                                _ptNotUsenet = _ptNotUsenet.filter(i => i.rating_key !== ratingKey);
+                                _ptSelected.delete(ratingKey);
+                                _ptRenderUsenetGroup('pt-in-usenet-tbody', _ptInUsenet);
+                                _ptRenderUsenetGroup('pt-not-usenet-tbody', _ptNotUsenet);
+                            }
+                            _ptUpdateUsenetCounts(); _ptUpdatePurgeBtn();
+                            if (scanItem?.file_dir) {
+                                fetch('/debrid_manager/api/plex_force_scan', {
+                                    method: 'POST', headers: {'Content-Type': 'application/json'},
+                                    body: JSON.stringify({ paths: [scanItem.file_dir], empty_trash: false }),
+                                }).catch(() => {});
+                            }
+                        } catch(e) { showPopup({ type: 'error', title: 'Error', message: 'Delete failed: ' + e.message, autoClose: 5000 }); btn.innerHTML = origHtml; btn.disabled = false; }
+                    },
+                    onCancel: function() { btn.disabled = false; }
+                });
+                return;
+            }
+        });
+    });
+}
+
+function _ptUpdateUsenetCounts() {
+    const inEl = document.getElementById('pt-in-usenet-count');
+    const outEl = document.getElementById('pt-not-usenet-count');
+    if (inEl) inEl.textContent = _ptInUsenet.length;
+    if (outEl) outEl.textContent = _ptNotUsenet.length;
+    // Update sub-tab badge
+    const usenetTotal = _ptInUsenet.length + _ptNotUsenet.length;
+    const subtabBadge = document.getElementById('pt-subtab-usenet-count');
+    if (subtabBadge) subtabBadge.textContent = usenetTotal || '';
+}
+
+
+document.getElementById('pt-in-usenet-select-all')?.addEventListener('change', function() {
+    if (this.checked) _ptInUsenet.forEach(i => _ptSelected.add(i.rating_key));
+    else _ptInUsenet.forEach(i => _ptSelected.delete(i.rating_key));
+    _ptRenderUsenetGroup('pt-in-usenet-tbody', _ptInUsenet);
+    _ptUpdatePurgeBtn();
+});
+document.getElementById('pt-not-usenet-select-all')?.addEventListener('change', function() {
+    if (this.checked) _ptNotUsenet.forEach(i => _ptSelected.add(i.rating_key));
+    else _ptNotUsenet.forEach(i => _ptSelected.delete(i.rating_key));
+    _ptRenderUsenetGroup('pt-not-usenet-tbody', _ptNotUsenet);
+    _ptUpdatePurgeBtn();
+});
+document.getElementById('pt-select-in-usenet')?.addEventListener('click', () => {
+    _ptInUsenet.forEach(i => _ptSelected.add(i.rating_key));
+    _ptRenderUsenetGroup('pt-in-usenet-tbody', _ptInUsenet);
+    _ptUpdatePurgeBtn();
+});
+document.getElementById('pt-select-not-usenet')?.addEventListener('click', () => {
+    _ptNotUsenet.forEach(i => _ptSelected.add(i.rating_key));
+    _ptRenderUsenetGroup('pt-not-usenet-tbody', _ptNotUsenet);
+    _ptUpdatePurgeBtn();
+});
+
+async function _ptBulkReNzb(items, label) {
+    if (!items.length) { showPopup({ type: 'warning', title: 'Notice', message: `No ${label} items to re-submit.`, autoClose: 4000 }); return; }
+    const btn = event.currentTarget;
+    const origHtml = btn.innerHTML;
+    showPopup({
+        type: 'confirm',
+        title: 'Re-NZB All',
+        message: `Re-submit ${items.length} ${label} item${items.length !== 1 ? 's' : ''} to Decypharr?\n\nItems without a stored URL will fall back to re-scraping.`,
+        confirmText: 'Re-NZB All',
+        cancelText: 'Cancel',
+        onConfirm: async function() {
+            btn.disabled = true;
+            btn.innerHTML = '<span class="dm-spinner"></span>';
+            let done = 0, failed = 0;
+            for (const item of items) {
+                try {
+                    const r = await fetch('/debrid_manager/api/nzb/reinsert', {
+                        method: 'POST', headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({ item_id: item.nzb_item_id, nzb_url: item.nzb_url || '', nzb_title: item.nzb_title || '', rating_key: item.rating_key }),
+                    });
+                    const d = await r.json();
+                    if (d.success) done++; else failed++;
+                } catch(e) { failed++; }
+            }
+            showPopup({ type: done ? 'success' : 'error', title: 'Re-NZB All', message: `Submitted: ${done}${failed ? `, Failed: ${failed}` : ''}`, autoClose: 5000 });
+            btn.innerHTML = origHtml; btn.disabled = false;
+        }
+    });
+}
+
+function _ptUsenetScanPaths(items) {
+    // Build new-download paths: parent(file_dir) + nzb_title
+    // Falls back to just parent(file_dir) if no title available
+    const paths = [];
+    for (const i of items) {
+        if (!i.file_dir) continue;
+        const parent = i.file_dir.substring(0, i.file_dir.lastIndexOf('/'));
+        if (!parent) continue;
+        const newPath = i.nzb_title ? `${parent}/${i.nzb_title}` : parent;
+        paths.push(newPath);
+    }
+    return [...new Set(paths)];
+}
+
+document.getElementById('pt-bulk-scan-in-usenet')?.addEventListener('click', async function() {
+    const paths = _ptUsenetScanPaths(_ptInUsenet);
+    if (!paths.length) { showPopup({ type: 'warning', title: 'Notice', message: 'No scan paths available.', autoClose: 4000 }); return; }
+    this.disabled = true;
+    const origHtml = this.innerHTML;
+    this.innerHTML = '<span class="dm-spinner"></span>';
+    try {
+        await fetch('/debrid_manager/api/plex_force_scan', {
+            method: 'POST', headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({paths, empty_trash: false}),
+        });
+        this.textContent = 'Done';
+        setTimeout(() => { this.innerHTML = origHtml; this.disabled = false; }, 2500);
+    } catch(e) { showPopup({ type: 'error', title: 'Error', message: 'Scan failed: ' + e.message, autoClose: 5000 }); this.innerHTML = origHtml; this.disabled = false; }
+});
+document.getElementById('pt-bulk-scan-not-usenet')?.addEventListener('click', async function() {
+    const paths = _ptUsenetScanPaths(_ptNotUsenet);
+    if (!paths.length) { showPopup({ type: 'warning', title: 'Notice', message: 'No scan paths available.', autoClose: 4000 }); return; }
+    this.disabled = true;
+    const origHtml = this.innerHTML;
+    this.innerHTML = '<span class="dm-spinner"></span>';
+    try {
+        await fetch('/debrid_manager/api/plex_force_scan', {
+            method: 'POST', headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({paths, empty_trash: false}),
+        });
+        this.textContent = 'Done';
+        setTimeout(() => { this.innerHTML = origHtml; this.disabled = false; }, 2500);
+    } catch(e) { showPopup({ type: 'error', title: 'Error', message: 'Scan failed: ' + e.message, autoClose: 5000 }); this.innerHTML = origHtml; this.disabled = false; }
+});
+document.getElementById('pt-bulk-renzb-in')?.addEventListener('click', function() {
+    _ptBulkReNzb(_ptInUsenet, 'in-Usenet');
+});
+document.getElementById('pt-bulk-renzb-not')?.addEventListener('click', function() {
+    _ptBulkReNzb(_ptNotUsenet, 'not-in-Usenet');
+});
+document.getElementById('pt-bulk-del-in-usenet')?.addEventListener('click', function() {
+    _ptBulkDelete(_ptInUsenet, 'in-Usenet');
+});
+document.getElementById('pt-bulk-del-not-usenet')?.addEventListener('click', function() {
+    _ptBulkDelete(_ptNotUsenet, 'not-in-Usenet');
+});
 {% endif %}
 
 // ── RECONCILE TAB ──────────────────────────────────────────────────────────

--- a/templates/upgrade_hub.html
+++ b/templates/upgrade_hub.html
@@ -47,8 +47,10 @@
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
         </svg>
-        <span><strong>Note:</strong> A local instance of Zilean is required. Configure it in
-        <a href="/settings#scrapers" class="uh-note-link">Settings → Scraper Settings → Zilean Scraper</a>.</span>
+        <span><strong>Note:</strong> Requires at least one upgrade source — a local
+        <a href="/settings#scrapers" class="uh-note-link">Zilean</a> instance and/or enabled
+        <a href="/settings#scrapers" class="uh-note-link">Newznab indexers</a>. Configure sources in
+        Settings → Scraper Settings. Select which source(s) to use in the Settings tab below.</span>
     </div>
 
     <!-- Progress bar (shown during scan) -->
@@ -365,6 +367,17 @@
                     </div>
                 </div>
 
+                <!-- Sub-card: Upgrade Source -->
+                <div class="uh-settings-section">
+                    <div class="uh-settings-subsection-title">Upgrade Source</div>
+                    <p class="uh-settings-desc">Which sources to scan for upgrade candidates.</p>
+                    <select id="settings-upgrade-source" class="uh-filter-select" style="margin-top:6px">
+                        <option value="both">Both (Zilean + NZB Indexers)</option>
+                        <option value="zilean_only">Zilean Only</option>
+                        <option value="nzb_only">NZB Indexers Only</option>
+                    </select>
+                </div>
+
                 <!-- Sub-card: Excluded Genres -->
                 <div class="uh-settings-section">
                     <div class="uh-settings-subsection-title uh-genre-title">Excluded Genres</div>
@@ -619,8 +632,8 @@ function buildUpgradeRow(u) {
         <td class="uh-col-type"><span class="uh-type-badge uh-type-${u.type}">${escHtml(label)}</span></td>
         <td class="uh-col-title">${title}</td>
         <td class="uh-col-files">
-            <div class="uh-muted">${escHtml(u.current_file || '—')}</div>
-            <div class="uh-best-candidate">${escHtml(u.new_title || '—')}</div>
+            <div class="uh-muted">${escHtml(u.current_file || '—')} ${u.current_protocol === 'nzb' ? '<span class="uh-proto-badge uh-proto-nzb">NZB</span>' : '<span class="uh-proto-badge uh-proto-debrid">Debrid</span>'}</div>
+            <div class="uh-best-candidate">${escHtml(u.new_title || '—')} ${u.protocol === 'nzb' ? '<span class="uh-proto-badge uh-proto-nzb">NZB</span>' : '<span class="uh-proto-badge uh-proto-debrid">Debrid</span>'}</div>
         </td>
         <td class="uh-col-version">${escHtml(u.version || '—')}<br>${cacheBadge}${rdBadge ? ' ' + rdBadge : ''}</td>
         <td class="uh-col-score">
@@ -657,17 +670,18 @@ function buildPackRow(p) {
 
     const files = p.current_files || [];
     let currentHtml;
+    const curProtoBadge = p.current_protocol === 'nzb' ? '<span class="uh-proto-badge uh-proto-nzb">NZB</span>' : '<span class="uh-proto-badge uh-proto-debrid">Debrid</span>';
     if (files.length === 0) {
-        currentHtml = '<div class="uh-muted">—</div>';
+        currentHtml = `<div class="uh-muted">— ${curProtoBadge}</div>`;
     } else if (files.length === 1) {
-        currentHtml = `<div class="uh-muted">${escHtml(files[0].file || '—')}</div>`;
+        currentHtml = `<div class="uh-muted">${escHtml(files[0].file || '—')} ${curProtoBadge}</div>`;
     } else {
         const epsHtml = files.map(f =>
             `<div class="uh-pack-ep"><span class="uh-ep-num">E${pad(f.ep)}</span>${escHtml(f.file || '—')}</div>`
         ).join('');
         const tagsStr = fileTagsStr(files[0].file || '');
         const tagsHtml = tagsStr ? `<span class="uh-ep-sep"> - </span><span class="uh-ep-tags">${escHtml(tagsStr)}</span>` : '';
-        currentHtml = `<button class="uh-pack-expand-btn" onclick="togglePackExpand(this)"><span class="uh-ep-count">${files.length} episodes</span>${tagsHtml}<span class="uh-expand-arrow">▼</span></button><div class="uh-pack-episodes">${epsHtml}</div>`;
+        currentHtml = `<button class="uh-pack-expand-btn" onclick="togglePackExpand(this)"><span class="uh-ep-count">${files.length} episodes</span>${tagsHtml} ${curProtoBadge}<span class="uh-expand-arrow">▼</span></button><div class="uh-pack-episodes">${epsHtml}</div>`;
     }
 
     return `<tr data-item-ids="${safeIds}">
@@ -680,7 +694,7 @@ function buildPackRow(p) {
         </td>
         <td class="uh-col-new">
             ${currentHtml}
-            <div class="uh-best-candidate">${escHtml(p.new_title || '—')}</div>
+            <div class="uh-best-candidate">${escHtml(p.new_title || '—')} ${p.protocol === 'nzb' ? '<span class="uh-proto-badge uh-proto-nzb">NZB</span>' : '<span class="uh-proto-badge uh-proto-debrid">Debrid</span>'}</div>
         </td>
         <td class="uh-col-version">${escHtml(p.version || '—')}<br>${cacheBadge}${rdBadge ? ' ' + rdBadge : ''}</td>
         <td class="uh-col-score">
@@ -1197,6 +1211,7 @@ let _settings = {
     recent_threshold_days: 90,
     excluded_genres: '',
     exclude_nas_items: false,
+    upgrade_source: 'both',
 };
 
 async function loadSettings() {
@@ -1265,6 +1280,10 @@ function applySettingsToUI() {
     // Exclude NAS items toggle
     const excludeNasChk = document.getElementById('settings-exclude-nas');
     if (excludeNasChk) excludeNasChk.checked = !!_settings.exclude_nas_items;
+
+    // Upgrade source
+    const upgradeSourceSel = document.getElementById('settings-upgrade-source');
+    if (upgradeSourceSel) upgradeSourceSel.value = _settings.upgrade_source || 'both';
 
     // Excluded genres chips
     const rawGenres = _settings.excluded_genres || '';
@@ -1377,6 +1396,7 @@ async function saveSettings() {
         recent_threshold_days:  recentDaysInp ? parseInt(recentDaysInp.value) || 90 : 90,
         excluded_genres:        _uhExcludedGenres.join(','),
         exclude_nas_items:      excludeNasChk ? excludeNasChk.checked : false,
+        upgrade_source:         (document.getElementById('settings-upgrade-source') || {}).value || 'both',
     };
     try {
         const res = await fetch('/upgrade_hub/api/settings', {

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -2669,6 +2669,11 @@ SETTINGS_SCHEMA = {
             "description": "Where to route when clicking on TV shows not in library (movies always go to Discover details)",
             "default": "discover",
             "choices": ["discover", "add_media"]
+        },
+        "hide_specials": {
+            "type": "boolean",
+            "description": "Hide TV show specials (Season 0) from the Discover details page season list",
+            "default": True
         }
     },
     "Bazarr Integration": {

--- a/utilities/web_scraper.py
+++ b/utilities/web_scraper.py
@@ -833,11 +833,13 @@ def get_media_meta(tmdb_id: str, media_type: str) -> Optional[Tuple[str, str, li
         status_code = getattr(getattr(e, 'response', None), 'status_code', None)
         if status_code == 404:
             logging.warning(f"TMDb details not found (404) for {media_type} {tmdb_id}: {e}")
+        elif status_code == 429:
+            logging.warning(f"TMDb rate limit hit for {media_type} {tmdb_id}")
         else:
-            logging.error(f"Error fetching media meta from TMDb: {e}")
+            logging.warning(f"TMDb HTTP error for {media_type} {tmdb_id}: {e}")
         return None
-    except api.exceptions.RequestException as e:
-        logging.error(f"Error fetching media meta from TMDb: {e}")
+    except (api.exceptions.RequestException, ValueError) as e:
+        logging.warning(f"TMDb request failed for {media_type} {tmdb_id}: {e}")
         return None
     
 def overseerr_tvshow(title: str, year: Optional[int] = None, media_id: Optional[int] = None, season: Optional[int] = None) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Add NZB indexer support to Upgrade Hub (browse pool, title+year matching, same scoring pipeline as Zilean) Add NZB/Debrid protocol badges to Upgrade Hub current file and candidate columns Add Upgrade Source setting to Upgrade Hub (Both / Zilean Only / NZB Indexers Only) Fix NZB upgrades routing to Decypharr instead of debrid service Fix NZB upgrade skipping old completed Decypharr job when re-upgrading Fix NZB upgrade success detection (Adding state vs Checking state) Fix library deletion now removes NZB items from Decypharr Add Plex trash tab shows NZB items, with option to re-submit to Decypharr Add NZB repair engine for detecting and replacing broken NZB downloads Add Decypharr cleanup utility
Add query result cache to Newznab and Prowlarr scrapers (10 min TTL) Fix TMDb gzip decompression error in library movie/show detail pages Fix database bloat: clear scrape_results on item collection, one-time cleanup migration Add TMDb to API rate limit monitor
Downgrade transient TMDb request failures from ERROR to WARNING