### PR TITLE
nzbdav: exact-name fallback in remove_nzb so library-delete of migrated items sticks

### DIFF
--- a/tests/test_nzbdav_remove.py
+++ b/tests/test_nzbdav_remove.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Unit tests for NzbdavClient.remove_nzb's id-then-exact-name deletion logic.
+
+Exercises the real class with the two cli-debrid imports stubbed. The HTTP layer
+(_raw_delete_by_id) and history fetch (_history_slots) are monkeypatched per test
+so the ORCHESTRATION is what's under test: delete-by-id first, then an exact
+full-name fallback for items whose stored id is no longer a live nzo_id (e.g.
+migrated between providers), with a hard refusal on ambiguous names.
+"""
+
+import unittest
+import sys
+import os
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _load():
+    if 'utilities' not in sys.modules:
+        sys.modules['utilities'] = types.ModuleType('utilities')
+    uss = types.ModuleType('utilities.settings')
+    # Return an enabled config so the client is "live".
+    uss.get_setting = lambda *a, **k: {'enabled': True, 'url': 'http://x:3000', 'api_token': 't'}
+    sys.modules['utilities.settings'] = uss
+    if 'routes' not in sys.modules:
+        sys.modules['routes'] = types.ModuleType('routes')
+    rta = types.ModuleType('routes.api_tracker')
+    rta.api = types.SimpleNamespace(get=None, post=None)
+    sys.modules['routes.api_tracker'] = rta
+    import importlib.util
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        'usenet', 'nzbdav_client.py')
+    spec = importlib.util.spec_from_file_location('nzbdav_client_remove_test', path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+nc = _load()
+
+HISTORY = [
+    {'nzo_id': 'live-1', 'name': 'Movie.A.2020.1080p.BluRay.x264-GRP'},
+    {'nzo_id': 'live-2', 'name': 'Movie.B.2021.2160p.BluRay.x265-GRP'},
+    {'nzo_id': 'dup-1',  'name': 'Dup.Title.2019.1080p-GRP'},
+    {'nzo_id': 'dup-2',  'name': 'Dup.Title.2019.1080p-GRP'},   # same normalised name
+]
+
+
+def _client(deletable):
+    c = nc.NzbdavClient()
+    c.enabled = True
+    c.base_url = 'http://x:3000'
+    c._history_slots = lambda *a, **k: list(HISTORY)
+    calls = []
+    def fake_delete(i):
+        calls.append(i)
+        return i in deletable
+    c._raw_delete_by_id = fake_delete
+    c._delete_calls = calls
+    return c
+
+
+class TestReleaseNameKey(unittest.TestCase):
+    def test_strips_ext_and_punct(self):
+        k = nc.NzbdavClient._release_name_key
+        self.assertEqual(k('Movie.A.2020.1080p.x264-GRP.mkv'), k('Movie.A.2020.1080p.x264-GRP'))
+        self.assertEqual(k('a/b/Some Name-GRP'), 'somenamegrp')
+
+    def test_distinguishes_resolution(self):
+        k = nc.NzbdavClient._release_name_key
+        self.assertNotEqual(k('Movie.2020.1080p.x264-GRP'), k('Movie.2020.2160p.x265-GRP'))
+
+
+class TestRemoveNzb(unittest.TestCase):
+    def test_native_id_deletes(self):
+        c = _client(deletable={'live-1'})
+        self.assertTrue(c.remove_nzb('live-1', 'whatever'))
+        self.assertEqual(c._delete_calls, ['live-1'])
+
+    def test_id_present_but_delete_fails_does_not_guess(self):
+        # live-2 is in history but not deletable -> hard failure, NO name fallback.
+        c = _client(deletable=set())
+        self.assertFalse(c.remove_nzb('live-2', 'Movie.B.2021.2160p.BluRay.x265-GRP'))
+        self.assertEqual(c._delete_calls, ['live-2'])  # never tried a second id
+
+    def test_migrated_stale_id_unique_name_fallback(self):
+        # stale id not in history -> fallback resolves the unique name to live-1.
+        c = _client(deletable={'live-1'})
+        self.assertTrue(c.remove_nzb('nzb-stale-uuid', 'Movie.A.2020.1080p.BluRay.x264-GRP'))
+        self.assertEqual(c._delete_calls, ['nzb-stale-uuid', 'live-1'])
+
+    def test_fallback_matches_on_full_name_not_substring(self):
+        # The 2160p title must resolve ONLY to its own slot, never the 1080p one.
+        c = _client(deletable={'live-2'})
+        self.assertTrue(c.remove_nzb('stale', 'Movie.B.2021.2160p.BluRay.x265-GRP'))
+        self.assertEqual(c._delete_calls, ['stale', 'live-2'])
+
+    def test_ambiguous_name_refuses(self):
+        c = _client(deletable={'dup-1', 'dup-2'})
+        self.assertFalse(c.remove_nzb('stale', 'Dup.Title.2019.1080p-GRP'))
+        # only the stale-id attempt; never deletes either ambiguous match
+        self.assertEqual(c._delete_calls, ['stale'])
+
+    def test_absent_name_no_match(self):
+        c = _client(deletable=set())
+        self.assertFalse(c.remove_nzb('stale', 'Nothing.That.Exists-GRP'))
+
+    def test_no_name_no_fallback(self):
+        c = _client(deletable=set())
+        self.assertFalse(c.remove_nzb('stale', ''))
+        self.assertEqual(c._delete_calls, ['stale'])
+
+    def test_disabled_client_returns_false(self):
+        c = _client(deletable={'live-1'})
+        c.enabled = False
+        self.assertFalse(c.remove_nzb('live-1', 'x'))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/usenet/nzbdav_client.py
+++ b/usenet/nzbdav_client.py
@@ -545,21 +545,31 @@ class NzbdavClient:
 
     # -- queue / removal ----------------------------------------------------
 
-    def remove_nzb(self, info_hash: str, entry_name: str = '') -> bool:
-        """Delete a history entry from nzbdav.
+    @staticmethod
+    def _release_name_key(s: str) -> str:
+        """Normalise a release/folder/file name for EXACT matching.
 
-        info_hash here is the nzo_id (UUID). nzbdav implements the SABnzbd
-        convention, which uses a GET query (NOT the HTTP DELETE verb):
-          GET /api?mode=history&name=delete&value=<nzo_id>&del_files=1
-        IMPORTANT: an HTTP DELETE to the same URL returns 200 but does NOT
-        delete anything — the entry silently survives. Use GET.
-        Returns True if removed (or already gone), False on hard error.
+        Drops a trailing video extension (so a filled_by_file like
+        `X-GROUP.mkv` matches the history folder `X-GROUP`), lowercases, and
+        strips every non-alphanumeric character. Callers compare the FULL key for
+        equality — never as a substring — so quality/codec/group tokens
+        (1080p vs 2160p, x264 vs x265) keep distinct releases apart.
         """
