### PR TITLE
nzbdav parity fixes (Batch 1): tag-exclusive routing, provider schema key, usenet-only guards, rename guard

### DIFF
--- a/debrid/__init__.py
+++ b/debrid/__init__.py
@@ -81,7 +81,9 @@ def get_debrid_providers() -> List[DebridProvider]:
         return _provider_list
 
     primary = get_debrid_provider()
-    providers = [primary]
+    # primary is None on a usenet-only setup (no debrid key); never put None in
+    # the chain — downstream iterates/derefs these providers.
+    providers = [primary] if primary is not None else []
 
     fallbacks = get_setting("Debrid Provider", "fallback_providers", []) or []
     for fb in fallbacks:

--- a/queues/pending_uncached_queue.py
+++ b/queues/pending_uncached_queue.py
@@ -198,6 +198,8 @@ class PendingUncachedQueue:
                             try:
                                 from usenet.decypharr_client import get_decypharr_client
                                 _dc3 = get_decypharr_client()
+                                if not hasattr(_dc3, 'rename_nzb'):
+                                    return  # active usenet provider (e.g. nzbdav) has no rename semantics
                                 for _a3 in range(20):
                                     if _dc3.rename_nzb(h, name):
                                         logging.info(f'[DebridNaming] Renamed {h!r} -> {name!r} (pending uncached)')

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -6367,6 +6367,8 @@ class ProgramRunner:
                                                         try:
                                                             from usenet.decypharr_client import get_decypharr_client
                                                             _dc = get_decypharr_client()
+                                                            if not hasattr(_dc, 'rename_nzb'):
+                                                                return  # active usenet provider (e.g. nzbdav) has no rename semantics
                                                             for _a in range(5):
                                                                 if _dc.rename_nzb(h, name):
                                                                     logging.info(f'[DebridNaming] Renamed {h!r} -> {name!r} (collected, attempt {_a+1})')

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -99,6 +99,10 @@ class TorrentProcessor:
 
             # Use passed provider or fall back to self.debrid_provider
             _provider = provider if provider is not None else self.debrid_provider
+            # usenet-only setup: no debrid provider to cache-check against. Treat
+            # as not-cached rather than dereferencing None.
+            if _provider is None:
+                return (False, 'no_provider')
 
             # Extract imdb_id and title from item
             imdb_id = item.get('imdb_id') if item else None
@@ -947,7 +951,12 @@ class TorrentProcessor:
                         logging.warning(f"[{prov.PROVIDER_NAME}] cache check error: {_e}")
                         return prov, None, 'error'
 
-                if len(providers) == 1:
+                if not providers:
+                    # usenet-only setup: no debrid provider to cache-check a
+                    # torrent result. Leave is_cached False (ThreadPoolExecutor
+                    # would raise on max_workers=0).
+                    is_cached = False
+                elif len(providers) == 1:
                     winning_provider, is_cached, cache_source = _check_one(providers[0])
                 else:
                     with ThreadPoolExecutor(max_workers=len(providers)) as _ex:
@@ -1229,6 +1238,8 @@ class TorrentProcessor:
                                             try:
                                                 from usenet.decypharr_client import get_decypharr_client
                                                 _dc = get_decypharr_client()
+                                                if not hasattr(_dc, 'rename_nzb'):
+                                                    return  # active usenet provider (e.g. nzbdav) has no rename semantics
                                                 for _attempt in range(20):
                                                     if _dc.rename_nzb(h, name):
                                                         logging.info(f'[DebridNaming] Renamed {h!r} -> {name!r} for {ident}')

--- a/routes/scraper_routes.py
+++ b/routes/scraper_routes.py
@@ -363,7 +363,9 @@ def add_torrent_to_debrid():
         from debrid.base import ProviderUnavailableError
         providers = get_debrid_providers()
         torrent_id = None
-        debrid_provider = providers[0]  # will be updated to whichever succeeds
+        # None on a usenet-only setup; the add loop below simply won't run and we
+        # return the "failed to add torrent" error.
+        debrid_provider = providers[0] if providers else None  # will be updated to whichever succeeds
         last_error = None
         for _prov in providers:
             try:

--- a/templates/_nzbdav_setup_helper.html
+++ b/templates/_nzbdav_setup_helper.html
@@ -291,6 +291,7 @@
       li.push('Bind the NzbDAV mount into cli-debrid: add <code>- ' + esc(p.mountbase) + '/nzbdav:' + esc(cm) + ':rshared</code> to cli-debrid\'s compose, apply the config block below, then <code>docker compose up -d --force-recreate cli_debrid</code>.');
     }
     li.push('Add the content folders to your Plex libraries (one per managed category — ' + CATS.map(function(c){ return '<code>' + esc(cm) + '/content/' + esc(c) + '</code>'; }).join(', ') + ') and disable Plex auto-scan on them (cli-debrid triggers scans itself).');
