### PR TITLE
Fixes and improvements

### DIFF
--- a/database/statistics.py
+++ b/database/statistics.py
@@ -150,8 +150,13 @@ def get_cached_download_stats():
         try:
             # Add timeout protection for provider initialization
             provider = get_debrid_provider()
+            if not provider:
+                download_stats_cache['active_downloads'] = {'count': 0, 'limit': 0, 'percentage': 0, 'status': 'error', 'error': 'no_provider'}
+                download_stats_cache['usage_stats'] = {'used': '0', 'limit': '0', 'percentage': 0, 'error': 'no_provider'}
+                download_stats_cache['last_update'] = current_time
+                return download_stats_cache['active_downloads'], download_stats_cache['usage_stats']
             logging.debug("Debrid provider initialized successfully")
-            
+
             # Get active downloads with timeout protection
             try:
                 logging.debug("Fetching active downloads...")
@@ -271,8 +276,8 @@ def get_cached_download_stats():
             download_stats_cache['last_update'] = current_time
             logging.debug("Download stats cache updated successfully")
             
-        except ProviderUnavailableError as e:
-            logging.error(f"Provider unavailable: {str(e)}")
+        except ProviderUnavailableError:
+            pass  # No debrid key configured — expected on usenet-only setups
             if download_stats_cache['active_downloads'] is None:
                 download_stats_cache['active_downloads'] = {
                     'count': 0,
@@ -329,9 +334,10 @@ def get_cached_subscription_status() -> Dict:
         # If we have never populated subscription, or our overall cache TTL expired, refresh
         if (download_stats_cache.get('subscription') is None or
             download_stats_cache['last_update'] + 1800 < current_time):
-            provider = get_debrid_provider()
+            _debrid_key = get_setting('Debrid Provider', 'api_key', default='').strip()
+            provider = get_debrid_provider() if _debrid_key else None
             # Get fresh subscription status from provider
-            subscription = provider.get_subscription_status() if hasattr(provider, 'get_subscription_status') else {
+            subscription = provider.get_subscription_status() if provider and hasattr(provider, 'get_subscription_status') else {
                 'days_remaining': None,
                 'expiration': None,
                 'premium': None

--- a/debrid/debridlink/client.py
+++ b/debrid/debridlink/client.py
@@ -465,6 +465,8 @@ class DebridLinkProvider(DebridProvider):
                                         if tid != torrent_id}
             logger.info(f"Debrid-Link torrent {torrent_id} deleted ({removal_reason})")
             return True
+        except ProviderUnavailableError:
+            return False
         except Exception as e:
             logger.error(f"Debrid-Link remove_torrent error for {torrent_id}: {e}")
             return False
@@ -504,6 +506,8 @@ class DebridLinkProvider(DebridProvider):
             active = sum(1 for t in torrents
                          if not self._is_complete(t) and not self._is_error(t))
             return active, self.MAX_DOWNLOADS
+        except ProviderUnavailableError:
+            raise
         except Exception as e:
             raise ProviderUnavailableError(f"Failed to get Debrid-Link active downloads: {e}")
 

--- a/debrid/real_debrid/client.py
+++ b/debrid/real_debrid/client.py
@@ -103,7 +103,7 @@ class RealDebridProvider(DebridProvider):
             from .api import get_api_key
             return get_api_key()
         except Exception as e:
-            logging.error(f"Failed to load API key: {str(e)}", exc_info=True)
+            logging.debug(f"Failed to load API key: {str(e)}")
             raise ProviderUnavailableError(f"Failed to load API key: {str(e)}")
 
     @property
@@ -177,6 +177,8 @@ class RealDebridProvider(DebridProvider):
                 'locale': user_info.get('locale', ''),
                 'type': user_info.get('type', ''),
             }
+        except ProviderUnavailableError:
+            return {'days_remaining': None, 'expiration': None, 'premium': None}
         except Exception as e:
             logging.error(f"Error fetching subscription status: {str(e)}")
             return {
@@ -716,6 +718,8 @@ class RealDebridProvider(DebridProvider):
             
         except TooManyDownloadsError:
             raise
+        except ProviderUnavailableError:
+            raise
         except Exception as e:
             logging.error(f"Error getting active downloads: {str(e)}", exc_info=True)
             raise ProviderUnavailableError(f"Failed to get active downloads: {str(e)}")
@@ -778,6 +782,8 @@ class RealDebridProvider(DebridProvider):
                 logging.exception("Full traceback:")
                 return {'downloaded': 0, 'limit': 2000}
 
+        except ProviderUnavailableError:
+            raise
         except Exception as e:
             logging.error(f"Error getting user traffic: {str(e)}")
             raise ProviderUnavailableError(f"Failed to get user traffic: {str(e)}")
@@ -959,6 +965,8 @@ class RealDebridProvider(DebridProvider):
                 if hash_value in self._all_torrent_ids:
                     del self._all_torrent_ids[hash_value]
 
+        except ProviderUnavailableError:
+            raise
         except Exception as e:
             if "404" in str(e):
                 logging.warning(f"Torrent {torrent_id} already removed from Real-Debrid")

--- a/overlays/overlay_manager.py
+++ b/overlays/overlay_manager.py
@@ -3103,15 +3103,14 @@ class OverlayManager:
                 f"show={show_plex_rating_key} season={season_number}")
 
         except Exception as e:
-            self.logger.error(
-                f"Failed to generate season overlay for {season_plex_rating_key}: {e}",
-                exc_info=True)
             result['status'] = 'error'
             result['message'] = str(e)
             # 404 means the Plex ratingKey no longer exists (stale after library rescan).
             # Delete the row so it stops being retried — it will be re-registered with
             # the new ratingKey on the next sync.
             if '404' in str(e):
+                self.logger.warning(
+                    f"Season overlay skipped for {season_plex_rating_key} — stale Plex key (404), will re-sync")
                 try:
                     from database.core import get_db_connection
                     _conn = get_db_connection()
@@ -3125,6 +3124,9 @@ class OverlayManager:
                 except Exception:
                     pass
             else:
+                self.logger.error(
+                    f"Failed to generate season overlay for {season_plex_rating_key}: {e}",
+                    exc_info=True)
                 try:
                     self._update_season_overlay_state(
                         show_plex_rating_key, season_plex_rating_key, season_number,

--- a/queues/checking_queue.py
+++ b/queues/checking_queue.py
@@ -87,6 +87,7 @@ class CheckingQueue:
         self.checking_times = {}
         self.last_check_time = datetime.now()
         self.last_report_time = datetime.now()
+        self._nzb_missing_counts = {}  # tracks consecutive not-found polls per torrent_id
 
     def update(self):
         from database import get_all_media_items
@@ -113,6 +114,8 @@ class CheckingQueue:
             logging.debug(f"New torrent IDs added: {added_torrents}")
         if removed_torrents:
             logging.debug(f"Torrent IDs no longer present: {removed_torrents}")
+            for _tid in removed_torrents:
+                self._nzb_missing_counts.pop(_tid, None)
         
         # Initialize checking times for new items
         for item in self.items:
@@ -120,7 +123,10 @@ class CheckingQueue:
                 self.checking_queue_times[item['id']] = time.time()
                 logging.debug(f"Initialized checking time for item {item['id']} with torrent ID {item.get('filled_by_torrent_id')}")
 
-    def get_contents(self):
+    def get_contents(self, raw=False):
+        # raw=True: skip live API calls, return items as-is (for page render, not SSE stream)
+        if raw:
+            return list(self.items)
         # Add progress and state information to each item
         items_with_info = []
         items_to_remove = []
@@ -457,15 +463,16 @@ class CheckingQueue:
             if not status:
                 # Job not found in Decypharr — track consecutive misses
                 # After 3 consecutive misses declare it missing so handle_missing_torrent fires
-                _key = f'_nzb_missing_{torrent_id}'
-                _count = getattr(self, _key, 0) + 1
-                setattr(self, _key, _count)
+                _count = self._nzb_missing_counts.get(torrent_id, 0) + 1
                 if _count >= 3:
                     logging.warning(f'[NZB] Job {job_id} not found in Decypharr after {_count} checks — declaring missing')
-                    setattr(self, _key, 0)
+                    self._nzb_missing_counts.pop(torrent_id, None)
                     return PROGRESS_RESULT_MISSING
+                self._nzb_missing_counts[torrent_id] = _count
                 logging.debug(f'[NZB] Job {job_id} not found in Decypharr (miss {_count}/3)')
                 return None
+            # Job found — clear any miss counter
+            self._nzb_missing_counts.pop(torrent_id, None)
             raw = status.get('raw', {})
             state = str(raw.get('state', status.get('state', 'unknown'))).lower()
             inner_status = str(raw.get('status', '')).lower()

--- a/queues/queue_manager.py
+++ b/queues/queue_manager.py
@@ -325,7 +325,11 @@ class QueueManager:
         """
         contents = OrderedDict()
         for state, queue in self.queues.items():
-            contents[state] = queue.get_contents()
+            # Checking queue: skip live API calls — SSE stream handles progress separately
+            if state == 'Checking' and hasattr(queue, 'get_contents'):
+                contents[state] = queue.get_contents(raw=True)
+            else:
+                contents[state] = queue.get_contents()
         return contents
 
     @staticmethod

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -164,9 +164,10 @@ class ProgramRunner:
             from metadata.metadata import _get_local_timezone # Added import
             tz = _get_local_timezone()
             logging.info(f"Initializing APScheduler with timezone: {tz.key}")
+            _queue_workers = max(1, min(3, int(get_setting('Queue', 'queue_pool_workers', 2))))
             executors = {
                 'default': ThreadPoolExecutor(max_workers=1),  # scheduled/maintenance tasks — sequential
-                'queue': ThreadPoolExecutor(max_workers=2),    # queue processing tasks — Scraping/Adding + Checking run simultaneously
+                'queue': ThreadPoolExecutor(max_workers=_queue_workers),
             }
             job_defaults = {
                 'coalesce': True,
@@ -174,12 +175,13 @@ class ProgramRunner:
                 'misfire_grace_time': None
             }
             self.scheduler = BackgroundScheduler(jobstores=_jobstores, executors=executors, job_defaults=job_defaults, timezone=tz)
-            logging.info("APScheduler configured with separate thread pools: queue(3) and default(2).")
+            logging.info(f"APScheduler configured with separate thread pools: queue({_queue_workers}) and default(1).")
         except Exception as e:
             logging.error(f"Failed to get local timezone for scheduler, using system default: {e}")
+            _queue_workers = max(1, min(3, int(get_setting('Queue', 'queue_pool_workers', 2))))
             executors = {
                 'default': ThreadPoolExecutor(max_workers=1),
-                'queue': ThreadPoolExecutor(max_workers=2),
+                'queue': ThreadPoolExecutor(max_workers=_queue_workers),
             }
             job_defaults = {
                 'coalesce': True,
@@ -2531,7 +2533,7 @@ class ProgramRunner:
                 try:
                     logging.info("Attempting to shut down APScheduler...")
                     if self.scheduler.running:
-                        self.scheduler.shutdown(wait=True) 
+                        self.scheduler.shutdown(wait=True)
                         logging.info("APScheduler shut down successfully.")
                     else:
                         logging.info("APScheduler was not running when stop was called.")
@@ -3196,10 +3198,24 @@ class ProgramRunner:
         except Exception as e:
             logging.error(f'[DEBRID_CLEANUP] Scheduled task error: {e}', exc_info=True)
 
+    # Track last health check duration to implement skip-if-slow guard
+    _nzb_health_last_duration: float = 0.0
+    _NZB_HEALTH_MAX_JOBS_PER_TICK = 15   # cap jobs polled per tick
+    _NZB_HEALTH_JOB_TIMEOUT = 8          # seconds per job poll before giving up
+    _NZB_HEALTH_SKIP_THRESHOLD = 8.0     # if last run took this long, skip next tick
+
     def task_nzb_health_check(self):
         """Poll NZB items in Adding state, run health checks, move to Checking or back to Wanted.
-        Runs as a dedicated scheduled task so it doesn't block the Adding/Scraping queue threads."""
+        Runs as a dedicated scheduled task so it doesn't block the Adding/Scraping queue threads.
+        Guards: skips tick if previous run was slow; caps jobs per tick; per-job timeout."""
+        import time as _time
         try:
+            # Option 2: skip this tick if previous run took too long
+            if self._nzb_health_last_duration >= self._NZB_HEALTH_SKIP_THRESHOLD:
+                logging.debug(f'[NZBHealthCheck] Skipping tick — previous run took {self._nzb_health_last_duration:.1f}s')
+                self._nzb_health_last_duration = 0.0  # reset so next tick runs
+                return
+
             if not self.queue_manager:
                 return
             adding_queue = self.queue_manager.queues.get('Adding')
@@ -3212,6 +3228,8 @@ class ProgramRunner:
             ]
             if not _nzb_items:
                 return
+
+            _tick_start = _time.monotonic()
 
             from usenet.decypharr_client import get_decypharr_client, reset_decypharr_client
             from utilities.settings import get_setting as _gs
@@ -3226,6 +3244,11 @@ class ProgramRunner:
             for _ni in _nzb_items:
                 _jid = _ni.get('filled_by_torrent_id', '')[4:]
                 _job_groups[_jid].append(_ni)
+
+            # Option 3: cap jobs per tick — process oldest first (preserve order)
+            _unique_jobs = list(_job_groups.keys())[:self._NZB_HEALTH_MAX_JOBS_PER_TICK]
+            if len(_job_groups) > self._NZB_HEALTH_MAX_JOBS_PER_TICK:
+                logging.debug(f'[NZBHealthCheck] Capping to {self._NZB_HEALTH_MAX_JOBS_PER_TICK}/{len(_job_groups)} jobs this tick')
 
             def _poll_job(job_id):
                 try:
@@ -3261,13 +3284,26 @@ class ProgramRunner:
                 except Exception as exc:
                     return job_id, None, None, exc
 
-            _unique_jobs = list(_job_groups.keys())
+            # Option 3: cap workers at 5, per-job timeout
             _job_results = {}
-            with _TPE(max_workers=min(len(_unique_jobs), 10)) as _pool:
+            with _TPE(max_workers=min(len(_unique_jobs), 5)) as _pool:
                 _futures = {_pool.submit(_poll_job, jid): jid for jid in _unique_jobs}
-                for _fut in _ac(_futures):
-                    jid, prog, entry, err = _fut.result()
-                    _job_results[jid] = (prog, entry, err)
+                try:
+                    for _fut in _ac(_futures, timeout=self._NZB_HEALTH_JOB_TIMEOUT * len(_unique_jobs)):
+                        try:
+                            jid, prog, entry, err = _fut.result(timeout=self._NZB_HEALTH_JOB_TIMEOUT)
+                            _job_results[jid] = (prog, entry, err)
+                        except Exception:
+                            pass
+                except Exception:
+                    # Timeout — process whatever completed so far, skip the rest
+                    for _fut, jid in _futures.items():
+                        if _fut.done():
+                            try:
+                                _, prog, entry, err = _fut.result()
+                                _job_results[jid] = (prog, entry, err)
+                            except Exception:
+                                pass
 
             # Health check completed entries in parallel
             _entries_to_check = {}
@@ -3284,9 +3320,21 @@ class ProgramRunner:
                         return entry_name, None
                 with _TPE(max_workers=min(len(_entries_to_check), 5)) as _hpool:
                     _hfutures = {_hpool.submit(_check_health, en): en for en in _entries_to_check}
-                    for _hfut in _ac(_hfutures):
-                        en, health = _hfut.result()
-                        _health_results[en] = health
+                    try:
+                        for _hfut in _ac(_hfutures, timeout=self._NZB_HEALTH_JOB_TIMEOUT * len(_entries_to_check)):
+                            try:
+                                en, health = _hfut.result(timeout=self._NZB_HEALTH_JOB_TIMEOUT)
+                                _health_results[en] = health
+                            except Exception:
+                                pass
+                    except Exception:
+                        for _hfut in _hfutures:
+                            if _hfut.done():
+                                try:
+                                    en, health = _hfut.result()
+                                    _health_results[en] = health
+                                except Exception:
+                                    pass
 
             # Process results per item
             for item in _nzb_items:
@@ -3429,8 +3477,12 @@ class ProgramRunner:
                 except Exception as _exc:
                     logging.error(f'[NZB] Error in health check for {torrent_id}: {_exc}', exc_info=True)
 
+            self._nzb_health_last_duration = _time.monotonic() - _tick_start
+            logging.debug(f'[NZBHealthCheck] Tick completed in {self._nzb_health_last_duration:.1f}s ({len(_unique_jobs)} jobs)')
+
         except Exception as e:
             logging.error(f'[NZBHealthCheck] Task error: {e}', exc_info=True)
+            self._nzb_health_last_duration = 0.0
 
     def task_backfill_nzb_torrent_ids(self):
         """Backfill filled_by_torrent_id for collected items on Decypharr mount that have no torrent ID.
@@ -4039,7 +4091,7 @@ class ProgramRunner:
         with self.scheduler_lock:
             if self.scheduler and self.scheduler.running:
                 logging.info("Shutting down scheduler for reinitialization...")
-                self.scheduler.shutdown(wait=True) # Wait for jobs to finish if possible
+                self.scheduler.shutdown(wait=True)
                 logging.info("Scheduler stopped.")
 
         self._initialized_runner_attributes = False
@@ -4240,7 +4292,6 @@ class ProgramRunner:
         
         if thread.is_alive():
             logging.error("Download stats refresh timed out after 30 seconds")
-            # Note: The thread will continue running in the background as a daemon thread
         elif exception[0]:
             logging.error(f"Download stats refresh failed: {str(exception[0])}")
 
@@ -5860,6 +5911,9 @@ class ProgramRunner:
 
         logging.info(f"[StuckPlex] Found {len(stuck)} stuck item(s): {stuck}")
 
+        # Symlink mode detection
+        _is_symlink_mode = get_setting('File Management', 'file_collection_management', default='') == 'Symlinked/Local'
+
         # Decypharr config
         from utilities.settings import get_setting as _gs
         decypharr_url = _gs('Usenet Provider', 'url', default='').rstrip('/')
@@ -5897,10 +5951,67 @@ class ProgramRunner:
                 logging.warning(f"[StuckPlex] Decypharr delete failed for {name}: {e}")
             return False
 
+        def delete_source_by_torrent_id(torrent_id, display):
+            """Delete the source (Decypharr NZB or debrid torrent) by filled_by_torrent_id."""
+            if not torrent_id:
+                return
+            try:
+                if str(torrent_id).startswith('nzb:'):
+                    # NZB — delete from Decypharr by hash
+                    if not decypharr_enabled or not decypharr_url:
+                        return
+                    nzb_hash = torrent_id[4:]  # strip 'nzb:' prefix
+                    d = _req.delete(f'{decypharr_url}/api/torrents',
+                                    params={'hashes': nzb_hash},
+                                    headers=decypharr_headers(), timeout=10)
+                    if d.status_code in (200, 204):
+                        logging.info(f"[StuckPlex] Deleted NZB source from Decypharr: {display} ({nzb_hash})")
+                    else:
+                        logging.debug(f"[StuckPlex] Decypharr NZB delete returned {d.status_code} for {display} — likely already gone")
+                else:
+                    # Debrid torrent
+                    try:
+                        from debrid import get_debrid_provider, ProviderUnavailableError
+                        provider = get_debrid_provider()
+                        if provider:
+                            provider.remove_torrent(torrent_id, removal_reason='Stuck Plex item cleanup')
+                            logging.info(f"[StuckPlex] Deleted debrid source: {display} ({torrent_id})")
+                    except Exception as _de:
+                        logging.debug(f"[StuckPlex] Debrid source delete for {display} — likely already gone: {_de}")
+            except Exception as e:
+                logging.debug(f"[StuckPlex] Source delete failed for {display} — likely already gone: {e}")
+
+        def find_db_item_by_path(file_path):
+            """Find CLI DB item matching a file path (works for both Plex and symlink mode)."""
+            symlink_path = file_path
+            if not symlink_path:
+                return None
+            try:
+                from database import get_db_connection as _gdb
+                conn = _gdb()
+                try:
+                    row = conn.execute(
+                        "SELECT * FROM media_items WHERE location_on_disk = ? LIMIT 1",
+                        (symlink_path,)
+                    ).fetchone()
+                    if not row:
+                        # Try basename match
+                        basename = os.path.basename(symlink_path)
+                        row = conn.execute(
+                            "SELECT * FROM media_items WHERE location_on_disk LIKE ? LIMIT 1",
+                            (f'%{basename}',)
+                        ).fetchone()
+                    return dict(row) if row else None
+                finally:
+                    conn.close()
+            except Exception as e:
+                logging.debug(f"[StuckPlex] DB lookup failed for {symlink_path}: {e}")
+                return None
+
         for item_id in stuck:
             try:
                 r = _req.get(f'{plex_url}/library/metadata/{item_id}',
-                             params={'X-Plex-Token': plex_token}, timeout=10)
+                             params={'X-Plex-Token': plex_token}, timeout=30)
                 if r.status_code == 404:
                     # Already gone — unstuck itself or was deleted, nothing to do
                     logging.info(f"[StuckPlex] Item {item_id} already gone from Plex (404) — skipping")
@@ -5949,13 +6060,58 @@ class ProgramRunner:
                     search_name = grandparent or title
                     delete_from_decypharr(search_name)
 
+                # Always delete source from Decypharr/debrid via DB filled_by_torrent_id
+                # so the file disappears from the mount and Plex can't re-scan it stuck
+                _part_path = next((p for p in parts if p), None)
+                _db_item_for_source = find_db_item_by_path(_part_path) if _part_path else None
+                if _db_item_for_source:
+                    delete_source_by_torrent_id(_db_item_for_source.get('filled_by_torrent_id'), display)
+
                 # Always delete from Plex
-                dr = _req.delete(f'{plex_url}/library/metadata/{item_id}',
-                                 params={'X-Plex-Token': plex_token}, timeout=10)
-                if dr.status_code == 200:
-                    logging.info(f"[StuckPlex] Deleted from Plex: {display} (id={item_id})")
-                else:
-                    logging.warning(f"[StuckPlex] Plex delete failed for {display}: HTTP {dr.status_code}")
+                try:
+                    dr = _req.delete(f'{plex_url}/library/metadata/{item_id}',
+                                     params={'X-Plex-Token': plex_token}, timeout=30)
+                    if dr.status_code == 200:
+                        logging.info(f"[StuckPlex] Deleted from Plex: {display} (id={item_id})")
+                    else:
+                        logging.warning(f"[StuckPlex] Plex delete failed for {display}: HTTP {dr.status_code}")
+                except Exception as _plex_del_err:
+                    logging.warning(f"[StuckPlex] Plex delete timed out or failed for {display} — Plex may be busy: {_plex_del_err}")
+
+                # Symlink mode: delete symlink, delete source, reset DB to Wanted
+                if _is_symlink_mode:
+                    # Use first valid part path as the symlink
+                    symlink_path = next((p for p in parts if p), None)
+                    db_item = find_db_item_by_path(symlink_path) if symlink_path else None
+
+                    # 1. Delete symlink from disk
+                    if symlink_path and os.path.islink(symlink_path):
+                        try:
+                            os.remove(symlink_path)
+                            logging.info(f"[StuckPlex] Deleted symlink: {symlink_path}")
+                        except Exception as _se:
+                            logging.debug(f"[StuckPlex] Symlink delete failed — likely already gone: {_se}")
+                    elif symlink_path:
+                        logging.debug(f"[StuckPlex] Symlink not found on disk (already gone): {symlink_path}")
+
+                    # 2. Delete source from Decypharr/debrid using filled_by_torrent_id
+                    if db_item:
+                        torrent_id = db_item.get('filled_by_torrent_id')
+                        delete_source_by_torrent_id(torrent_id, display)
+
+                        # 3. Reset DB item to Wanted
+                        try:
+                            from database.database_writing import update_media_item_state, update_media_item
+                            update_media_item_state(db_item['id'], 'Wanted')
+                            update_media_item(db_item['id'],
+                                filled_by_torrent_id=None, filled_by_file=None,
+                                filled_by_magnet=None, location_on_disk=None,
+                                filled_by_title=None)
+                            logging.info(f"[StuckPlex] Reset to Wanted: {display} (db_id={db_item['id']})")
+                        except Exception as _dbe:
+                            logging.warning(f"[StuckPlex] DB reset failed for {display}: {_dbe}")
+                    else:
+                        logging.debug(f"[StuckPlex] No DB item found for {display} — skipping source/DB cleanup")
 
             except Exception as e:
                 logging.error(f"[StuckPlex] Error processing item {item_id}: {e}", exc_info=True)
@@ -8470,9 +8626,10 @@ def _setup_scheduler_listeners(runner_instance):
             logging.error(f"[_setup_scheduler_listeners] Failed to get local timezone for scheduler, using UTC fallback: {e_tz}")
             tz = pytz.utc
 
+        _queue_workers = max(1, min(3, int(get_setting('Queue', 'queue_pool_workers', 2))))
         executors = {
             'default': ThreadPoolExecutor(max_workers=1),
-            'queue': ThreadPoolExecutor(max_workers=2),
+            'queue': ThreadPoolExecutor(max_workers=_queue_workers),
         }
         job_defaults = {'coalesce': True, 'max_instances': 1}
 

--- a/queues/scraping_queue.py
+++ b/queues/scraping_queue.py
@@ -284,14 +284,16 @@ class ScrapingQueue:
                     try:
                         from database import get_db_connection as _gdb
                         _cconn = _gdb()
-                        _sibling_nzb = _cconn.execute(
-                            "SELECT filled_by_torrent_id, filled_by_file, filled_by_magnet "
-                            "FROM media_items WHERE imdb_id=? AND season_number=? AND type='episode' "
-                            "AND state IN ('Adding','Checking') "
-                            "AND filled_by_torrent_id LIKE 'nzb:%' LIMIT 1",
-                            (_coalesce_imdb, _coalesce_season)
-                        ).fetchone()
-                        _cconn.close()
+                        try:
+                            _sibling_nzb = _cconn.execute(
+                                "SELECT filled_by_torrent_id, filled_by_file, filled_by_magnet "
+                                "FROM media_items WHERE imdb_id=? AND season_number=? AND type='episode' "
+                                "AND state IN ('Adding','Checking') "
+                                "AND filled_by_torrent_id LIKE 'nzb:%' LIMIT 1",
+                                (_coalesce_imdb, _coalesce_season)
+                            ).fetchone()
+                        finally:
+                            _cconn.close()
                         if _sibling_nzb:
                             _job_id = _sibling_nzb[0]
                             _job_file = _sibling_nzb[1] or ''
@@ -639,6 +641,7 @@ class ScrapingQueue:
                                         year=item_to_process.get('year', ''),
                                         season=_curr_season,
                                         episode_numbers=_ep_nums,
+                                        version_settings=version_settings,
                                     )
                                     if _agg_results:
                                         _best = _agg_results[0]
