### PR TITLE
stats: non-blocking dashboard stats (stale-while-revalidate) so a down debrid provider can't hang the dashboard

### DIFF
--- a/database/statistics.py
+++ b/database/statistics.py
@@ -32,9 +32,31 @@ download_stats_cache = {
     'active_downloads': None,
     'usage_stats': None,
     'subscription': None,
-    'last_update': 0,
-    'cache_duration': 300  # 5 minutes in seconds
+    'last_update': 0,       # set when a refresh produces data (success or graceful)
+    'last_attempt': 0,      # set whenever a background refresh is started (throttle)
+    'cache_duration': 300   # 5 minutes in seconds
 }
+
+# Background-refresh coordination so the (potentially slow / unreachable) debrid
+# provider can never block the request thread. A down provider used to hang the
+# dashboard for up to ~90s (3 retries x 30s timeout). See get_cached_download_stats.
+import threading as _threading
+_stats_refresh_lock = _threading.Lock()
+_stats_refresh_in_progress = False
+_STATS_MIN_RETRY = 30        # seconds: don't restart a background refresh more often than this
+# Cold start only (no cached value yet): how long the request may wait for the
+# very first refresh before returning a non-blocking placeholder. Kept just long
+# enough for a HEALTHY provider's first response (~1s); a down provider therefore
+# costs at most this, not the full ~90s retry chain. The dashboard renders stats
+# server-side without polling, so a tiny wait lets a healthy first load show real
+# data instead of a placeholder.
+_STATS_COLD_START_WAIT = 3.0  # seconds
+
+# Same coordination for the subscription-status fetch (its own 30-min TTL). The
+# dashboard renders it server-side too, so it must not block on a down provider.
+_sub_refresh_lock = _threading.Lock()
+_sub_refresh_in_progress = False
+_SUB_TTL = 1800  # 30 minutes
 
 def parse_size(size_str):
     """Convert human readable size string to bytes"""
@@ -59,10 +81,69 @@ def parse_size(size_str):
         return 0
 
 def get_cached_download_stats():
-    """Get cached download stats or fetch new ones if cache is expired"""
+    """Return download stats, refreshing in the BACKGROUND (stale-while-revalidate).
+
+    The debrid provider call can be slow or time out (a down provider blocked the
+    dashboard for up to ~90s — 3 retries x 30s). To keep a non-critical stats
+    widget from ever blocking the request, we always serve the last cached value
+    immediately and refresh it on a background thread. On failure the background
+    refresh keeps the last good value (stale-if-error) instead of replacing it
+    with an error state. Only a true cold start (no value yet) waits a short,
+    bounded time and then returns a non-blocking placeholder.
+    """
+    now = time.time()
+    has_data = (download_stats_cache['active_downloads'] is not None and
+                download_stats_cache['usage_stats'] is not None)
+    fresh = has_data and (download_stats_cache['last_update'] + download_stats_cache['cache_duration'] >= now)
+    if fresh:
+        return download_stats_cache['active_downloads'], download_stats_cache['usage_stats']
+
+    # Kick off (at most one) background refresh, throttled so a failing provider
+    # isn't hammered on every request.
+    global _stats_refresh_in_progress
+    started = False
+    with _stats_refresh_lock:
+        if not _stats_refresh_in_progress and (now - download_stats_cache.get('last_attempt', 0) >= _STATS_MIN_RETRY):
+            _stats_refresh_in_progress = True
+            download_stats_cache['last_attempt'] = now
+            started = True
+    if started:
+        _t = _threading.Thread(target=_run_stats_refresh, name='download-stats-refresh', daemon=True)
+        _t.start()
+        if not has_data:
+            # cold start only: give the very first fetch a short, bounded chance
+            _t.join(timeout=_STATS_COLD_START_WAIT)
+
+    if (download_stats_cache['active_downloads'] is not None and
+            download_stats_cache['usage_stats'] is not None):
+        return download_stats_cache['active_downloads'], download_stats_cache['usage_stats']
+    # cold start and the provider is still slow → do NOT block; show a placeholder
+    return ({'count': 0, 'limit': 0, 'percentage': 0, 'status': 'loading', 'error': None},
+            {'used': '—', 'limit': '—', 'percentage': 0, 'error': None})
+
+
+def _run_stats_refresh():
+    """Background worker: run the blocking refresh and always clear the in-progress flag."""
+    global _stats_refresh_in_progress
+    try:
+        _refresh_download_stats_blocking()
+    except Exception as e:
+        logging.error(f"Background download-stats refresh failed: {str(e)}")
+    finally:
+        with _stats_refresh_lock:
+            _stats_refresh_in_progress = False
+
+
+def _refresh_download_stats_blocking():
+    """Fetch fresh download stats from the active provider and update the cache.
+
+    May block (provider I/O with retries) — always call this OFF the request
+    thread via _run_stats_refresh. On a provider error it preserves the last good
+    cached value (stale-if-error) rather than overwriting it with an error state.
+    """
     current_time = time.time()