+    li.push('<strong>⚠️ Important for library deletes &amp; health checks:</strong> cli-debrid resolves a file\'s on-disk location for deletion/health via <code>Plex.mounted_file_location</code> and <code>File Management.original_files_path</code> — <em>not</em> the NzbDAV mount path. Make sure both point at a path that actually contains your NzbDAV content (the union mount above, or — for an NzbDAV-only box — your NzbDAV mount, e.g. <code>' + esc(cm) + '</code>). If they\'re left at a debrid default like <code>/mnt/zurg/__all__</code> on an NzbDAV-only setup, deletes/health checks look at the wrong (empty) mount and can wrongly flag items as missing.');
     return '<div style="margin-top:8px;"><strong>Deploy steps (run these on your host):</strong><ol class="settings-description" style="line-height:1.6;margin-top:4px;">'
       + li.map(function(s){ return '<li>' + s + '</li>'; }).join('') + '</ol></div>';
   }

--- a/tests/test_nzbdav_categories.py
+++ b/tests/test_nzbdav_categories.py
@@ -95,6 +95,19 @@ class TestResolveCategory(unittest.TestCase):
         m = {'movies': 'movies'}  # no fallback key
         self.assertEqual(nc._resolve_category('music', m), '')
 
+    def test_tag_exclusive_routes_to_own_category_not_fallback(self):
+        # tags_exclusive passes the tag itself as the bucket. A tag is not a
+        # structural bucket, so with a custom map it must NOT fall to the
+        # catch-all — it should land in its own category verbatim.
+        self.assertEqual(nc._resolve_category('ufc', OURMAP), 'ufc')
+        self.assertEqual(nc._resolve_category('sports', OURMAP), 'sports')
+        # a tag that the user explicitly mapped still honors the mapping
+        m = dict(OURMAP); m['ufc'] = 'combat_sports'
+        self.assertEqual(nc._resolve_category('ufc', m), 'combat_sports')
+        # structural buckets are unaffected: unmapped 2160p still -> fallback
+        self.assertEqual(nc._resolve_category('movies_2160p', {'movies': 'movies', 'fallback': '__unplayable__'}), 'movies')
+        self.assertEqual(nc._resolve_category('music', OURMAP), '__unplayable__')
+
 
 class TestManagedCategories(unittest.TestCase):
     def test_default_excludes_music(self):

--- a/usenet/nzbdav_client.py
+++ b/usenet/nzbdav_client.py
@@ -128,6 +128,13 @@ def _resolve_category(bucket: str, cat_map: dict) -> str:
         if node in cat_map:
             return cat_map[node]
         node = _CATEGORY_PARENT.get(node)
+    # Tag-exclusive routing passes the tag itself as `bucket`. A tag is not a
+    # structural bucket (movies/shows/resolution/remux/anime) and has no parent
+    # chain, so without this it would fall through to the catch-all whenever a
+    # category map is configured. Land tag-exclusive items in their own category
+    # verbatim instead. Structural buckets stay in _ALL_CATEGORIES → unchanged.
+    if bucket and bucket not in _ALL_CATEGORIES:
+        return bucket
     return cat_map.get(_FALLBACK_KEY, '')
 
 

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -353,6 +353,12 @@ SETTINGS_SCHEMA = {
             "description": "Maximum age of NZB results in days. Results older than this are filtered out before submission. Set to 0 to disable. Applies everywhere NZB indexers are searched.",
             "default": 1500
         },
