### PR TITLE
nzbdav: configurable category map (fix submit/setup taxonomy drift → invisible items)

### DIFF
--- a/routes/program_operation_routes.py
+++ b/routes/program_operation_routes.py
@@ -1528,7 +1528,9 @@ def _format_task_display_name(task_name, queue_map, content_sources_map):
 
 # Categories cli-debrid's title heuristic routes grabs into; these must exist in
 # NzbDAV or submits are rejected (items loop in "Wanted"). Mirrors nzbdav_migrate.py.
-NZBDAV_REQUIRED_CATEGORIES = ['movies', 'shows', 'movies_1080p_264', 'shows_1080p_264', '__unplayable__']
+# Fallback only — the live list is derived from usenet.nzbdav_client (the same
+# source the submit-router and repair scope use), see _nzbdav_required_categories.
+NZBDAV_REQUIRED_CATEGORIES = ['movies', 'shows', 'movies_1080p', 'shows_1080p', '__unplayable__']
 NZBDAV_RECOMMENDED_CATEGORIES = ['music']
 
 
@@ -1541,7 +1543,19 @@ def _nzbdav_base_url(raw):
 
 
 def _nzbdav_required_categories(download_folder=''):
-    cats = list(NZBDAV_REQUIRED_CATEGORIES)
+    """Categories cli-debrid needs on the NzbDAV instance.
+
+    Derived from the SAME source as the submit-router and repair scope
+    (usenet.nzbdav_client.managed_categories + the optional category map), so the
+    setup helper can never tell the user to create a set that disagrees with what
+    cli-debrid actually uploads to — the historical cause of invisible items.
+    """
+    try:
+        from usenet.nzbdav_client import _parse_category_map, managed_categories
+        cat_map = _parse_category_map(get_setting('Usenet Provider', 'nzbdav_category_map', ''))
+        cats = sorted(managed_categories(cat_map))
+    except Exception:
+        cats = list(NZBDAV_REQUIRED_CATEGORIES)
     df = (download_folder or '').strip()
     if df and df not in cats:
         cats.append(df)

--- a/routes/web_server.py
+++ b/routes/web_server.py
@@ -72,6 +72,23 @@ def inject_usenet_provider_name():
         return dict(usenet_provider_name='Decypharr')
 
 @app.context_processor
+def inject_nzbdav_categories():
+    """Expose the managed NzbDAV category list to templates.
+
+    The NzbDAV setup helper's scaffold generator (compose/rclone/union examples)
+    uses this so it lists the SAME categories cli-debrid actually submits to and
+    that repair/the check helper expect — derived from the optional
+    `Usenet Provider.nzbdav_category_map`. Keeps all category surfaces in sync.
+    """
+    try:
+        from usenet.nzbdav_client import _parse_category_map, managed_categories
+        from utilities.settings import get_setting
+        cm = _parse_category_map(get_setting('Usenet Provider', 'nzbdav_category_map', ''))
+        return dict(nzbdav_managed_categories=sorted(managed_categories(cm)))
+    except Exception:
+        return dict(nzbdav_managed_categories=[])
+
+@app.context_processor
 def inject_logo_selection():
     from utilities.settings import get_setting
     # Get the logo selection from settings

--- a/templates/_nzbdav_setup_helper.html
+++ b/templates/_nzbdav_setup_helper.html
@@ -113,7 +113,18 @@
     try { var u = new URL(url); return u.port || dflt; } catch(e){ return dflt; }
   }
 