@@ -661,6 +664,7 @@ class ScrapingQueue:
                                                     version=_curr_version,
                                                     tmdb_id=item_to_process.get('tmdb_id'),
                                                     original_scraped_torrent_title=_best.get('title', ''),
+                                                    episode_filenames=_best.get('episode_filenames', {}),
                                                     genres=json.loads(item_to_process.get('genres', '[]') or '[]'),
                                                     current_score=item_to_process.get('current_score', 0.0),
                                                     existing_items=_existing,

--- a/routes/debrid_manager_routes.py
+++ b/routes/debrid_manager_routes.py
@@ -2132,6 +2132,8 @@ def api_usage():
     try:
         from datetime import datetime
         provider = get_debrid_provider()
+        if not provider:
+            return jsonify({'error': 'No debrid provider configured'}), 503
         sub = provider.get_subscription_status()
 
         # Get traffic data via provider abstraction (handles RD and AllDebrid differences)
@@ -5148,6 +5150,68 @@ def usenet_repair_progress():
         is_running=is_running,
         **_repair_progress,
     )
+
+
+@debrid_manager_bp.route('/api/usenet/repair/delete_all_broken', methods=['POST'])
+def usenet_delete_all_broken():
+    """Delete all broken NZBs from Decypharr, Plex, and reset CLI DB items to Wanted."""
+    try:
+        from usenet.repair_engine import (
+            fetch_broken_items, _find_db_items_by_entry_name,
+            _delete_from_decypharr, _delete_from_plex,
+        )
+        from database.database_writing import update_media_item_state
+        from database.not_wanted_magnets import add_to_not_wanted_nzb_guid
+
+        broken = fetch_broken_items()
+        if not broken:
+            return jsonify(success=True, message='No broken items found', deleted_decypharr=0, deleted_plex=0, reset_db=0)
+
+        deleted_decypharr = 0
+        deleted_plex = 0
+        reset_db = 0
+
+        for entry in broken:
+            info_hash = entry.get('info_hash', '')
+            entry_name = entry.get('entry_name', '') or entry.get('name', '')
+
+            # Delete from Decypharr first
+            if _delete_from_decypharr(info_hash, entry_name):
+                deleted_decypharr += 1
+
+            # Find matching DB items
+            db_items = _find_db_items_by_entry_name(entry_name) if entry_name else []
+
+            if db_items:
+                for item in db_items:
+                    # Delete from Plex
+                    if _delete_from_plex(item):
+                        deleted_plex += 1
+                    # Reset to Wanted so it re-scrapes
+                    try:
+                        update_media_item_state(item['id'], 'Wanted')
+                        reset_db += 1
+                    except Exception as _dbe:
+                        logging.warning(f'[DeleteBroken] DB reset failed for item {item.get("id")}: {_dbe}')
+                    # Blacklist broken NZB URL so it won't be re-submitted
+                    nzb_url = item.get('filled_by_magnet') or item.get('link', '')
+                    if nzb_url:
+                        try:
+                            add_to_not_wanted_nzb_guid(nzb_url)
+                        except Exception:
+                            pass
+
+        msg = (f'Deleted {deleted_decypharr} from Decypharr, '
+               f'{deleted_plex} from Plex, '
+               f'{reset_db} items reset to Wanted.')
+        logging.info(f'[DeleteBroken] {msg}')
+        return jsonify(success=True, message=msg,
+                       deleted_decypharr=deleted_decypharr,
+                       deleted_plex=deleted_plex,
+                       reset_db=reset_db)
+    except Exception as e:
+        logging.error(f'[DeleteBroken] Error: {e}', exc_info=True)
+        return jsonify(success=False, error=str(e))
 
 
 @debrid_manager_bp.route('/api/usenet/repair/settings', methods=['GET'])