+        "provider": {
+            "type": "string",
+            "description": "Which usenet backend to use: Decypharr or NzbDAV.",
+            "default": "decypharr",
+            "choices": ["decypharr", "nzbdav"]
+        },
         "owned_categories": {
             "type": "string",
             "description": "NzbDAV only. Comma-separated list of nzbdav categories the repair/health tool may act on. nzbdav history is shared with other SAB clients (e.g. Lidarr music), and repair can only re-acquire content cli-debrid manages — so it must never touch another app's entries. Leave empty to auto-pick the categories cli-debrid grabs into (movies, shows, movies_1080p_264, shows_1080p_264, plus the download-folder fallback). Set this only if your category names differ.",

--- a/utilities/web_scraper.py
+++ b/utilities/web_scraper.py
@@ -1772,9 +1772,11 @@ def process_media_selection(media_id: str, title: str, year: str, media_type: st
     # Get all configured debrid providers (primary + fallbacks)
     from debrid import get_debrid_providers
     all_providers = get_debrid_providers()
-    debrid_provider = all_providers[0]  # primary — used for capability flags and legacy paths
-    supports_cache_check = debrid_provider.supports_direct_cache_check
-    supports_bulk_check = debrid_provider.supports_bulk_cache_checking
+    # usenet-only setup: no debrid provider. Use None + capability flags off so the
+    # cache-check blocks below (all gated on supports_cache_check) are skipped.
+    debrid_provider = all_providers[0] if all_providers else None  # primary — capability flags / legacy paths
+    supports_cache_check = debrid_provider.supports_direct_cache_check if debrid_provider else False
+    supports_bulk_check = debrid_provider.supports_bulk_cache_checking if debrid_provider else False
 
     # Determine behavior from provider capability flags
     is_real_debrid = getattr(debrid_provider, 'supports_direct_cache_check', False)


### PR DESCRIPTION
Provider-parity fixes for the NzbDAV (usenet) backend, from a focused audit of which pre-existing settings/features that worked with debrid also work with nzbdav. **Every change is strictly provider-agnostic — debrid and decypharr behaviour is unchanged; the new guards are inert whenever a debrid provider exists.** Independently verified before submission.

## A — tag-exclusive category misroute (nzbdav)
With a custom `nzbdav_category_map` set, a content-source `tags_exclusive` tag (e.g. `ufc`) was routed to the catch-all (`fallback`) instead of its own category: `_resolve_category` walks the structural parent ladder (movies/shows/resolution/remux/anime), and a tag has no entry there, so it fell through. Fix: return the tag verbatim when the bucket is not a structural category. Structural buckets stay in `_ALL_CATEGORIES` → unchanged. (`usenet/nzbdav_client.py` + test.)

## B — add the `Usenet Provider.provider` schema key
The key that selects nzbdav (`decypharr`|`nzbdav`) is read by code but had no schema entry — it only survived via deep-merge of unknown keys (no default/validation/export). Added (string, default `decypharr`). The schema-default merge is key-existence-guarded, so a user's saved `nzbdav` is never reset. (`utilities/settings_schema.py`.)

## C — usenet-only (no debrid key) crash safety — additive None/empty guards
On a usenet-only setup `get_debrid_provider()` returns `None`. NZB results route out early so the happy path is fine, but a **torrent** result (e.g. a Prowlarr indexer still returning torrents) could `AttributeError`/`IndexError`/`ValueError`:
- `debrid/__init__.py`: never put `None` in the providers chain (`[]` not `[None]`).
- `queues/torrent_processor.py`: `check_cache_status` returns `(False,'no_provider')` when there's no provider; skip the parallel cache-check when `providers` is empty (avoids `ThreadPoolExecutor(max_workers=0)`).
- `utilities/web_scraper.py`, `routes/scraper_routes.py`: guard `providers[0]` indexing so a torrent result degrades cleanly instead of crashing.
All guards are inert when a debrid provider exists (debrid/decypharr behaviour byte-identical).

## F — DebridNaming `rename_nzb` under nzbdav
Three sites call `<usenet_client>.rename_nzb(...)`; the factory returns `NzbdavClient` (no `rename_nzb`) under `provider=nzbdav`. Added a `hasattr` guard **before** the retry loop so it skips cleanly instead of `AttributeError` + idle-spinning the daemon thread. (`queues/torrent_processor.py`, `pending_uncached_queue.py`, `run_program.py`.) NzbdavClient deliberately gets no no-op `rename_nzb` — it has no rename semantics.

## Docs — NzbDAV setup helper deletion/mount warning
cli-debrid resolves a file's on-disk location for deletion/health via `Plex.mounted_file_location` + `File Management.original_files_path`, not the NzbDAV mount path. Added a warning in the setup helper that NzbDAV-only users must point those at a path containing their NzbDAV content, or deletes/health checks look at the wrong (debrid-default) mount. No code change to the deletion path. (`templates/_nzbdav_setup_helper.html`.)

## Testing
- `pytest tests/test_nzbdav_categories.py` (+ the existing nzbdav/stats suites) — all green; new test covers the tag-exclusive fix.
- Dogfooded on a live debrid+nzbdav instance: app starts clean, nzbdav routing intact, the tag-exclusive fix resolves to the tag category live, and the debrid path is unchanged (guards inert with a provider present).
