### PR TITLE
Fix missing get_db_connection import in queue_manager (silent NameError causes wrongful blacklisting)

### DIFF
--- a/queues/queue_manager.py
+++ b/queues/queue_manager.py
@@ -6,6 +6,7 @@ import json
 import os
 import time
 
+from database.core import get_db_connection
 from database.database_writing import update_media_item_state, add_media_item
 from database.database_reading import get_media_item_by_id, get_item_count_by_state
 from database.collected_items import add_to_collected_notifications


### PR DESCRIPTION
## Problem

`queues/queue_manager.py` calls `get_db_connection()` in the new-item ghostlist/blacklist pre-check (around line 1115), but `get_db_connection` is never imported at module level (nor locally in that function).

```python
if imdb_id or tmdb_id:
    conn_check = None
    try:
        conn_check = get_db_connection()   # NameError: name 'get_db_connection' is not defined
        ...
```

Because the call is inside a `try`/`except`, the resulting `NameError` is swallowed. The pre-check silently fails, which can lead to items being **wrongly blacklisted instead of falling back to a 1080p result**. The symptom is hard to spot because there's no visible error.

## Fix

Add the missing module-level import, matching the existing import style already used throughout the codebase (e.g. `database/database_reading.py`, `database/database_writing.py` both do `from database.core import get_db_connection`).

```diff
+from database.core import get_db_connection
 from database.database_writing import update_media_item_state, add_media_item
 from database.database_reading import get_media_item_by_id, get_item_count_by_state
 from database.collected_items import add_to_collected_notifications
```

This is a one-line, behavior-correcting change. No other logic is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)