--- a/routes/queues_routes.py
+++ b/routes/queues_routes.py
@@ -118,29 +118,18 @@ def get_queue_contents_with_progressive_fallback(queue_manager, max_time=20):
             elif hasattr(queue, '__len__'):
                 count = len(queue)
             else:
-                # For database-backed queues, try to get count with timeout protection
+                # For database-backed queues, use a non-blocking read so a locked DB
+                # (e.g. add_collected_items holding BEGIN IMMEDIATE) never stalls the page load
                 if queue_name in ['Wanted', 'Blacklisted', 'Unreleased']:
-                    count_start = time.time()
-                    from database.database_reading import get_item_count_by_state
-                    count = get_item_count_by_state(queue_name)
-                    count_time = time.time() - count_start
-
-                    # Log timing for debugging
-                    if count_time > 0.1:  # Log queries that take more than 100ms
-                        logging.debug(f"[QUEUE_ROUTES] Count query for {queue_name} took {count_time:.3f}s (result: {count})")
-
-                    # If a single count query takes too long, skip database counts entirely
-                    if count_time > 1.0:  # More than 1 second for one count
-                        logging.warning(f"[QUEUE_ROUTES] Count query for {queue_name} took {count_time:.3f}s, skipping remaining database counts")
-                        # Return what we have so far and mark as minimal
-                        for remaining_queue in ['Wanted', 'Blacklisted', 'Unreleased']:
-                            if remaining_queue not in quick_summary:
-                                quick_summary[remaining_queue] = {'count': 0, 'loaded': False, 'items': []}
-                        # Convert to expected format - empty lists for all queues
-                        minimal_result = {}
-                        for queue_name in quick_summary.keys():
-                            minimal_result[queue_name] = []
-                        return minimal_result, "minimal"
+                    try:
+                        import sqlite3 as _sqlite3, os as _os
+                        _db_path = _os.path.join(_os.environ.get('USER_DB_CONTENT', '/user/db_content'), 'media_items.db')
+                        _rc = _sqlite3.connect(_db_path, timeout=0)
+                        _rc.row_factory = _sqlite3.Row
+                        count = _rc.execute("SELECT COUNT(*) FROM media_items WHERE state=?", (queue_name,)).fetchone()[0]
+                        _rc.close()
+                    except Exception:
+                        count = 0
                 else:
                     count = 0
 