-        if not self.is_enabled():
-            return False
-        if not info_hash:
-            logging.debug(f'[NzbDAV] remove_nzb called without info_hash for {entry_name!r}')
-            return False
+        s = os.path.basename(str(s or ''))
+        root, ext = os.path.splitext(s)
+        if ext.lower() in _VIDEO_EXTS:
+            s = root
+        return re.sub(r'[^a-z0-9]', '', s.lower())
+
+    def _raw_delete_by_id(self, info_hash: str) -> bool:
+        """Delete one history entry by nzo_id via the SABnzbd GET convention.
+
+          GET /api?mode=history&name=delete&value=<nzo_id>&del_files=1
+        An HTTP DELETE to the same URL returns 200 but does NOT delete anything
+        (the entry silently survives) — so always use GET. Returns True only on
+        confirmed removal (or 404 already-gone); False otherwise (incl.
+        status=false, meaning the id was not present).
+        """
         try:
             r = api.get(
                 self._sab_url(),
@@ -574,16 +584,88 @@ class NzbdavClient:
                 if ok:
                     logging.info(f'[NzbDAV] Removed NZB job {info_hash}')
                     return True
-                logging.warning(f'[NzbDAV] remove_nzb status=false for {info_hash}: {r.text[:200]}')
+                logging.info(f'[NzbDAV] delete-by-id status=false for {info_hash} (id not present)')
                 return False
             if r.status_code == 404:
                 logging.info(f'[NzbDAV] NZB job {info_hash} already gone (404)')
                 return True
-            logging.warning(f'[NzbDAV] remove_nzb returned HTTP {r.status_code}: {r.text[:200]}')
+            logging.info(f'[NzbDAV] delete-by-id HTTP {r.status_code} for {info_hash}: {r.text[:200]}')
             return False
         except Exception as exc:
-            logging.debug(f'[NzbDAV] remove_nzb error: {exc}')
+            logging.debug(f'[NzbDAV] _raw_delete_by_id error: {exc}')
             return False
+
+    def _id_in_history(self, info_hash: str) -> bool:
+        """True iff `info_hash` is a real nzo_id currently in nzbdav's history."""
+        target = str(info_hash)
+        for s in self._history_slots():
+            if str(s.get('nzo_id', '')) == target:
+                return True
+        return False
+
+    def _delete_by_exact_name(self, entry_name: str) -> bool:
+        """Remove a history entry matched by EXACT, full normalised name.
+
+        Last-resort fallback when the stored job-id is not a live nzbdav nzo_id
+        (e.g. an item migrated between providers via provider_transfer, whose
+        filled_by_torrent_id still holds the old provider's id). Matching is on
+        the *whole* normalised name, never a substring: a 1080p release must
+        never resolve to its 2160p sibling. If the name is ambiguous (more than
+        one history entry normalises equal) we REFUSE rather than guess.
+        """
+        key = self._release_name_key(entry_name)
+        if not key:
+            return False
+        matches = []
+        for s in self._history_slots():
+            nm = s.get('name') or s.get('nzb_name') or ''
+            if self._release_name_key(nm) == key:
+                nzo = str(s.get('nzo_id') or '')
+                if nzo:
+                    matches.append(nzo)
+        matches = list(dict.fromkeys(matches))  # dedup, keep order
+        if len(matches) == 1:
+            logging.info(f'[NzbDAV] exact-name fallback matched {entry_name!r} -> {matches[0]}')
+            return self._raw_delete_by_id(matches[0])
+        if not matches:
+            logging.warning(f'[NzbDAV] exact-name fallback: no history entry matches {entry_name!r}')
+            return False
+        logging.warning(
+            f'[NzbDAV] exact-name fallback: {len(matches)} history entries match '
+            f'{entry_name!r}; refusing to guess which to delete'
+        )
+        return False
+
+    def remove_nzb(self, info_hash: str, entry_name: str = '') -> bool:
+        """Delete a library item's NZB from nzbdav.
+
+        Primary path: delete by nzo_id (info_hash). If the id is not a live
+        nzbdav id — which happens for items migrated from another provider via
+        provider_transfer, whose filled_by_torrent_id still holds the old
+        provider's id — fall back to an EXACT-name match (see
+        _delete_by_exact_name). Without this, a library delete leaves the file in
+        nzbdav and Plex re-imports it, writing the item straight back into the DB
+        (delete-from-library doesn't stick).
+
+        Returns True if removed (or confirmed already gone), False otherwise.
+        """
+        if not self.is_enabled():
+            return False
+        if info_hash and self._raw_delete_by_id(info_hash):
+            return True
+        # Delete-by-id didn't confirm. Distinguish "id genuinely absent" (safe to
+        # try a name fallback) from "id present but delete errored" (a real
+        # failure — must NOT start guessing by name).
+        if info_hash and self._id_in_history(info_hash):
+            logging.warning(
+                f'[NzbDAV] job {info_hash} is in history but could not be deleted — '
+                'treating as failure (not guessing by name)'
+            )
+            return False
+        if entry_name:
+            return self._delete_by_exact_name(entry_name)
+        logging.info(f'[NzbDAV] remove_nzb: id {info_hash!r} absent and no name to match')
+        return False
 
     def get_job_status(self, job_id: str) -> Optional[Dict[str, Any]]:
         """Poll nzbdav for a single job's state.

--- a/utilities/deletion_manager.py
+++ b/utilities/deletion_manager.py
@@ -2073,7 +2073,13 @@ class DeletionManager:
                         reset_usenet_client()
                         client = get_usenet_client()
                         info_hash = torrent_id[4:]  # strip 'nzb:'
-                        removed = client.remove_nzb(info_hash, item.get('filled_by_file') or item_title)
+                        # Pass location_basename (the scene release name) as the
+                        # fallback match key: it equals the provider's history entry
+                        # name and carries quality/codec, so a stale id on a migrated
+                        # item resolves to the right entry. filled_by_file is often an
+                        # opaque blob name; title is too loose.
+                        nzb_match_name = item.get('location_basename') or item.get('filled_by_file') or item_title
+                        removed = client.remove_nzb(info_hash, nzb_match_name)
                         result['debrid_removed'] = removed
                         result['debrid_nzb_removed'] = 1 if removed else 0
                         if removed:
@@ -2498,7 +2504,10 @@ class DeletionManager:
                         title = item.get('title', 'Unknown')
                         if str(tid).startswith('nzb:'):
                             if tid not in unique_nzb_ids:
-                                unique_nzb_ids[tid] = (item.get('filled_by_file') or title, title)
+                                # location_basename = scene release name = the provider's
+                                # history entry name (the exact-name fallback key).
+                                match_name = item.get('location_basename') or item.get('filled_by_file') or title
+                                unique_nzb_ids[tid] = (match_name, title)
                         elif tid not in unique_torrent_ids:
                             unique_torrent_ids[tid] = title
                 except Exception as e:


### PR DESCRIPTION
## Problem

`NzbdavClient.remove_nzb` deletes a history entry only by `nzo_id`. 0.7.44 ships `utilities/provider_transfer.py`, which migrates downloads between Decypharr and NzbDAV. After such a migration a library item's `filled_by_torrent_id` still holds the **old** provider's id, which is not a live NzbDAV `nzo_id`.

So when the user deletes that item from the library, delete-by-id finds nothing and silently no-ops → the file stays in NzbDAV → Plex re-imports it → cli-debrid writes the item straight back into the DB. Delete-from-library doesn't stick.

Secondary: `utilities/deletion_manager.py` passed `filled_by_file` as the removal name hint. NzbDAV history entries are keyed by the **release/folder name**, while `filled_by_file` is frequently an opaque blob name (e.g. `BTL0H1z….mkv`), so even a name-based fallback would miss with that key.

## Fix

- `remove_nzb`: keep delete-by-id as the primary path. If it doesn't confirm **and** the id is genuinely absent from history (distinguished from "present but the delete errored"), fall back to an **exact, full normalised-name** match against the history entry name. Matching is never a substring — a `1080p` release must not resolve to its `2160p` sibling — and if more than one entry normalises equal, it **refuses** rather than guess. An id that *is* in history but failed to delete is treated as a hard failure (no name guessing).
- `deletion_manager.py`: pass `location_basename` (the scene release name, which equals the NzbDAV history entry name and carries quality/codec) as the match key, falling back to `filled_by_file`/title.

## Changes

- `usenet/nzbdav_client.py`: split the delete into `_raw_delete_by_id`, add `_id_in_history`, `_release_name_key`, `_delete_by_exact_name`, and the orchestration in `remove_nzb`.
- `utilities/deletion_manager.py`: use `location_basename` as the removal match key at both call sites.
- `tests/test_nzbdav_remove.py`: native delete, migrated-id fallback, full-name (not substring) matching, ambiguity refusal, and the present-but-errored no-guess path (10 tests).

## Testing

`python3 -m pytest tests/test_nzbdav_remove.py` — 10 passing.

## Notes

Independent of #428 (configurable category map). Both touch `usenet/nzbdav_client.py` but in different methods; happy to rebase whichever merges second.