-    if (download_stats_cache['last_update'] + download_stats_cache['cache_duration'] < current_time or 
-        download_stats_cache['active_downloads'] is None or 
+    if (download_stats_cache['last_update'] + download_stats_cache['cache_duration'] < current_time or
+        download_stats_cache['active_downloads'] is None or
         download_stats_cache['usage_stats'] is None):
         
         logging.debug("Download stats cache expired, fetching fresh data...")
@@ -205,13 +286,17 @@ def get_cached_download_stats():
                     }
             except Exception as e:
                 logging.error(f"Error getting active downloads: {str(e)}")
-                download_stats_cache['active_downloads'] = {
-                    'count': 0,
-                    'limit': 0,
-                    'percentage': 0,
-                    'status': 'error',
-                    'error': str(e)
-                }
+                # stale-if-error: keep the last good value if we have one; only
+                # surface an error state when there is nothing better to show.
+                _prev = download_stats_cache.get('active_downloads')
+                if not (_prev and _prev.get('error') is None):
+                    download_stats_cache['active_downloads'] = {
+                        'count': 0,
+                        'limit': 0,
+                        'percentage': 0,
+                        'status': 'error',
+                        'error': str(e)
+                    }
             
             # Get usage stats with timeout protection
             usage = None
@@ -268,12 +353,15 @@ def get_cached_download_stats():
             except Exception as e:
                 logging.error(f"Error getting usage stats: {str(e)}")
                 logging.error(f"Raw usage data that caused error: {usage}")
-                download_stats_cache['usage_stats'] = {
-                    'used': '0 GB',
-                    'limit': '2000 GB',
-                    'percentage': 0,
-                    'error': str(e)
-                }
+                # stale-if-error: preserve the last good usage value if present.
+                _prev_usage = download_stats_cache.get('usage_stats')
+                if not (_prev_usage and _prev_usage.get('error') is None):
+                    download_stats_cache['usage_stats'] = {
+                        'used': '0 GB',
+                        'limit': '2000 GB',
+                        'percentage': 0,
+                        'error': str(e)
+                    }
 
             download_stats_cache['last_update'] = current_time
             logging.debug("Download stats cache updated successfully")
@@ -329,39 +417,81 @@ def get_cached_download_stats():
 
     return download_stats_cache['active_downloads'], download_stats_cache['usage_stats']
 
-def get_cached_subscription_status() -> Dict:
-    """Return cached subscription info, refreshing if needed (30 min cache window)."""
+def _refresh_subscription_blocking():
+    """Fetch subscription status from the provider (may block on provider I/O).
+
+    Always run OFF the request thread via _run_subscription_refresh. On a provider
+    error the last good value is preserved (stale-if-error)."""
     try:
-        current_time = time.time()
-        # If we have never populated subscription, or our overall cache TTL expired, refresh
-        if (download_stats_cache.get('subscription') is None or
-            download_stats_cache['last_update'] + 1800 < current_time):
-            _debrid_key = get_setting('Debrid Provider', 'api_key', default='').strip()
-            provider = get_debrid_provider() if _debrid_key else None
-            # Get fresh subscription status from provider
-            subscription = provider.get_subscription_status() if provider and hasattr(provider, 'get_subscription_status') else {
-                'days_remaining': None,
-                'expiration': None,
-                'premium': None
-            }
-            download_stats_cache['subscription'] = subscription
-            # Do not touch last_update for download/usage cache cadence; subscription has its own TTL above
-        return download_stats_cache['subscription']
+        _debrid_key = get_setting('Debrid Provider', 'api_key', default='').strip()
+        provider = get_debrid_provider() if _debrid_key else None
+        subscription = provider.get_subscription_status() if provider and hasattr(provider, 'get_subscription_status') else {
+            'days_remaining': None,
+            'expiration': None,
+            'premium': None
+        }
+        download_stats_cache['subscription'] = subscription
+        download_stats_cache['subscription_update'] = time.time()
     except ProviderUnavailableError:
-        return {
-            'days_remaining': None,
-            'expiration': None,
-            'premium': None,
-            'error': 'provider_unavailable'
-        }
+        _prev = download_stats_cache.get('subscription')
+        if not (_prev and _prev.get('error') is None):
+            download_stats_cache['subscription'] = {
+                'days_remaining': None, 'expiration': None, 'premium': None,
+                'error': 'provider_unavailable'
+            }
     except Exception as e:
-        logging.error(f"Error getting cached subscription status: {str(e)}")
-        return {
-            'days_remaining': None,
-            'expiration': None,
-            'premium': None,
-            'error': str(e)
-        }
+        logging.error(f"Error refreshing subscription status: {str(e)}")
+        _prev = download_stats_cache.get('subscription')
+        if not (_prev and _prev.get('error') is None):
+            download_stats_cache['subscription'] = {
+                'days_remaining': None, 'expiration': None, 'premium': None,
+                'error': str(e)
+            }
+
+
+def _run_subscription_refresh():
+    """Background worker: run the blocking subscription refresh; clear the flag."""
+    global _sub_refresh_in_progress
+    try:
+        _refresh_subscription_blocking()
+    except Exception as e:
+        logging.error(f"Background subscription refresh failed: {str(e)}")
+    finally:
+        with _sub_refresh_lock:
+            _sub_refresh_in_progress = False
+
+
+def get_cached_subscription_status() -> Dict:
+    """Return subscription info, refreshing in the BACKGROUND (stale-while-revalidate).
+
+    The debrid call can block ~90s when the provider is down; the dashboard renders
+    this server-side, so we never call it on the request thread. Serve the last
+    cached value immediately; a cold start waits a short bounded time then returns
+    a neutral placeholder. (30-minute refresh cadence via _SUB_TTL.)
+    """
+    now = time.time()
+    sub = download_stats_cache.get('subscription')
+    fresh = sub is not None and (download_stats_cache.get('subscription_update', 0) + _SUB_TTL >= now)
+    if fresh:
+        return sub
+
+    global _sub_refresh_in_progress
+    started = False
+    with _sub_refresh_lock:
+        if not _sub_refresh_in_progress and (now - download_stats_cache.get('subscription_attempt', 0) >= _STATS_MIN_RETRY):
+            _sub_refresh_in_progress = True
+            download_stats_cache['subscription_attempt'] = now
+            started = True
+    if started:
+        _t = _threading.Thread(target=_run_subscription_refresh, name='subscription-refresh', daemon=True)
+        _t.start()
+        if sub is None:
+            _t.join(timeout=_STATS_COLD_START_WAIT)
+
+    sub = download_stats_cache.get('subscription')
+    if sub is not None:
+        return sub
+    return {'days_remaining': None, 'expiration': None, 'premium': None, 'error': None}
 
 def cache_for_seconds(seconds):
     """Cache the result of a function for the specified number of seconds."""