@@ -178,13 +167,17 @@ def get_queue_contents_with_progressive_fallback(queue_manager, max_time=20):
                 continue
 
             # Get full contents for in-memory queues
-            items = queue.get_contents()
+            # Checking queue: skip live API calls on page render — SSE stream handles live progress
+            if queue_name == 'Checking' and hasattr(queue, 'get_contents'):
+                items = queue.get_contents(raw=True)
+            else:
+                items = queue.get_contents()
             quick_summary[queue_name]['items'] = items
             quick_summary[queue_name]['loaded'] = True
 
             queue_time = time.time() - queue_start
-            if queue_time > 2.0:  # Log slow queues
-                logging.debug(f"[QUEUE_ROUTES] Queue {queue_name} took {queue_time:.3f}s ({len(items)} items)")
+            if queue_time > 0.5:
+                logging.info(f"[QUEUE_ROUTES] Queue {queue_name} took {queue_time:.3f}s ({len(items)} items)")
 
             # Check if we're approaching the time limit
             elapsed = time.time() - start_time
@@ -200,7 +193,7 @@ def get_queue_contents_with_progressive_fallback(queue_manager, max_time=20):
     full_load_time = time.time() - full_load_start
     total_time = time.time() - start_time
 
-    logging.debug(f"[QUEUE_ROUTES] Full queue loading took {full_load_time:.3f}s (total: {total_time:.3f}s)")
+    logging.info(f"[QUEUE_ROUTES] Full queue loading took {full_load_time:.3f}s (total: {total_time:.3f}s)")
 
     # Convert to the expected format for compatibility
     final_result = {}
@@ -250,7 +243,13 @@ def can_check_torrent_status(torrent_id: str) -> bool:
         last_check = _torrent_status_rate_limiter['last_check'][torrent_id]
         min_interval = get_torrent_status_check_interval()
         current_time = time.time()
-        
+
+        if last_check == 0.0:
+            # Never checked — register now but skip this cycle so the first SSE
+            # cycle doesn't make N simultaneous API calls and stall for 30s.
+            _torrent_status_rate_limiter['last_check'][torrent_id] = current_time
+            return False
+
         if current_time - last_check >= min_interval:
             _torrent_status_rate_limiter['last_check'][torrent_id] = current_time
             return True
@@ -262,14 +261,11 @@ def get_torrent_status_with_rate_limiting(torrent_id: str, queue_manager) -> Dic
     cached_status = get_cached_torrent_status(torrent_id, queue_manager)
     if cached_status:
         return cached_status
-    
-    # Check rate limiting
+
+    # Check rate limiting — on cache miss with no rate limit token, return defaults
+    # immediately rather than making a live API call. This prevents the first SSE
+    # cycle from making N simultaneous API calls and stalling for 30s.
     if not can_check_torrent_status(torrent_id):
-        # Return cached data even if expired, or default values
-        if cached_status:
-            logging.debug(f"Rate limited torrent status check for {torrent_id}, using cached data")
-            return cached_status
-        logging.debug(f"Rate limited torrent status check for {torrent_id}, using default values")
         return {'progress': 0, 'state': 'unknown'}
     
     try:
@@ -313,6 +309,24 @@ def get_rate_limiting_stats() -> Dict:
 
 queues_bp = Blueprint('queues', __name__)
 queue_manager = QueueManager()
+
+
+@queues_bp.route('/api/queue_workers', methods=['POST'])
+@onboarding_required
+def save_queue_workers():
+    """Save queue_pool_workers setting and reinitialize only the APScheduler — no full restart."""
+    try:
+        data = request.get_json(silent=True) or {}
+        workers = int(data.get('workers', 2))
+        workers = max(1, min(3, workers))
+
+        from utilities.settings import set_setting
+        set_setting('Queue', 'queue_pool_workers', workers)
+        logging.info(f'[QueueWorkers] queue_pool_workers saved as {workers} — takes effect on next restart')
+        return jsonify(success=True, workers=workers, message=f'Queue workers set to {workers}. Takes effect on next restart.')
+    except Exception as e:
+        logging.error(f'[QueueWorkers] Error: {e}')
+        return jsonify(success=False, error=str(e))
 
 # Cache settings to avoid repeated database/file reads
 _settings_cache = {}
@@ -481,22 +495,14 @@ def index():
                 item['upgrades_found'] = item.get('upgrades_found', 0)
         elif queue_name == 'Checking':
             for item in items:
-                # Skip if item is not a dictionary
                 if not isinstance(item, dict):
-                    logging.warning(f"[QUEUE_ROUTES] Skipping non-dict item in {queue_name}: {type(item)}")
                     continue
-
                 item['time_added'] = item.get('time_added', datetime.now())
                 item['filled_by_file'] = item.get('filled_by_file', 'Unknown')
                 item['filled_by_torrent_id'] = item.get('filled_by_torrent_id', 'Unknown')
+                # Don't make live API calls on page render — SSE stream populates progress
                 item['progress'] = item.get('progress', 0)
                 item['state'] = item.get('state', 'unknown')
-                # Use the cached progress information instead of making direct API calls
-                if item.get('filled_by_torrent_id') and item['filled_by_torrent_id'] != 'Unknown':
-                    # Use rate-limited function to prevent API bombardment
-                    status_data = get_torrent_status_with_rate_limiting(item['filled_by_torrent_id'], queue_manager)
-                    item['progress'] = status_data['progress']
-                    item['state'] = status_data['state']
         elif queue_name == 'Sleeping':
             for item in items:
                 # Skip if item is not a dictionary
@@ -566,7 +572,9 @@ def index():
 
     template_start = time.time()
     upgrading_queue = queue_contents.get('Upgrading', [])
-    response = render_template('queues.html', queue_contents=queue_contents, upgrading_queue=upgrading_queue, program_status=program_status)
+    from utilities.settings import get_setting as _qs
+    _queue_pool_workers = int(_qs('Queue', 'queue_pool_workers', 2))
+    response = render_template('queues.html', queue_contents=queue_contents, upgrading_queue=upgrading_queue, program_status=program_status, queue_pool_workers=_queue_pool_workers)
     template_time = time.time() - template_start
     logging.debug(f"[QUEUE_ROUTES] Template rendering took {template_time:.3f}s")
     