-  var CATS = ['movies', 'shows', 'movies_1080p_264', 'shows_1080p_264', '__unplayable__', 'music'];
+  // Categories cli-debrid manages, derived from the configured category map
+  // (injected by the inject_nzbdav_categories context processor) so the scaffold
+  // matches what the submit-router emits and the check helper expects. 'music' is
+  // appended as a recommended extra for shared-with-Lidarr setups.
+  var CATS = (function(){
+    var managed = {{ (nzbdav_managed_categories or []) | tojson }};
+    if (!managed || !managed.length) {
+      managed = ['movies', 'shows', 'movies_1080p', 'shows_1080p', '__unplayable__'];
+    }
+    if (managed.indexOf('music') === -1) managed = managed.concat(['music']);
+    return managed;
+  })();
 
   function buildCompose(p){
     return [
@@ -205,13 +216,9 @@
   }
 
   function buildUnionCompose(p){
-    var branches = [p.debridbranch,
-      '/source/nzbdav/content/movies',
-      '/source/nzbdav/content/movies_1080p_264',
-      '/source/nzbdav/content/shows',
-      '/source/nzbdav/content/shows_1080p_264',
-      '/source/nzbdav/content/music',
-      '/source/nzbdav/content/__unplayable__'].join(':');
+    var branches = [p.debridbranch].concat(
+      CATS.map(function(c){ return '/source/nzbdav/content/' + c; })
+    ).join(':');
     return [
 '# debrid-usenet-union: mergerfs aggregate so cli-debrid\'s single file-presence',
 '# path sees both debrid (zurg) and usenet (nzbdav) files. Read-only.',
@@ -283,7 +290,7 @@
     } else {
       li.push('Bind the NzbDAV mount into cli-debrid: add <code>- ' + esc(p.mountbase) + '/nzbdav:' + esc(cm) + ':rshared</code> to cli-debrid\'s compose, apply the config block below, then <code>docker compose up -d --force-recreate cli_debrid</code>.');
     }
-    li.push('Add the content folders to your Plex libraries (<code>' + esc(cm) + '/content/movies</code>, <code>/content/shows</code>, + the <code>_1080p_264</code> variants) and disable Plex auto-scan on them (cli-debrid triggers scans itself).');
+    li.push('Add the content folders to your Plex libraries (one per managed category — ' + CATS.map(function(c){ return '<code>' + esc(cm) + '/content/' + esc(c) + '</code>'; }).join(', ') + ') and disable Plex auto-scan on them (cli-debrid triggers scans itself).');
     return '<div style="margin-top:8px;"><strong>Deploy steps (run these on your host):</strong><ol class="settings-description" style="line-height:1.6;margin-top:4px;">'
       + li.map(function(s){ return '<li>' + s + '</li>'; }).join('') + '</ol></div>';
   }

--- a/tests/test_nzbdav_categories.py
+++ b/tests/test_nzbdav_categories.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the NzbDAV configurable category map.
+
+Exercises the REAL functions in usenet/nzbdav_client.py by stubbing the two
+cli-debrid imports that module pulls at load time (utilities.settings and
+routes.api_tracker), so no full app/config is needed.
+
+Core invariant under test: the title heuristic can NEVER route a release into a
+category that the configured map doesn't manage — every emitted bucket resolves
+to one of managed_categories(map). This is what prevents "invisible items"
+(uploads landing in a category with no matching Plex section).
+"""
+
+import unittest
+import sys
+import os
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _load_client_module():
+    # Stub the two cli-debrid imports nzbdav_client does at module scope.
+    if 'utilities' not in sys.modules:
+        sys.modules['utilities'] = types.ModuleType('utilities')
+    uss = types.ModuleType('utilities.settings')
+    uss.get_setting = lambda *a, **k: {}
+    sys.modules['utilities.settings'] = uss
+    if 'routes' not in sys.modules:
+        sys.modules['routes'] = types.ModuleType('routes')
+    rta = types.ModuleType('routes.api_tracker')
+    rta.api = types.SimpleNamespace(get=None, post=None)
+    sys.modules['routes.api_tracker'] = rta
+    import importlib.util
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        'usenet', 'nzbdav_client.py')
+    spec = importlib.util.spec_from_file_location('nzbdav_client_under_test', path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+nc = _load_client_module()
+
+# A realistic non-default map: base + a 1080p split under custom names, 4K/anime
+# deliberately NOT split (they collapse to base).
+OURMAP = nc._parse_category_map(
+    'movies=movies, shows=shows, '
+    'movies_1080p=movies_1080p_264, shows_1080p=shows_1080p_264, '
+    'fallback=__unplayable__'
+)
+
+
+class TestParseCategoryMap(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(nc._parse_category_map(''), {})
+        self.assertEqual(nc._parse_category_map(None), {})
+
+    def test_pairs_and_tolerance(self):
+        got = nc._parse_category_map('movies=movies,  movies_1080p = movies_1080p_264 ,bad,=x,y=')
+        self.assertEqual(got, {'movies': 'movies', 'movies_1080p': 'movies_1080p_264'})
+
+
+class TestResolveCategory(unittest.TestCase):
+    def test_identity_when_empty_map(self):
+        # Empty map = stock behaviour: bucket used verbatim.
+        for b in ['movies', 'movies_1080p', 'movies_2160p', 'anime_shows', 'music']:
+            self.assertEqual(nc._resolve_category(b, {}), b)
+
+    def test_direct_hit(self):
+        self.assertEqual(nc._resolve_category('movies_1080p', OURMAP), 'movies_1080p_264')
+        self.assertEqual(nc._resolve_category('shows_1080p', OURMAP), 'shows_1080p_264')
+        self.assertEqual(nc._resolve_category('movies', OURMAP), 'movies')
+
+    def test_parent_walk(self):
+        # 2160p not mapped -> walks to base movies/shows
+        self.assertEqual(nc._resolve_category('movies_2160p', OURMAP), 'movies')
+        self.assertEqual(nc._resolve_category('shows_2160p', OURMAP), 'shows')
+        # 2160p remux -> 2160p -> movies
+        self.assertEqual(nc._resolve_category('movies_2160p_remux', OURMAP), 'movies')
+        # 1080p remux -> 1080p (mapped) -> custom name
+        self.assertEqual(nc._resolve_category('movies_1080p_remux', OURMAP), 'movies_1080p_264')
+        # anime -> base
+        self.assertEqual(nc._resolve_category('anime_movies', OURMAP), 'movies')
+        self.assertEqual(nc._resolve_category('anime_shows', OURMAP), 'shows')
+
+    def test_fallback(self):
+        # music has no parent and isn't mapped -> explicit fallback value
+        self.assertEqual(nc._resolve_category('music', OURMAP), '__unplayable__')
+        # empty bucket (heuristic found nothing) -> fallback
+        self.assertEqual(nc._resolve_category('', OURMAP), '__unplayable__')
+
+    def test_no_fallback_returns_empty(self):
+        m = {'movies': 'movies'}  # no fallback key
+        self.assertEqual(nc._resolve_category('music', m), '')
+
+
+class TestManagedCategories(unittest.TestCase):
+    def test_default_excludes_music(self):
+        managed = nc.managed_categories({})
+        self.assertIn('movies', managed)
+        self.assertIn('shows', managed)
+        self.assertIn('__unplayable__', managed)
+        self.assertNotIn('music', managed)  # repair must never own Lidarr's music
+
+    def test_from_map_values(self):
+        self.assertEqual(
+            nc.managed_categories(OURMAP),
+            {'movies', 'shows', 'movies_1080p_264', 'shows_1080p_264', '__unplayable__'},
+        )
+
+
+class TestNoInvisibleCategoryInvariant(unittest.TestCase):
+    """Every category the heuristic can emit must resolve into the managed set."""
+
+    def test_all_emittable_buckets_resolve_into_managed_set(self):
+        managed = nc.managed_categories(OURMAP)
+        # All buckets the heuristic can produce (canonical taxonomy + base + music + '')
+        emittable = set(nc._CATEGORY_PARENT) | {'movies', 'shows', 'music', '__unplayable__', ''}
+        for b in emittable:
+            resolved = nc._resolve_category(b, OURMAP)
+            self.assertIn(resolved, managed,
+                          f'bucket {b!r} resolved to {resolved!r} which is NOT in managed set {managed}')
+
+    def test_heuristic_outputs_route_into_managed_set(self):
+        managed = nc.managed_categories(OURMAP)
+        titles = [
+            'The.Matrix.1999.1080p.BluRay.x264-GRP',
+            'Dune.2021.2160p.UHD.BluRay.x265-GRP',
+            'Movie.2020.1080p.REMUX.AVC-GRP',
+            'Show.S01E02.1080p.WEB.h264-GRP',
+            'Show.S05E01.2160p.WEB-GRP',
+            'Random.720p.Thing-GRP',
+            'Totally unstructured name',
+        ]
+        for t in titles:
+            bucket = nc._detect_category_from_title(t)
+            resolved = nc._resolve_category(bucket, OURMAP)
+            # '' is acceptable only when no fallback; here OURMAP has a fallback,
+            # so every title must land in a managed category.
+            self.assertIn(resolved, managed,
+                          f'title {t!r} -> bucket {bucket!r} -> {resolved!r} not in {managed}')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/usenet/nzbdav_client.py
+++ b/usenet/nzbdav_client.py
@@ -43,19 +43,105 @@ from routes.api_tracker import api
 # Video-file extensions used for "is this a media file" checks in browse helpers.
 _VIDEO_EXTS = {'.mkv', '.mp4', '.avi', '.mov', '.wmv', '.m4v', '.ts'}
 
-# Default set of nzbdav categories cli-debrid considers "its own" for repair/health.
-# '__all__' is included so repair acts on everything regardless of category.
-# 'music' is intentionally excluded — a shared nzbdav typically serves music via
-# Lidarr and repair must not purge another app's history.
-# Users can override via `Usenet Provider.owned_categories` config key (comma-separated).
-_DEFAULT_OWNED_CATEGORIES = {
-    'movies', 'shows',
-    'movies_1080p', 'shows_1080p',
-    'movies_2160p', 'shows_2160p',
-    'movies_1080p_remux', 'movies_2160p_remux',
-    'anime_movies', 'anime_shows',
-    '__unplayable__',
+# ── Category taxonomy (single source of truth) ─────────────────────────────
+#
+# nzbdav (unlike Decypharr) does NO post-categorisation: whatever SAB category a
+# job is submitted under becomes the folder, verbatim. If cli-debrid submits a
+# category that the instance hasn't created (and that no Plex section maps), the
+# item is invisible to Plex and loops in "Wanted". So the set of categories the
+# submit-router can emit, the set the setup-helper tells the user to create, and
+# the set repair/health is allowed to act on MUST be identical. Historically
+# these were three independent hard-coded lists that drifted apart.
+#
+# They now all derive from ONE place: the taxonomy below + an optional per-user
+# `Usenet Provider.nzbdav_category_map`.
+#
+# `_CATEGORY_PARENT` is the specificity ladder: each detailed bucket falls back
+# to a less-detailed parent when the user hasn't mapped it, e.g.
+#   movies_2160p_remux → movies_2160p → movies
+# Base buckets (movies/shows) and music have no parent.
+_CATEGORY_PARENT = {
+    'movies_2160p_remux': 'movies_2160p',
+    'movies_1080p_remux': 'movies_1080p',
+    'movies_2160p':       'movies',
+    'movies_1080p':       'movies',
+    'anime_movies':       'movies',
+    'shows_2160p':        'shows',
+    'shows_1080p':        'shows',
+    'anime_shows':        'shows',
 }
+
+# Every category the title heuristic can emit.
+_ALL_CATEGORIES = set(_CATEGORY_PARENT) | {'movies', 'shows', 'music', '__unplayable__'}
+
+# Default "managed" set when no category map is configured. 'music' is excluded —
+# a shared nzbdav typically serves music via Lidarr and repair must never purge
+# another app's history. This is what repair/health and the setup helper use by
+# default; the submit-router uses identity routing (stock names) when unmapped.
+_DEFAULT_MANAGED_CATEGORIES = set(_ALL_CATEGORIES) - {'music'}
+
+# Pseudo-bucket key in the category map: the catch-all used when nothing in a
+# bucket's parent chain is mapped (e.g. an unmapped 'music', or an unstructured
+# title the heuristic couldn't classify).
+_FALLBACK_KEY = 'fallback'
+
+# Back-compat alias: external callers referenced _DEFAULT_OWNED_CATEGORIES.
+_DEFAULT_OWNED_CATEGORIES = _DEFAULT_MANAGED_CATEGORIES
+
+
+def _parse_category_map(value) -> dict:
+    """Parse a `bucket=name, bucket=name` string into a {bucket: name} dict.
+
+    Tolerant of surrounding whitespace and malformed/empty entries. Accepts a
+    dict unchanged. Empty/falsey input → {} (identity routing = stock behaviour).
+    """
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return {str(k).strip(): str(v).strip()
+                for k, v in value.items() if str(k).strip() and str(v).strip()}
+    out = {}
+    for part in str(value).split(','):
+        part = part.strip()
+        if not part or '=' not in part:
+            continue
+        k, v = part.split('=', 1)
+        k, v = k.strip(), v.strip()
+        if k and v:
+            out[k] = v
+    return out
+
+
+def _resolve_category(bucket: str, cat_map: dict) -> str:
+    """Map a heuristic bucket onto a real nzbdav category name via `cat_map`.
+
+    Walks the specificity ladder (movies_2160p_remux → movies_2160p → movies) to
+    the first bucket present in `cat_map`. If none match, uses the explicit
+    'fallback' mapping; else returns '' (caller applies self.default_category).
+    An empty `cat_map` means identity: the bucket name is used verbatim — this is
+    exactly the stock taxonomy, so existing setups are unaffected.
+    """
+    if not cat_map:
+        return bucket or ''
+    node = bucket
+    while node:
+        if node in cat_map:
+            return cat_map[node]
+        node = _CATEGORY_PARENT.get(node)
+    return cat_map.get(_FALLBACK_KEY, '')
+
+
+def managed_categories(cat_map: dict) -> set:
+    """The distinct real category names cli-debrid manages on this instance.
+
+    With a map: the set of its values (the actual category names, incl. the
+    fallback's). Without a map: the default taxonomy (music excluded). This one
+    function feeds the setup-helper required list AND the repair owned-set, so
+    they cannot disagree with what the submit-router emits.
+    """
+    if cat_map:
+        return set(cat_map.values())
+    return set(_DEFAULT_MANAGED_CATEGORIES)
 
 
 # Title-based category detection patterns.
@@ -162,6 +248,9 @@ class NzbdavClient:
         #   include = `owned_categories` config if set, else the heuristic's video
         #             categories + the configured fallback (auto-picked default)
         #   then subtract `exclude_categories` config (deny-list, optional)
+        # Optional user map: heuristic bucket -> real category name on this
+        # instance (see _resolve_category). Empty = stock identity routing.
+        self.category_map = _parse_category_map(cfg.get('nzbdav_category_map'))
         self.owned_categories = self._resolve_owned_categories(cfg)
         # Host-side filesystem path to where the nzbdav WebDAV mount appears
         # (used for browse helpers since nzbdav has no /browse API). Default to
@@ -195,7 +284,10 @@ class NzbdavClient:
         """
         include = self._parse_cat_list(cfg.get('owned_categories'))
         if not include:
-            include = set(_DEFAULT_OWNED_CATEGORIES)
+            # Derive from the same source the submit-router and setup-helper use,
+            # so repair never owns a category the router can't emit (and never a
+            # category another app, e.g. Lidarr's music, manages).
+            include = managed_categories(_parse_category_map(cfg.get('nzbdav_category_map')))
             if self.default_category:
                 include.add(self.default_category.lower())
         # Add any tag categories defined in content sources
@@ -212,6 +304,12 @@ class NzbdavClient:
             pass
         include -= self._parse_cat_list(cfg.get('exclude_categories'))
         return include
+
+    def _route_category(self, title: str, **kw) -> str:
+        """Detect the release bucket from the title, then resolve it to a real
+        category name on this instance via the configured category map."""
+        bucket = _detect_category_from_title(title, **kw)
+        return _resolve_category(bucket, self.category_map)
 
     def _sab_params(self, **extra) -> Dict[str, str]:
         """Build query params for nzbdav SAB-API calls. apikey is always added."""
@@ -255,8 +353,8 @@ class NzbdavClient:
             logging.warning('[NzbDAV] Usenet provider is disabled or not configured')
             return None
 
-        cat = category or _detect_category_from_title(title, is_anime=is_anime, media_type=media_type,
-                                                       tags=tags, tags_exclusive=tags_exclusive) or self.default_category
+        cat = category or self._route_category(title, is_anime=is_anime, media_type=media_type,
+                                               tags=tags, tags_exclusive=tags_exclusive) or self.default_category
         # nzbdav uses `nzbname` for the resulting folder name; default to title
         nzbname = title or 'download'
         filename = f'{nzbname}.nzb'
@@ -299,8 +397,8 @@ class NzbdavClient:
             logging.warning('[NzbDAV] Usenet provider is disabled or not configured')
             return None
 
-        cat = category or _detect_category_from_title(title, is_anime=is_anime, media_type=media_type,
-                                                       tags=tags, tags_exclusive=tags_exclusive) or self.default_category
+        cat = category or self._route_category(title, is_anime=is_anime, media_type=media_type,
+                                               tags=tags, tags_exclusive=tags_exclusive) or self.default_category
         nzbname = title or 'download'
 
         try:

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -363,6 +363,11 @@ SETTINGS_SCHEMA = {
             "description": "NzbDAV only. Comma-separated nzbdav categories the repair/health tool must ignore, subtracted from the included set. Use this if you point Radarr/Sonarr at the same nzbdav and don't want cli-debrid touching their categories.",
             "default": ""
         },
+        "nzbdav_category_map": {
+            "type": "string",
+            "description": "NzbDAV only. Optional. Choose which categories you want and what they're named on your instance, as comma-separated bucket=name pairs, e.g. `movies=movies, shows=shows, movies_1080p=movies_1080p, shows_1080p=shows_1080p, fallback=__unplayable__`. Detected buckets you omit fall back to their parent (movies_2160p_remux → movies_2160p → movies), so items never land in a category that doesn't exist on your instance. Recognised buckets: movies, shows, movies_1080p, shows_1080p, movies_2160p, shows_2160p, movies_1080p_remux, movies_2160p_remux, anime_movies, anime_shows, music, and 'fallback'. Leave empty to use the full default taxonomy. The setup helper's required-category list and the repair scope follow this map automatically.",
+            "default": ""
+        },
     },
     "TMDB": {
         "tab": "Additional Settings",


### PR DESCRIPTION
## Problem

The NzbDAV provider has **three independent hard-coded category lists** that have drifted apart:

- **Submit router** (`usenet/nzbdav_client.py::_detect_category_from_title`) emits `movies_1080p`, `movies_2160p`, `movies_1080p_remux`, `movies_2160p_remux`, `anime_movies`, `anime_shows`, …
- **Setup helper** (`routes/program_operation_routes.py::NZBDAV_REQUIRED_CATEGORIES` + `templates/_nzbdav_setup_helper.html`) tells the user to create `movies_1080p_264` / `shows_1080p_264`.
- **Repair/health owned-set** (`_DEFAULT_OWNED_CATEGORIES`) is a third list.

A user who follows the in-app setup helper therefore creates `movies_1080p_264` but the client uploads to `movies_1080p` — and to `movies_2160p` / `anime_*` / `*_remux`, which are never created at all. Because NzbDAV (unlike Decypharr) does **no post-categorisation**, whatever SAB category is submitted becomes the folder verbatim. Items submitted under a category that has no matching Plex section are invisible to Plex and loop in **Wanted**.

## Fix

Make all three surfaces derive from **one source of truth**: the taxonomy in `nzbdav_client` plus an optional, per-instance `Usenet Provider.nzbdav_category_map`.

- `nzbdav_category_map` is a comma-separated `bucket=name` string, e.g.
  `movies=movies, shows=shows, movies_1080p=movies_1080p, shows_1080p=shows_1080p, fallback=__unplayable__`
- Buckets the user omits **fall back along a specificity ladder** (`movies_2160p_remux → movies_2160p → movies`), so the router can never emit a category the instance doesn't manage.
- **Empty map = identity routing over the stock taxonomy**, so existing setups are unaffected (fully backward compatible).
- The setup-helper required list (`_nzbdav_required_categories`) and the repair owned-set both now derive from `managed_categories(map)` — they can no longer disagree with what the router emits.

This also lets each user choose their own granularity and category names (some want remux/anime/2160p splits, many just want movies/shows + a 1080p split, under whatever names their Plex sections already use) without touching code.

## Changes

- `usenet/nzbdav_client.py`: `_parse_category_map` / `_resolve_category` / `managed_categories` + `_route_category`; owned-set derives from `managed_categories`.
- `routes/program_operation_routes.py`: `_nzbdav_required_categories` derives from the map.
- `routes/web_server.py`: `inject_nzbdav_categories` context processor so the setup-helper scaffold lists the managed categories.
- `templates/_nzbdav_setup_helper.html`: scaffold (compose/rclone/union) generator uses the managed list instead of a hard-coded one.
- `utilities/settings_schema.py`: new `nzbdav_category_map` key.
- `tests/test_nzbdav_categories.py`: parsing, ladder fallback, and a "no release ever routes to an unmanaged category" invariant (11 tests).

## Testing

- `python3 -m pytest tests/test_nzbdav_categories.py` — 11 passing.
- Dogfooded live on a 0.7.44 instance: with a custom map, submit routing and the repair owned-set both resolve only to categories that exist on the instance; 2160p/remux/anime correctly collapse to base `movies`/`shows`; unstructured titles hit the fallback. No invisible-category submissions.

## Notes

Backward compatible: with no `nzbdav_category_map` set, routing is identical to today. The new `movies_1080p` / `movies_2160p` / `*_remux` / `anime_*` names are great; this PR only removes the *inconsistency* between the surfaces and makes the set configurable.