--- a/tests/test_stats_resilience.py
+++ b/tests/test_stats_resilience.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Unit tests for database/statistics.py get_cached_download_stats resilience.
+
+The dashboard stats must NEVER block on a slow/unreachable debrid provider: the
+refresh runs on a background thread and the request always returns the current
+(possibly stale) cached value immediately; a true cold start returns a
+non-blocking placeholder. The blocking refresh worker is stubbed so we test the
+wrapper's behaviour, not provider I/O.
+"""
+
+import unittest
+import sys
+import os
+import types
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _permissive(name, **attrs):
+    m = types.ModuleType(name)
+    m.__getattr__ = lambda a: (lambda *x, **k: None)
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    return m
+
+
+def _load_statistics():
+    # database package + stubbed submodules (relative imports resolve against these)
+    pkg = types.ModuleType('database'); pkg.__path__ = []
+    sys.modules['database'] = pkg
+    sys.modules['database.core'] = _permissive('database.core')
+    sys.modules['database.poster_management'] = _permissive('database.poster_management')
+    sys.modules['routes'] = _permissive('routes')
+    sys.modules['routes.poster_cache'] = _permissive('routes.poster_cache')
+    if 'utilities' not in sys.modules:
+        sys.modules['utilities'] = types.ModuleType('utilities')
+    sys.modules['utilities.settings'] = _permissive('utilities.settings',
+                                                    get_setting=lambda *a, **k: (a[2] if len(a) > 2 else ''))
+    sys.modules['aiohttp'] = _permissive('aiohttp')
+    sys.modules['flask'] = _permissive('flask', request=None, url_for=lambda *a, **k: '')
+    # debrid: the exception names MUST be real classes (used in except clauses)
+    debrid = types.ModuleType('debrid')
+    class TooManyDownloadsError(Exception): pass
+    class ProviderUnavailableError(Exception): pass
+    debrid.TooManyDownloadsError = TooManyDownloadsError
+    debrid.ProviderUnavailableError = ProviderUnavailableError
+    debrid.get_debrid_provider = lambda *a, **k: None
+    sys.modules['debrid'] = debrid
+
+    import importlib.util
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        'database', 'statistics.py')
+    spec = importlib.util.spec_from_file_location('database.statistics', path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules['database.statistics'] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+st = _load_statistics()
+
+GOOD_ACTIVE = {'count': 3, 'limit': 10, 'percentage': 30, 'status': 'normal', 'error': None}
+GOOD_USAGE = {'used': '500 GB', 'limit': '2000 GB', 'percentage': 25, 'error': None}
+
+
+class TestStatsResilience(unittest.TestCase):
+    def setUp(self):
+        # reset module cache + coordination state before each test
+        st.download_stats_cache.update({
+            'active_downloads': None, 'usage_stats': None, 'subscription': None,
+            'last_update': 0, 'last_attempt': 0, 'cache_duration': 300,
+        })
+        st._stats_refresh_in_progress = False
+        self._orig = st._refresh_download_stats_blocking
+        self.addCleanup(lambda: setattr(st, '_refresh_download_stats_blocking', self._orig))
+
+    def test_fresh_cache_returns_immediately_without_refresh(self):
+        st.download_stats_cache.update({'active_downloads': GOOD_ACTIVE, 'usage_stats': GOOD_USAGE,
+                                        'last_update': time.time()})
+        called = []
+        st._refresh_download_stats_blocking = lambda: called.append(1)
+        a, u = st.get_cached_download_stats()
+        self.assertEqual(a, GOOD_ACTIVE)
+        self.assertEqual(called, [])  # no refresh when fresh
+
+    def test_expired_with_stale_data_returns_stale_without_blocking(self):
+        # prior good data but cache expired; refresh is SLOW (5s) → must not block
+        st.download_stats_cache.update({'active_downloads': GOOD_ACTIVE, 'usage_stats': GOOD_USAGE,
+                                        'last_update': time.time() - 10_000})
+        def slow():
+            time.sleep(5)
+        st._refresh_download_stats_blocking = slow
+        t0 = time.time()
+        a, u = st.get_cached_download_stats()
+        elapsed = time.time() - t0
+        self.assertLess(elapsed, 2.0, 'must return stale data without waiting for the slow refresh')
+        self.assertEqual(a, GOOD_ACTIVE)        # served stale
+        self.assertEqual(u, GOOD_USAGE)
+
+    def test_cold_start_returns_placeholder_not_block(self):
+        # no data at all; refresh produces nothing → placeholder, no long wait
+        st._refresh_download_stats_blocking = lambda: None  # returns fast, sets nothing
+        t0 = time.time()
+        a, u = st.get_cached_download_stats()
+        elapsed = time.time() - t0
+        self.assertLess(elapsed, 3.0)
+        self.assertEqual(a['status'], 'loading')
+        self.assertIsNone(a['error'])
+
+    def test_refresh_started_only_once_under_throttle(self):
+        st.download_stats_cache.update({'active_downloads': GOOD_ACTIVE, 'usage_stats': GOOD_USAGE,
+                                        'last_update': time.time() - 10_000})
+        starts = []
+        def slow():
+            starts.append(1); time.sleep(0.5)
+        st._refresh_download_stats_blocking = slow
+        for _ in range(5):
+            st.get_cached_download_stats()
+        time.sleep(0.8)
+        self.assertEqual(len(starts), 1, 'concurrent/expired hits must coalesce into one refresh')
+
+
+GOOD_SUB = {'days_remaining': 200, 'expiration': '2027-01-01', 'premium': True, 'error': None}
+
+
+class TestSubscriptionResilience(unittest.TestCase):
+    def setUp(self):
+        st.download_stats_cache.update({
+            'subscription': None, 'subscription_update': 0, 'subscription_attempt': 0,
+            'last_update': 0, 'last_attempt': 0,
+        })
+        st._sub_refresh_in_progress = False
+        self._orig = st._refresh_subscription_blocking
+        self.addCleanup(lambda: setattr(st, '_refresh_subscription_blocking', self._orig))
+
+    def test_fresh_returns_without_refresh(self):
+        st.download_stats_cache.update({'subscription': GOOD_SUB, 'subscription_update': time.time()})
+        called = []
+        st._refresh_subscription_blocking = lambda: called.append(1)
+        self.assertEqual(st.get_cached_subscription_status(), GOOD_SUB)
+        self.assertEqual(called, [])
+
+    def test_stale_served_without_blocking(self):
+        st.download_stats_cache.update({'subscription': GOOD_SUB, 'subscription_update': time.time() - 100_000})
+        st._refresh_subscription_blocking = lambda: time.sleep(5)
+        t0 = time.time()
+        sub = st.get_cached_subscription_status()
+        self.assertLess(time.time() - t0, 2.0)   # must not wait for the slow refresh
+        self.assertEqual(sub, GOOD_SUB)           # stale served
+
+    def test_cold_start_placeholder_not_block(self):
+        st._refresh_subscription_blocking = lambda: None
+        t0 = time.time()
+        sub = st.get_cached_subscription_status()
+        self.assertLess(time.time() - t0, 4.0)
+        self.assertIsNone(sub['error'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

The dashboard renders **download stats** and the **debrid subscription status** server-side. Both helpers (`database/statistics.py::get_cached_download_stats` and `get_cached_subscription_status`) fetched the debrid provider **synchronously on the request thread**. That call can take ~90s when the provider is unreachable (the TorBox client retries 3× with a 30s timeout each), so a down/slow debrid provider **hung the entire dashboard render for up to ~90s** — for a couple of non-critical widgets.

(Observed in the wild during a TorBox API outage: the dashboard hung; `get_cached_download_stats` logged `Torbox request timed out` after the full retry chain.)

## Fix — stale-while-revalidate

Both helpers now follow established resilience practice (graceful degradation / stale-while-revalidate / fail-fast on user-facing paths):

- **Background refresh**: the refresh runs on a daemon thread; the request always returns the current cached value immediately and never blocks on provider I/O (soft dependency).
- **Stale-if-error**: a failed refresh keeps the last good value instead of overwriting it with an error state.
- **Bounded cold start**: with no cached value yet, the request waits a short bounded time (3s, `_STATS_COLD_START_WAIT`) for the first result, then returns a non-blocking placeholder. The page renders stats server-side without polling, so a brief wait lets a healthy first load show real data, while a down provider costs at most 3s instead of ~90s.
- **Coalesced + throttled**: at most one background refresh at a time, and not restarted more often than every 30s, so a failing provider isn't hammered.

## Scope

Only the two **server-rendered dashboard helpers** — the actual navigation blockers. Action endpoints (POST: deletes, etc.) and XHR data endpoints (`/api/library_size`, `/api/torrent-status`) are intentionally left unchanged: they don't block page navigation, and a spinning widget correctly reflects that the provider has a real problem.

## Changes

- `database/statistics.py`: split each helper into a public stale-while-revalidate wrapper + a background blocking worker; preserve last-good values on error.
- `tests/test_stats_resilience.py`: fresh short-circuit, serve-stale-without-blocking, cold-start placeholder, refresh coalescing — for both download stats and subscription (7 tests).

## Testing

- `python3 -m pytest tests/test_stats_resilience.py` — 7 passing.
- Validated live against a real provider outage: with prior data the call returns in ~0.0s (stale), and a cold start with a fully-hung provider returns in 3.0s (placeholder) instead of ~90s.