--- a/routes/scraper_routes.py
+++ b/routes/scraper_routes.py
@@ -254,15 +254,18 @@ def add_torrent_to_debrid():
         nzb_url = request.form.get('nzb_url', '')
         episode_nzb_urls_raw = request.form.get('episode_nzb_urls', '')
         fallback_nzb_urls_raw = request.form.get('fallback_nzb_urls', '')
+        episode_filenames_raw = request.form.get('episode_filenames', '')
         if protocol == 'nzb' or (nzb_url and not magnet_link) or episode_nzb_urls_raw:
             # Virtual season pack — per-episode NZB URLs
             if episode_nzb_urls_raw:
                 try:
                     episode_nzb_urls = {int(k): v for k, v in json.loads(episode_nzb_urls_raw).items()}
                     fallback_nzb_urls = {int(k): v for k, v in json.loads(fallback_nzb_urls_raw).items()} if fallback_nzb_urls_raw else {}
+                    episode_filenames_ui = {int(k): v for k, v in json.loads(episode_filenames_raw).items()} if episode_filenames_raw else {}
                 except Exception:
                     episode_nzb_urls = {}
                     fallback_nzb_urls = {}
+                    episode_filenames_ui = {}
                 if episode_nzb_urls:
                     return _add_nzb_pack_to_usenet(
                         episode_nzb_urls=episode_nzb_urls,
@@ -271,6 +274,7 @@ def add_torrent_to_debrid():
                         season=season_number,
                         version=final_version_for_item, tmdb_id=tmdb_id,
                         original_scraped_torrent_title=original_scraped_torrent_title,
+                        episode_filenames=episode_filenames_ui,
                         genres=genres, current_score=current_score,
                         selected_folder=selected_folder,
                         selected_folder_is_custom=selected_folder_is_custom,
@@ -1705,11 +1709,17 @@ def select_media():
         return jsonify({'error': 'An error occurred while processing your request'}), 500
 
 def _build_nzb_title(title, year, imdb_id, version, original_scraped_torrent_title,
-                     media_type=None, season=None, episode=None, episode_title=None):
+                     media_type=None, season=None, episode=None, episode_title=None,
+                     pack_original=None):
     """
     Build a structured NZB job title when 'Enable NZB File Naming' is on.
     This becomes both the Decypharr folder name and filename.
     Falls back to original_scraped_torrent_title if setting is off or data missing.
+
+    pack_original: if provided, used for the (original) bracket instead of
+                   original_scraped_torrent_title. Used by NZB aggregate packs so
+                   the bracket always shows the pack quality tags regardless of
+                   per-episode filename availability.
     """
     from utilities.settings import get_setting as _gs
     if not _gs('Usenet Provider', 'enable_nzb_naming', False):
@@ -1724,32 +1734,57 @@ def _build_nzb_title(title, year, imdb_id, version, original_scraped_torrent_tit
     _year = _san(year)
     _imdb = _san(imdb_id) if imdb_id else ''
     _version = _san(version).strip('*') if version else ''
-    _orig = _san(os.path.splitext(original_scraped_torrent_title or '')[0])
+    # (original) bracket uses pack_original when provided, else original_scraped_torrent_title
+    _orig = _san(pack_original or original_scraped_torrent_title or '')
 
     is_episode = media_type in ('tv', 'show', 'episode') and season is not None and episode is not None
 
+    _MAX_TITLE = 220  # leave room for path prefix + .nzb.processing suffix
+
+    def _assemble(*p):
+        return ' - '.join(x for x in p if x)
+
     if is_episode:
         _ep_title = _san(episode_title or '')
-        parts = [f'{_title} ({_year})']
-        parts.append(f'S{int(season):02d}E{int(episode):02d}')
-        if _ep_title:
-            parts.append(_ep_title)
-        if _imdb:
-            parts.append(f'{{imdb-{_imdb}}}')
-        if _version:
-            parts.append(_version)
+        base = _assemble(f'{_title} ({_year})', f'S{int(season):02d}E{int(episode):02d}')
+        _imdb_part = f'{{imdb-{_imdb}}}' if _imdb else ''
+
+        # Try full title first
+        full = _assemble(base, _ep_title, _imdb_part, _version, f'({_orig})' if _orig else '')
+        if len(full) <= _MAX_TITLE:
+            return full
+
+        # Drop episode title, keep (original)
+        without_ep = _assemble(base, _imdb_part, _version, f'({_orig})' if _orig else '')
+        if len(without_ep) <= _MAX_TITLE:
+            return without_ep
+
+        # Truncate (original) to fit — always keep it, just shorter
         if _orig:
-            parts.append(f'({_orig})')
-        return ' - '.join(parts)
+            fixed_part = _assemble(base, _imdb_part, _version)
+            # " - (" prefix + ")" suffix = 4 chars overhead
+            available = _MAX_TITLE - len(fixed_part) - 4
+            if available > 10:
+                truncated_orig = _orig[:available]
+                return f'{fixed_part} - ({truncated_orig})'
+
+        # Last resort: no (original)
+        without_orig = _assemble(base, _imdb_part, _version)
+        if len(without_orig) <= _MAX_TITLE:
+            return without_orig
+        return base[:_MAX_TITLE]
     else:
-        parts = [f'{_title} ({_year})']
-        if _imdb:
-            parts.append(f'{{imdb-{_imdb}}}')
-        if _version:
-            parts.append(_version)
-        if _orig:
-            parts.append(f'({_orig})')
-        return ' - '.join(parts)
+        _season_part = f'S{int(season):02d}' if season is not None else ''
+        base = _assemble(f'{_title} ({_year})', _season_part)
+        for attempt in [
+            _assemble(base, f'{{imdb-{_imdb}}}' if _imdb else '', _version, f'({_orig})' if _orig else ''),
+            _assemble(base, f'{{imdb-{_imdb}}}' if _imdb else '', _version),
+            _assemble(base, f'{{imdb-{_imdb}}}' if _imdb else ''),
+            base,
+        ]:
+            if len(attempt) <= _MAX_TITLE:
+                return attempt
+        return base[:_MAX_TITLE]
 
 
 def _submit_single_episode_nzb(client, nzb_url, ep_label):
@@ -1780,6 +1815,7 @@ def _submit_single_episode_nzb(client, nzb_url, ep_label):
 
 def _add_nzb_pack_to_usenet(episode_nzb_urls, fallback_nzb_urls, title, year, media_type,
                              season, version, tmdb_id, original_scraped_torrent_title=None,
+                             episode_filenames=None,
                              genres=None, current_score=0.0,
                              selected_folder=None, selected_folder_is_custom=False,
                              existing_items=None):
@@ -1896,17 +1932,23 @@ def _add_nzb_pack_to_usenet(episode_nzb_urls, fallback_nzb_urls, title, year, me
             logging.info(f'[NZBPack] Skipping S{season:02d}E{ep_num:02d} — already Collected')
             continue
 
-        # Strip the virtual pack label from the title so Decypharr gets a clean name
         import re as _re_label
-        _clean_title = _re_label.sub(r'\s*\[NZB Pack[^\]]*\]', '', original_scraped_torrent_title or title).strip()
-        # Also replace S01 with S01E01 style — remove any existing season-only marker first
-        _clean_title = _re_label.sub(r'\.S\d{2}\.', '.', _clean_title).strip(' .')
+        # Aggregate pack display title — always has quality tags, used for (original) bracket
+        _pack_orig = _re_label.sub(r'\s*\[NZB Pack[^\]]*\]', '', original_scraped_torrent_title or title).strip()
+
+        # Per-episode raw filename — used only for the Decypharr job name (has SxxExx)
+        _ep_raw = (episode_filenames or {}).get(ep_num, '') or ''
+        _ep_raw_clean = _re_label.sub(r'\.(mkv|mp4|avi|m4v|nfo|nzb)$', '', _ep_raw, flags=_re_label.IGNORECASE).strip()
+        if not _ep_raw_clean:
+            _ep_raw_clean = _pack_orig  # fallback job name still has quality tags
+
         ep_label = _build_nzb_title(
             title=title, year=year, imdb_id=imdb_id,
-            version=version, original_scraped_torrent_title=_clean_title,
+            version=version, original_scraped_torrent_title=f'{_ep_raw_clean}-[NZB Pack]',
             media_type='episode', season=season, episode=ep_num,
             episode_title=episode_titles.get(ep_num),
-        ) or f'{_clean_title}.S{season:02d}E{ep_num:02d}'
+            pack_original=f'{_pack_orig}-[NZB Pack]',
+        ) or f'{_ep_raw_clean}-[NZB Pack]'
         primary_url = episode_nzb_urls[ep_num]
         fallbacks = fallback_nzb_urls.get(ep_num, [])
 

--- a/routes/torrent_status_routes.py
+++ b/routes/torrent_status_routes.py
@@ -20,8 +20,13 @@ def get_torrent_status():
     try:
        
         # Get the configured debrid provider instance
-        provider = get_debrid_provider()
-        
+        try:
+            provider = get_debrid_provider()
+        except Exception:
+            provider = None
+        if not provider:
+            return jsonify({"error": "No debrid provider configured"}), 503
+
         # Get active torrents and stats using the provider
         active_torrents, download_stats = provider.get_torrent_status()
         

--- a/scraper/newznab.py
+++ b/scraper/newznab.py
@@ -356,12 +356,26 @@ def _parse_newznab_xml(xml_text: str, instance: str) -> List[Dict[str, Any]]:
 _NORM_RE = re.compile(r'[^a-z0-9]')
 
 
-def _norm_group_key(title: str, resolution: str, group: str) -> str:
-    """Normalise title+res+group into a stable grouping key."""
+def _norm_group_key(title: str, resolution: str, group: str, hdr_flag: str = '') -> str:
+    """Normalise title+res+hdr+group into a stable grouping key."""
     t = _NORM_RE.sub('', (title or '').lower())
     r = _NORM_RE.sub('', (resolution or '').lower())
     g = _NORM_RE.sub('', (group or '').lower())
-    return f'{t}|{r}|{g}'
+    h = _NORM_RE.sub('', (hdr_flag or '').lower())
+    return f'{t}|{r}|{h}|{g}'
+
+
+def _hdr_flag(hdr_list) -> str:
+    """Normalise HDR tags to a consistent flag for grouping.
+    DV > HDR10 > HDR > SDR — captures the highest tier present."""
+    tags = [h.lower() for h in (hdr_list or [])]
+    if any(t in ('dv', 'dolby vision', 'dovi') for t in tags):
+        return 'dv'
+    if any(t in ('hdr10+', 'hdr10plus') for t in tags):
+        return 'hdr10plus'
+    if any(t in ('hdr10', 'hdr') for t in tags):
+        return 'hdr'
+    return 'sdr'
 
 
 def scrape_newznab_season_aggregate(
@@ -373,6 +387,7 @@ def scrape_newznab_season_aggregate(
     episode_count: int = 0,
     timeout: int = 20,
     episode_numbers: Optional[List[int]] = None,  # explicit list overrides range(1, episode_count+1)
+    version_settings: Optional[Dict] = None,      # version filter settings for resolution/quality
 ) -> List[Dict[str, Any]]:
     """
     Search each episode individually across all indexers in parallel.
@@ -481,6 +496,7 @@ def scrape_newznab_season_aggregate(
 
     # Group by key across episodes
     # group_data[key] = {ep_num: [result, ...]}
+    # Each result also stored in broader keys for waterfall fallback
     group_data: Dict[str, Dict[int, List[Dict]]] = {}
     group_meta: Dict[str, Dict] = {}  # key -> first result's parsed fields
 
@@ -503,19 +519,52 @@ def scrape_newznab_season_aggregate(
                 if _sim < 0.6:
                     logging.debug(f'[NZBAggregate] Rejecting title mismatch: {parsed_title!r} vs {title!r} (sim={_sim:.2f})')
                     continue
-            key = _norm_group_key(parsed_title, pi.get('resolution', ''), pi.get('group', ''))
-            if not key.replace('|', ''):
-                continue
-            if key not in group_data:
-                group_data[key] = {}
-                group_meta[key] = pi
-            group_data[key].setdefault(ep_num, []).append(res)
+            res_hdr = _hdr_flag(pi.get('hdr', []))
+            res_resolution = pi.get('resolution', '')
+            res_group = pi.get('group', '')
+            # Store under all waterfall key levels
+            for key in [
+                _norm_group_key(parsed_title, res_resolution, res_group, res_hdr),  # level 1: res+hdr+group
+                _norm_group_key(parsed_title, res_resolution, '',        res_hdr),  # level 2: res+hdr
+                _norm_group_key(parsed_title, res_resolution, '',        ''),       # level 3: res only
+            ]:
+                if not key.replace('|', ''):
+                    continue
+                if key not in group_data:
+                    group_data[key] = {}
+                    group_meta[key] = pi
+                group_data[key].setdefault(ep_num, []).append(res)
+
+    # Waterfall: try each level in order, stop at first level that yields complete packs.
+    # Level 1: (title, resolution, hdr, group) — most specific
+    # Level 2: (title, resolution, hdr)        — any group, same quality tier
+    # Level 3: (title, resolution)             — any group, any HDR variant
+    def _key_level(k: str) -> int:
+        parts = k.split('|')
+        # parts = [title, resolution, hdr, group]
+        if len(parts) == 4 and parts[3]:  # group present
+            return 1
+        if len(parts) == 4 and parts[2]:  # hdr present, no group
+            return 2
+        return 3  # resolution only
+
+    complete_keys_by_level: Dict[int, list] = {1: [], 2: [], 3: []}
+    for key, ep_map in group_data.items():
+        if len(ep_map) >= len(_ep_list):
+            complete_keys_by_level[_key_level(key)].append(key)
+
+    # Pick the best level that has complete packs
+    active_keys = []
+    for lvl in (1, 2, 3):
+        if complete_keys_by_level[lvl]:
+            active_keys = complete_keys_by_level[lvl]
+            logging.info(f'[NZBAggregate] {title} S{season:02d}: using waterfall level {lvl} ({len(active_keys)} complete group(s))')
+            break
 
     virtual_packs = []
-    for key, ep_map in group_data.items():
-        # Must cover every episode
+    for key in active_keys:
+        ep_map = group_data[key]
         if len(ep_map) < len(_ep_list):
-            logging.debug(f'[NZBAggregate] Skipping incomplete group {key!r}: {len(ep_map)}/{len(_ep_list)} eps')
             continue
 
         pi = group_meta[key]
@@ -536,7 +585,26 @@ def scrape_newznab_season_aggregate(
             ep_size = ep_result.get('size', 0.0)
             episode_sizes[ep_num] = ep_size
             total_size += ep_size
-            episode_filenames[ep_num] = ep_result.get('original_title') or ep_result.get('title') or ''
+            _raw_title = ep_result.get('original_title') or ep_result.get('title') or ''
+            # If the title doesn't contain this episode's SxxExx (e.g. PTT couldn't parse
+            # episode numbers so a season-pack-style title was accepted for all episodes),
+            # inject the correct SxxExx so quality tags are preserved but episode is correct.
+            if _raw_title and not re.search(
+                    rf'[Ss]{season:02d}[Ee]{ep_num:02d}', _raw_title):
+                _ep_marker = re.search(r'[Ss]\d{1,2}[Ee]\d{1,2}', _raw_title)
+                if _ep_marker:
+                    # Replace existing SxxExx with correct one
+                    _raw_title = _raw_title[:_ep_marker.start()] + \
+                                 f'S{season:02d}E{ep_num:02d}' + \
+                                 _raw_title[_ep_marker.end():]
+                else:
+                    # No SxxExx at all — inject after season marker if present
+                    _s_marker = re.search(r'([Ss]\d{1,2})(?![Ee]\d)', _raw_title)
+                    if _s_marker:
+                        _raw_title = _raw_title[:_s_marker.end()] + \
+                                     f'E{ep_num:02d}' + \
+                                     _raw_title[_s_marker.end():]
+            episode_filenames[ep_num] = _raw_title
 
         # Build display title: strip episode number AND episode title words,
         # keeping show title + season + quality tags only.
@@ -625,4 +693,27 @@ def scrape_newznab_season_aggregate(
         })
 
     logging.info(f'[NZBAggregate] {title} S{season:02d}: {len(virtual_packs)} complete virtual packs found')
+
+    # Apply version resolution filter and sort by quality preference
+    if version_settings and virtual_packs:
+        from scraper.functions.filter_results import get_resolution_value, resolution_filter
+        max_res = version_settings.get('max_resolution', '2160p')
+        res_wanted = version_settings.get('resolution_wanted', '<=')
+
+        before = len(virtual_packs)
+        virtual_packs = [
+            p for p in virtual_packs
+            if resolution_filter(p.get('resolution') or p.get('parsed_info', {}).get('resolution') or '', max_res, res_wanted)
+        ]
+        if len(virtual_packs) < before:
+            logging.info(f'[NZBAggregate] {title} S{season:02d}: filtered {before - len(virtual_packs)} packs by resolution ({res_wanted} {max_res}), {len(virtual_packs)} remaining')
+
+        # Sort highest resolution first for both <= and >= — user always wants the best
+        # quality that passes the filter. == is already exact so order doesn't matter.
+        if virtual_packs and res_wanted != '==':
+            virtual_packs.sort(
+                key=lambda p: get_resolution_value(p.get('resolution') or p.get('parsed_info', {}).get('resolution') or ''),
+                reverse=True
+            )
+
     return virtual_packs

--- a/static/js/scraper.js
+++ b/static/js/scraper.js
@@ -46,6 +46,7 @@ function addToRealDebrid(magnetLink, torrent) {
                 formData.append('protocol', 'nzb');
                 formData.append('episode_nzb_urls', JSON.stringify(torrent.episode_nzb_urls || {}));
                 formData.append('fallback_nzb_urls', JSON.stringify(torrent.fallback_nzb_urls || {}));
+                formData.append('episode_filenames', JSON.stringify(torrent.episode_filenames || {}));
             } else if (isNzb) {
                 formData.append('protocol', 'nzb');
                 formData.append('nzb_url', torrent.nzb_url || magnetLink || '');

--- a/templates/debrid_manager.html
+++ b/templates/debrid_manager.html
@@ -639,6 +639,9 @@
                     <button id="usenet-fix-btn" onclick="usenetRunRepair()" class="un-btn">
                         <i class="fa-solid fa-wrench" style="color:#e8601c"></i> Fix Broken
                     </button>
+                    <button id="usenet-delete-broken-btn" onclick="usenetDeleteAllBroken()" class="un-btn">
+                        <i class="fa-solid fa-trash" style="color:#ef4444"></i> Delete All Broken
+                    </button>
                 </div>
             </div>
 
@@ -4404,6 +4407,44 @@ async function usenetRunRepair() {
         btn.disabled = false;
         btn.innerHTML = orig;
         console.error('[Usenet] run repair error', e);
+    }
+}
+
+async function usenetDeleteAllBroken() {
+    const btn = document.getElementById('usenet-delete-broken-btn');
+    const orig = btn.innerHTML;
+    const brokenCount = parseInt(document.getElementById('usenet-stat-broken')?.textContent || '0') || 0;
+    const label = brokenCount > 0 ? `${brokenCount} broken` : 'all broken';
+    if (!confirm(`Delete ${label} NZBs?\n\nThis will:\n• Delete from Decypharr\n• Delete from Plex\n• Reset items to Wanted (will re-scrape)\n\nContinue?`)) return;
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Deleting…';
+    try {
+        const r = await fetch('/debrid_manager/api/usenet/repair/delete_all_broken', {method: 'POST'});
+        const d = await r.json();
+        if (d.success) {
+            btn.innerHTML = '<i class="fa-solid fa-check" style="color:#4ade80"></i> Done';
+            setTimeout(() => { btn.disabled = false; btn.innerHTML = orig; }, 3000);
+            // Refresh stats
+            fetch('/debrid_manager/api/usenet/repair/stats').then(r => r.json()).then(sd => {
+                if (sd.success) _usenetRenderStats(sd.health || {}, sd.activity || {}, sd.versions || [], sd.repair_version || '');
+            }).catch(() => {});
+            // Show result
+            const msg = d.message || 'Done';
+            const statusEl = document.getElementById('usenet-repair-status-text');
+            const runningEl = document.getElementById('usenet-repair-running');
+            if (statusEl && runningEl) {
+                runningEl.style.display = 'block';
+                statusEl.textContent = msg;
+            }
+        } else {
+            btn.disabled = false;
+            btn.innerHTML = orig;
+            alert('Delete failed: ' + (d.error || 'Unknown error'));
+        }
+    } catch(e) {
+        btn.disabled = false;
+        btn.innerHTML = orig;
+        console.error('[Usenet] delete all broken error', e);
     }
 }
 

--- a/templates/manual_blacklist.html
+++ b/templates/manual_blacklist.html
@@ -390,6 +390,10 @@
       cbs.forEach(cb => cb.checked = this.checked);
       updateSeasonSummary(wrap);
       markUnsaved();
+      // Auto-expand season list when unchecking All Seasons so user can pick specific seasons
+      if (!this.checked && list.style.display === 'none') {
+        chevron.click();
+      }
     });
 
     chevron.addEventListener('click', async function() {
@@ -549,14 +553,23 @@
 
   // ── Save all ──
   async function saveAll() {
-    // De-dupe by imdb id — table and card both have wraps for the same item
-    const seen = new Set();
-    const wraps = Array.from(document.querySelectorAll('.bl-season-wrap')).filter(w => {
+    // De-dupe by imdb id — table and card both have wraps for the same item.
+    // Prefer the wrap that already has season checkboxes loaded (desktop table row)
+    // over one that hasn't been expanded yet (mobile card).
+    const byId = {};
+    document.querySelectorAll('.bl-season-wrap').forEach(w => {
       const id = w.dataset.imdb;
-      if (seen.has(id)) return false;
-      seen.add(id);
-      return true;
+      if (!byId[id]) {
+        byId[id] = w;
+      } else {
+        // Prefer whichever has season checkboxes loaded
+        const existing = byId[id];
+        if (w.querySelectorAll('.bl-season-cb').length > existing.querySelectorAll('.bl-season-cb').length) {
+          byId[id] = w;
+        }
+      }
     });
+    const wraps = Object.values(byId);
     let success = true;
 
     for (const wrap of wraps) {

--- a/templates/queues.html
+++ b/templates/queues.html
@@ -30,6 +30,15 @@
         <strong>Items per Hour:</strong> <span id="stats-items-per-hour">N/A</span>
         &nbsp;|&nbsp;
         <strong>Estimated Remaining Scrape Time:</strong> <span id="stats-remaining-time">N/A</span>
+        &nbsp;|&nbsp;
+        <strong>Queue Workers:</strong>
+        <select id="queue-workers-select" style="background:#1e1e1e;color:#ccc;border:1px solid #444;border-radius:4px;padding:1px 4px;font-size:12px;">
+            <option value="1">1 (Slow machine)</option>
+            <option value="2" selected>2 (Default)</option>
+            <option value="3">3 (Fast machine)</option>
+        </select>
+        <button id="queue-workers-save-btn" onclick="saveQueueWorkers()" style="background:#e8601c;color:#fff;border:none;border-radius:4px;padding:2px 8px;font-size:12px;cursor:pointer;margin-left:4px;">Save</button>
+        <span id="queue-workers-status" style="font-size:11px;color:#888;margin-left:4px;"></span>
     </div>
     <!-- Subtle connection status notification -->
     <div id="connection-status" class="connection-status"></div>
@@ -1081,6 +1090,33 @@
     }
 
     // Use it in your setup
+    // Initialize queue workers select from server-rendered value
+    (function() {
+        const sel = document.getElementById('queue-workers-select');
+        if (sel) sel.value = '{{ queue_pool_workers }}';
+    })();
+
+    window.saveQueueWorkers = async function saveQueueWorkers() {
+        const btn = document.getElementById('queue-workers-save-btn');
+        const status = document.getElementById('queue-workers-status');
+        const val = parseInt(document.getElementById('queue-workers-select').value);
+        btn.disabled = true;
+        status.textContent = 'Saving…';
+        try {
+            const r = await fetch('/queues/api/queue_workers', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({'workers': val})
+            });
+            const d = await r.json();
+            status.textContent = d.success ? `✓ Saved — restart to apply` : '✗ Failed: ' + (d.error || '');
+        } catch(e) {
+            status.textContent = '✗ Error';
+        }
+        btn.disabled = false;
+        setTimeout(() => { status.textContent = ''; }, 4000);
+    }
+
     document.addEventListener('DOMContentLoaded', function() {
         console.log('DOMContentLoaded event fired');
         

--- a/templates/settings_tabs/required_tangerine.html
+++ b/templates/settings_tabs/required_tangerine.html
@@ -225,13 +225,15 @@
                    min="0" placeholder="1500">
             <p class="settings-description">Maximum age of NZB results in days. Results older than this are filtered out at search time and never submitted to Decypharr. Set to 0 to disable. Applies everywhere NZB indexers are searched (queue, scraper results, upgrade hub, repair).</p>
         </div>
-        <div class="settings-form-group">   
+        {% if settings.get('File Management', {}).get('file_collection_management', '') != 'Symlinked/Local' %}
+        <div class="settings-form-group">
             <label for="usenet_provider-enable_nzb_naming" class="settings-title">Enable NZB File Naming:</label>
             <input type="checkbox" id="usenet_provider-enable_nzb_naming" name="Usenet Provider.enable_nzb_naming"
                    data-section="Usenet Provider" data-key="enable_nzb_naming"
                    {% if settings.get('Usenet Provider', {}).get('enable_nzb_naming') %}checked{% endif %}>
             <p class="settings-description">Names NZB jobs submitted to Decypharr using a structured format: <code>{title} ({year}) - {imdb-id} - {version} - (original)</code> for movies and <code>{title} ({year}) - SxxExx - {episode title} - {imdb-id} - {version} - (original)</code> for episodes. This becomes the folder and filename in Decypharr.</p>
         </div>
+        {% endif %}
     </div>
 </div>
 

--- a/usenet/decypharr_client.py
+++ b/usenet/decypharr_client.py
@@ -153,16 +153,31 @@ class DecypharrClient:
             logging.error(f'[Decypharr] add_nzb exception: {exc}')
             return None
 
-    def _find_nzb_folder(self, job_norm: str) -> Optional[str]:
-        """Paginate /api/browse/nzbs to find a folder matching job_norm."""
+    def _find_nzb_folder(self, job_norm: str, original_name: str = '') -> Optional[str]:
+        """Find a Decypharr NZB folder by name.
+        Tries direct URL lookup first (fast, single request).
+        Falls back to paginated search only if direct lookup fails.
+        """
         def _norm(s):
             return re.sub(r'[^a-z0-9]', '', s.lower())
+
+        # Fast path: try direct URL with the original (un-normalised) name
+        if original_name:
+            try:
+                r = api.get(f'{self.base_url}/api/browse/nzbs/{original_name}',
+                            headers=self._headers(), timeout=10)
+                if r.status_code == 200:
+                    return original_name
+            except Exception:
+                pass
+
+        # Slow path: paginate /api/browse/nzbs (only reached if direct lookup missed)
         try:
             page = 1
             while True:
                 r = api.get(f'{self.base_url}/api/browse/nzbs',
                             headers=self._headers(), timeout=15,
-                            params={'page': page})
+                            params={'page': page, 'limit': 100})
                 if r.status_code != 200:
                     break
                 data = r.json()
@@ -214,7 +229,7 @@ class DecypharrClient:
         job_norm = _norm(job_name)
 
         try:
-            folder_name = self._find_nzb_folder(job_norm)
+            folder_name = self._find_nzb_folder(job_norm, original_name=job_name)
             if not folder_name:
                 logging.debug(f'[Decypharr] No folder found for job {job_name!r}')
                 return None
@@ -258,7 +273,7 @@ class DecypharrClient:
 
         job_norm = _norm(job_name)
         try:
-            folder_name = self._find_nzb_folder(job_norm)
+            folder_name = self._find_nzb_folder(job_norm, original_name=job_name)
             if not folder_name:
                 return None
             video_files = sorted([name for name, _ in self._list_nzb_folder_files(folder_name)])

--- a/usenet/repair_engine.py
+++ b/usenet/repair_engine.py
@@ -329,13 +329,37 @@ def _delete_from_plex(item: dict) -> bool:
     media_type = item.get('type', 'movie')
     season = item.get('season_number')
     episode = item.get('episode_number')
+    ms_item_id = item.get('ms_item_id')  # Plex ratingKey stored in DB
+    location_on_disk = item.get('location_on_disk')
 
     params = {'X-Plex-Token': plex_token}
     hdrs = {'Accept': 'application/json'}
 
     try:
+        # --- Priority 1: ms_item_id (direct ratingKey — most precise) ---
+        if ms_item_id:
+            r = requests.delete(
+                f'{plex_url}/library/metadata/{ms_item_id}',
+                params=params, timeout=10,
+            )
+            if r.status_code in (200, 204):
+                logger.info(f'[NZBRepair] Deleted from Plex via ms_item_id={ms_item_id}: {title}')
+                return True
+            logger.debug(f'[NZBRepair] ms_item_id delete returned {r.status_code} for {title}, trying fallbacks')
+
+        # --- Priority 2: location_on_disk (file path match via Plex search) ---
+        if location_on_disk:
+            try:
+                from utilities.plex_functions import remove_file_from_plex
+                ep_title = item.get('episode_title') if media_type != 'movie' else None
+                if remove_file_from_plex(title, location_on_disk, ep_title):
+                    logger.info(f'[NZBRepair] Deleted from Plex via location_on_disk: {title} ({location_on_disk})')
+                    return True
+            except Exception as _loc_err:
+                logger.debug(f'[NZBRepair] location_on_disk Plex delete failed for {title!r}: {_loc_err}')
+
+        # --- Priority 3: title + season/episode number (last resort) ---
         if media_type == 'movie':
-            # Search movies
             r = requests.get(
                 f'{plex_url}/library/all',
                 params={**params, 'title': title, 'type': 1},
@@ -346,30 +370,22 @@ def _delete_from_plex(item: dict) -> bool:
                 for m in items:
                     key = m.get('ratingKey', '')
                     if key:
-                        requests.delete(
-                            f'{plex_url}/library/metadata/{key}',
-                            params=params, timeout=10,
-                        )
-                        logger.info(f'[NZBRepair] Deleted from Plex (movie): {title}')
+                        requests.delete(f'{plex_url}/library/metadata/{key}', params=params, timeout=10)
+                        logger.info(f'[NZBRepair] Deleted from Plex via title (movie): {title}')
                         return True
         else:
-            # Search shows → find episode
             r = requests.get(
                 f'{plex_url}/library/all',
                 params={**params, 'title': title, 'type': 2},
                 headers=hdrs, timeout=10,
             )
             if r.status_code == 200:
-                shows = r.json().get('MediaContainer', {}).get('Metadata', [])
-                for show in shows:
+                for show in r.json().get('MediaContainer', {}).get('Metadata', []):
                     show_key = show.get('ratingKey', '')
                     if not show_key:
                         continue
-                    # Get seasons
-                    rs = requests.get(
-                        f'{plex_url}/library/metadata/{show_key}/children',
-                        params=params, headers=hdrs, timeout=10,
-                    )
+                    rs = requests.get(f'{plex_url}/library/metadata/{show_key}/children',
+                                      params=params, headers=hdrs, timeout=10)
                     if rs.status_code != 200:
                         continue
                     for season_meta in rs.json().get('MediaContainer', {}).get('Metadata', []):
@@ -378,21 +394,17 @@ def _delete_from_plex(item: dict) -> bool:
                         season_key = season_meta.get('ratingKey', '')
                         if not season_key:
                             continue
-                        re_ = requests.get(
-                            f'{plex_url}/library/metadata/{season_key}/children',
-                            params=params, headers=hdrs, timeout=10,
-                        )
+                        re_ = requests.get(f'{plex_url}/library/metadata/{season_key}/children',
+                                           params=params, headers=hdrs, timeout=10)
                         if re_.status_code != 200:
                             continue
                         for ep in re_.json().get('MediaContainer', {}).get('Metadata', []):
                             if ep.get('index') == episode:
                                 ep_key = ep.get('ratingKey', '')
                                 if ep_key:
-                                    requests.delete(
-                                        f'{plex_url}/library/metadata/{ep_key}',
-                                        params=params, timeout=10,
-                                    )
-                                    logger.info(f'[NZBRepair] Deleted from Plex (episode): {title} S{season:02d}E{episode:02d}')
+                                    requests.delete(f'{plex_url}/library/metadata/{ep_key}',
+                                                    params=params, timeout=10)
+                                    logger.info(f'[NZBRepair] Deleted from Plex via title (episode): {title} S{season:02d}E{episode:02d}')
                                     return True
     except Exception as e:
         logger.warning(f'[NZBRepair] Plex delete error for {title!r}: {e}')

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1356,24 +1356,35 @@ def check_local_file_for_item(item: Dict[str, Any], is_webhook: bool = False, ex
                 old_filename = item.get('upgrading_from') # Filename of the file being replaced
 
                 if old_torrent_id:
-                    logging.info(f"[UPGRADE] Attempting to remove old torrent {old_torrent_id} via debrid API.")
-                    try:
-                        from debrid import get_debrid_provider
-                        debrid_provider = get_debrid_provider()
-                        # Assuming remove_torrent returns True/False or raises Exception
-                        debrid_provider.remove_torrent(
-                            old_torrent_id,
-                            removal_reason="Removed old torrent after successful upgrade"
-                        )
-                        removal_successful = True # Assume success if no exception
-                        logging.info(f"[UPGRADE] Successfully initiated removal of old torrent {old_torrent_id} via debrid API.")
-                    except Exception as remove_err:
-                        # Check if it's a 404 (Not Found), which might mean it was already deleted
-                        if '404' in str(remove_err):
-                             logging.warning(f"[UPGRADE] Old torrent {old_torrent_id} not found on debrid (likely already removed). Proceeding.")
-                             removal_successful = True # Treat as success
-                        else:
-                            logging.error(f"[UPGRADE] Failed to remove old torrent {old_torrent_id} via debrid API: {remove_err}")
+                    if str(old_torrent_id).startswith('nzb:'):
+                        # NZB jobs are managed by Decypharr, not debrid — skip debrid removal
+                        logging.debug(f"[UPGRADE] Old torrent {old_torrent_id} is an NZB job — skipping debrid removal")
+                        removal_successful = True
+                    else:
+                        logging.info(f"[UPGRADE] Attempting to remove old torrent {old_torrent_id} via debrid API.")
+                        try:
+                            from debrid import get_debrid_provider, ProviderUnavailableError
+                            debrid_provider = get_debrid_provider()
+                            if not debrid_provider:
+                                logging.debug(f"[UPGRADE] No debrid provider configured — skipping torrent removal for {old_torrent_id}")
+                                removal_successful = True
+                            else:
+                                debrid_provider.remove_torrent(
+                                    old_torrent_id,
+                                    removal_reason="Removed old torrent after successful upgrade"
+                                )
+                                removal_successful = True
+                                logging.info(f"[UPGRADE] Successfully initiated removal of old torrent {old_torrent_id} via debrid API.")
+                        except ProviderUnavailableError:
+                            logging.debug(f"[UPGRADE] Debrid provider unavailable — skipping torrent removal for {old_torrent_id}")
+                            removal_successful = True
+                        except Exception as remove_err:
+                            # Check if it's a 404 (Not Found), which might mean it was already deleted
+                            if '404' in str(remove_err):
+                                logging.warning(f"[UPGRADE] Old torrent {old_torrent_id} not found on debrid (likely already removed). Proceeding.")
+                                removal_successful = True
+                            else:
+                                logging.error(f"[UPGRADE] Failed to remove old torrent {old_torrent_id} via debrid API: {remove_err}")
                 else:
                     old_file_path_from_item = item.get('original_path_for_symlink') # Get path from item dict
                     logging.warning(f"[UPGRADE] Old torrent ID is missing for item {item['id']}. Attempting local file deletion using item's original path: '{old_file_path_from_item}'")
@@ -1600,7 +1611,7 @@ def check_local_file_for_item(item: Dict[str, Any], is_webhook: bool = False, ex
                                 from debrid import get_debrid_provider as _get_debrid
                                 from utilities.plex_functions import remove_file_from_plex, scan_and_empty_plex_trash
                                 import os as _os_scan
-                                _debrid = _get_debrid()
+                                _debrid = _get_debrid()  # May be None in symlink/usenet-only mode
                                 new_torrent_id = item.get('filled_by_torrent_id')
                                 _scan_paths = set()
 

--- a/utilities/post_processing.py
+++ b/utilities/post_processing.py
@@ -28,7 +28,10 @@ def replace_cleanup_after_collect(item_dict):
         from utilities.plex_functions import remove_file_from_plex, scan_and_empty_plex_trash
         import os as _os
 
-        _debrid_prov = _get_debrid_prov()
+        try:
+            _debrid_prov = _get_debrid_prov()
+        except Exception:
+            _debrid_prov = None
         conn = get_db_connection()
         cur = conn.cursor()
 

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -442,6 +442,13 @@ SETTINGS_SCHEMA = {
             "description": "Enable pausing the queue during a scheduled time frame",
             "default": False
         },
+        "queue_pool_workers": {
+            "type": "integer",
+            "description": "Number of concurrent worker threads for queue processing tasks (Adding, Checking, Scraping etc.). Higher values process more items in parallel but use more CPU/memory. Recommended: 1 for slow/older machines, 2 for normal, 3 for fast machines. Takes effect after saving (no restart required).",
+            "default": 2,
+            "min": 1,
+            "max": 3
+        },
         "pause_start_time": {
             "type": "string",
             "description": "Start time for scheduled queue pause (HH:MM format)",

--- a/utilities/web_scraper.py
+++ b/utilities/web_scraper.py
@@ -2004,7 +2004,12 @@ def process_torrent_selection(torrent_index: int, torrent_results: List[Dict[str
         if magnet_link:
             logging.info(f"Selected torrent: {selected_torrent}")
             logging.info(f"Magnet link: {magnet_link}")
-            debrid_provider = get_debrid_provider()
+            try:
+                debrid_provider = get_debrid_provider()
+            except Exception:
+                debrid_provider = None
+            if not debrid_provider:
+                return {"success": False, "message": "No debrid provider configured"}
             result = debrid_provider.add_to_debrid(magnet_link)
             if result:
                 logging.info(f"Torrent result: {result}")


### PR DESCRIPTION
- NZB aggregate naming fixed — quality tags always shown in (original) bracket
- Decypharr folder lookup now instant (direct URL instead of full pagination)
- Queue page load time fixed — no longer makes live API calls on render
- NZB health check no longer blocks thread pool and causes app restarts
- Stuck Plex items now also deletes symlink/source and resets to Wanted (symlink mode)
- Plex mode stuck items now deletes Decypharr/debrid source so item can't re-scan
- Real-Debrid API key errors silenced on usenet/symlink-only setups
- Manual blacklist season save fixed on mobile
- Queue pool workers now configurable (1/2/3) in queues page and settings
- NZB title release group suffix no longer stripped (x265-GROUP preserved)