### PR TITLE
nzbdav parity fixes (Batch 2): StuckPlex usenet routing, maintenance presence net, reverse-parser source scope, label clarity

### DIFF
--- a/database/maintenance.py
+++ b/database/maintenance.py
@@ -744,7 +744,25 @@ def run_plex_library_maintenance():
                     # If we can't resolve the path, skip this item
                     continue
                 
-                if not os.path.exists(full_path):
+                _missing = not os.path.exists(full_path)
+                if _missing and str(filled_by_torrent_id or '').startswith('nzb:'):
+                    # nzbdav safety net (READ-ONLY existence check — can only turn
+                    # 'missing' -> 'present', never cause a delete/re-grab). This
+                    # maintenance base is Plex.mounted_file_location, but nzbdav files
+                    # live on the Usenet Provider mount. Before declaring a Collected
+                    # nzb: item missing, also look on the usenet mount — otherwise an
+                    # nzbdav-only box left at the debrid default would wrongly re-grab
+                    # / DB-remove good items. Debrid/decypharr items skip this branch.
+                    _u_mount = (get_setting('Usenet Provider', 'mounted_file_location', '') or '').rstrip('/')
+                    if _u_mount.endswith('/__all__'):
+                        _u_mount = _u_mount[:-len('/__all__')]
+                    if _u_mount:
+                        try:
+                            if os.path.exists(os.path.join(_u_mount, location_on_disk)):
+                                _missing = False
+                        except Exception:
+                            pass
+                if _missing:
                     logging.warning(f"File not found for {title}: {full_path}")
                     missing_files.append({
                         'id': item_id,

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -4271,6 +4271,15 @@ class ProgramRunner:
             from database.database_reading import get_all_media_items
             from database.database_writing import update_media_item
 
+            # Decypharr-specific: this backfills filled_by_torrent_id for legacy
+            # Decypharr-collected items that predate the nzb: convention, via
+            # /api/torrents (which nzbdav doesn't implement). nzbdav items already
+            # carry their nzb: id natively, so there is nothing to backfill — skip
+            # cleanly to avoid failed requests + a misleading "Loaded 0 entries" log.
+            if (get_setting('Usenet Provider', 'provider', 'decypharr') or 'decypharr').strip().lower() != 'decypharr':
+                logging.info('[NZBBackfill] Skipped — Decypharr-specific backfill (active usenet provider is not decypharr).')
+                return
+
             dcy_url = get_setting('Usenet Provider', 'url', default='').rstrip('/')
             dcy_token = get_setting('Usenet Provider', 'api_token', default='')
             if not dcy_url:
@@ -7356,17 +7365,21 @@ class ProgramRunner:
                 return
             try:
                 if str(torrent_id).startswith('nzb:'):
-                    # NZB — delete from Decypharr by hash
-                    if not decypharr_enabled or not decypharr_url:
-                        return
+                    # NZB — remove from the ACTIVE usenet provider via the factory
+                    # (decypharr|nzbdav). The old inline Decypharr /api/torrents call
+                    # silently no-op'd under nzbdav, leaving the job + its WebDAV
+                    # content behind for Plex to re-import. remove_nzb exists on both
+                    # clients; decypharr issues the same /api/torrents delete.
                     nzb_hash = torrent_id[4:]  # strip 'nzb:' prefix
-                    d = _req.delete(f'{decypharr_url}/api/torrents',
-                                    params={'hashes': nzb_hash},
-                                    headers=decypharr_headers(), timeout=10)
-                    if d.status_code in (200, 204):
-                        logging.info(f"[StuckPlex] Deleted NZB source from Decypharr: {display} ({nzb_hash})")
-                    else:
-                        logging.debug(f"[StuckPlex] Decypharr NZB delete returned {d.status_code} for {display} — likely already gone")
+                    try:
+                        from usenet import get_usenet_client
+                        _uclient = get_usenet_client()
+                        if _uclient and _uclient.is_enabled() and _uclient.remove_nzb(nzb_hash, display):
+                            logging.info(f"[StuckPlex] Removed NZB source from usenet provider: {display} ({nzb_hash})")
+                        else:
+                            logging.debug(f"[StuckPlex] NZB source removal returned False for {display} ({nzb_hash}) — likely already gone")
+                    except Exception as _uerr:
+                        logging.debug(f"[StuckPlex] NZB source removal error for {display}: {_uerr}")
                 else:
                     # Debrid torrent
                     try:

--- a/routes/database_routes.py
+++ b/routes/database_routes.py
@@ -1508,7 +1508,7 @@ def reverse_parser():
 
         # Parse versions using parse_filename_for_version function
         for item in items:
-            parsed_version = parse_filename_for_version(item['filled_by_file'])
+            parsed_version = parse_filename_for_version(item['filled_by_file'], is_nzb=str(item.get('filled_by_torrent_id') or '').startswith('nzb:'))
             item['parsed_version'] = parsed_version
             logging.debug(f"Filename: {item['filled_by_file']}, Parsed Version: {parsed_version}")
 
@@ -1550,7 +1550,7 @@ def apply_parsed_versions():
 
     for item in items_to_update:
         if item['filled_by_file']:
-            parsed_version = parse_filename_for_version(item['filled_by_file'])
+            parsed_version = parse_filename_for_version(item['filled_by_file'], is_nzb=str(item.get('filled_by_torrent_id') or '').startswith('nzb:'))
             
             current_version = item.get('version') # Use .get() for safety
             if parsed_version != current_version:

--- a/tests/test_reverse_parser_source_scope.py
+++ b/tests/test_reverse_parser_source_scope.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Unit tests for reverse_parser source-scoping (filter_in/filter_out `source`).
+
+The reverse-parser must honor a filter term's `source` (both|nzb|debrid) when
+assigning a version, exactly like filter_results — so a term scoped to the other
+protocol doesn't affect the label. Default (`is_nzb=False`, source 'both') must
+be byte-identical to the previous behaviour.
+"""
+
+import unittest
+import sys
+import os
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _load():
+    if 'utilities' not in sys.modules:
+        sys.modules['utilities'] = types.ModuleType('utilities')
+    sys.modules['utilities.settings'] = types.ModuleType('utilities.settings')
+    sys.modules['utilities.settings'].get_setting = lambda *a, **k: (a[2] if len(a) > 2 else None)
+    # smart_search stub: case-insensitive substring (enough to exercise the gating)
+    sf = types.ModuleType('scraper'); sff = types.ModuleType('scraper.functions')
+    sfo = types.ModuleType('scraper.functions.other_functions')
+    sfo.smart_search = lambda term, text: str(term).lower() in str(text).lower()
+    sys.modules['scraper'] = sf
+    sys.modules['scraper.functions'] = sff
+    sys.modules['scraper.functions.other_functions'] = sfo
+    import importlib.util
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        'utilities', 'reverse_parser.py')
+    spec = importlib.util.spec_from_file_location('reverse_parser_under_test', path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+rp = _load()
+NEG_INF = -float('inf')
+PTT = {'title': 'Movie', 'resolution': '1080p', 'source': 'WEB', 'codec': 'x264', 'group': 'GRP'}
+
+
+def score(filename, cfg, is_nzb):
+    return rp._calculate_match_score(filename, dict(PTT), 'v1', cfg, is_nzb=is_nzb)
+
+
+class TestFilterOutSourceScope(unittest.TestCase):
+    def test_debrid_scoped_filter_out_ignored_for_nzb(self):
+        cfg = {'filter_out': [{'pattern': 'CAM', 'source': 'debrid'}]}
+        # nzb item: a debrid-scoped filter_out must NOT disqualify
+        self.assertNotEqual(score('Movie.2020.CAM.x264', cfg, is_nzb=True), NEG_INF)
+        # debrid item: it applies -> DQ
+        self.assertEqual(score('Movie.2020.CAM.x264', cfg, is_nzb=False), NEG_INF)
+
+    def test_both_scoped_filter_out_applies_to_all(self):
+        cfg = {'filter_out': [{'pattern': 'CAM'}]}  # no source -> 'both'
+        self.assertEqual(score('Movie.2020.CAM.x264', cfg, is_nzb=True), NEG_INF)
+        self.assertEqual(score('Movie.2020.CAM.x264', cfg, is_nzb=False), NEG_INF)
+
+    def test_legacy_string_filter_out_unchanged(self):
+        cfg = {'filter_out': ['CAM']}  # legacy plain string -> 'both'
+        self.assertEqual(score('Movie.2020.CAM.x264', cfg, is_nzb=True), NEG_INF)
+
+
+class TestFilterInSourceScope(unittest.TestCase):
+    def test_other_protocol_only_filter_in_does_not_dq(self):
+        # all filter_in scoped to debrid; evaluated for an nzb item -> no applicable
+        # mandatory filter_in -> must NOT DQ
+        cfg = {'filter_in': [{'pattern': 'REMUX', 'source': 'debrid'}]}
+        self.assertNotEqual(score('Movie.2020.WEB.x264', cfg, is_nzb=True), NEG_INF)
+
+    def test_applicable_filter_in_missing_dqs(self):
+        cfg = {'filter_in': [{'pattern': 'REMUX', 'source': 'both'}]}
+        # REMUX not in filename, term applies -> DQ
+        self.assertEqual(score('Movie.2020.WEB.x264', cfg, is_nzb=True), NEG_INF)
+        # present -> not DQ
+        self.assertNotEqual(score('Movie.2020.REMUX.x264', cfg, is_nzb=True), NEG_INF)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/utilities/reverse_parser.py
+++ b/utilities/reverse_parser.py
@@ -274,7 +274,7 @@ def _check_preferred_rp(patterns_weights, fields_to_check: list, is_bonus: bool)
                 break 
     return score_change #, breakdown
 
-def _calculate_match_score(filename: str, ptt_data: dict, version_name: str, version_config: dict) -> float:
+def _calculate_match_score(filename: str, ptt_data: dict, version_name: str, version_config: dict, is_nzb: bool = False) -> float:
     """
     Calculates a score based on how well PTT-parsed data matches the scraping version_config,
     using logic adapted from filter_results.py and rank_results.py.
@@ -302,6 +302,12 @@ def _calculate_match_score(filename: str, ptt_data: dict, version_name: str, ver
         f"{ptt_data.get('group','')}"
     )
     for term_obj in version_config.get("filter_out", []):
+        # Honor the per-term source scope (both|nzb|debrid) exactly like
+        # filter_results.py, so a term scoped to the other protocol doesn't affect
+        # version assignment. Default 'both' → unchanged for existing configs.
+        _src = term_obj.get('source', 'both') if isinstance(term_obj, dict) else 'both'
+        if (_src == 'nzb' and not is_nzb) or (_src == 'debrid' and is_nzb):
+            continue
         term = term_obj['pattern'] if isinstance(term_obj, dict) else str(term_obj)
         if smart_search(term, combined_text_for_filter_out):
             term_display = (term[:15] + '...') if len(term) > 18 else term
@@ -324,19 +330,27 @@ def _calculate_match_score(filename: str, ptt_data: dict, version_name: str, ver
     filter_in_terms = version_config.get("filter_in", [])
     if filter_in_terms: 
         found_mandatory_filter_in = False
+        _applicable_filter_in = 0  # filter_in terms that apply to THIS protocol
         matched_filter_in_term_for_log = ""
         for term_obj in filter_in_terms:
+            _src = term_obj.get('source', 'both') if isinstance(term_obj, dict) else 'both'
+            if (_src == 'nzb' and not is_nzb) or (_src == 'debrid' and is_nzb):
+                continue  # term scoped to the other protocol — mirror filter_results
+            _applicable_filter_in += 1
             term = term_obj['pattern'] if isinstance(term_obj, dict) else str(term_obj)
             if any(smart_search(term, field_val) for field_val in ptt_matchable_fields_str):
                 found_mandatory_filter_in = True
                 matched_filter_in_term_for_log = term # For logging
                 break
-        
-        if not found_mandatory_filter_in:
+
+        # Only DQ when there WERE filter_in terms applicable to this protocol and
+        # none matched. If every filter_in term was scoped to the other protocol,
+        # this version has no mandatory filter_in here → don't DQ (mirror filter_results).
+        if _applicable_filter_in > 0 and not found_mandatory_filter_in:
             details = "DQ: Missing filter_in"
             logging.debug(f"{filename_display:<80} | {version_name_display:<20} | {details:<45}")
             return -float('inf')
-        else:
+        elif found_mandatory_filter_in:
             score += 20 # Base bonus for passing mandatory filter_in
             
             # Calculate special bonus based on highest preferred_filter_in score
@@ -448,11 +462,15 @@ def _calculate_match_score(filename: str, ptt_data: dict, version_name: str, ver
     
     return score
 
-def parse_filename_for_version(filename: str) -> str:
+def parse_filename_for_version(filename: str, is_nzb: bool = False) -> str:
     """
-    Dynamically parses a filename using PTT and then determines its best matching 
+    Dynamically parses a filename using PTT and then determines its best matching
     "Scraping" version by scoring it against all configured scraping versions.
     Excludes generic version names '1080p' and '2160p' from being matched.
+
+    `is_nzb` lets callers that know the result protocol apply per-term filter
+    source-scoping (both|nzb|debrid) consistently with filter_results. Callers
+    that don't know the protocol leave the safe default (False / treat as 'both').
     """
     scraping_versions_config = get_setting('Scraping', 'versions', {})
     default_rp_version = get_default_version()
@@ -493,7 +511,7 @@ def parse_filename_for_version(filename: str) -> str:
             logging.warning(f"Skipping invalid version config for '{version_name}'. Expected dict, got {type(version_config)}")
             continue
         
-        current_score = _calculate_match_score(filename, ptt_data, version_name, version_config)
+        current_score = _calculate_match_score(filename, ptt_data, version_name, version_config, is_nzb=is_nzb)
         
         if current_score > highest_score:
             highest_score = current_score

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -528,9 +528,16 @@ SETTINGS_SCHEMA = {
     },
     "Scraping": {
         "tab": "Versions",
+        # NOTE: 'Hybrid' is a real third option but is a VIRTUAL UI value — the UI
+        # decomposes it on save into uncached_content_handling='None' + hybrid_mode=True
+        # (see static/js/settings.js), so the stored value is never literally 'Hybrid'.
+        # The 'Hybrid' branch in main.py is a backward-compat migration for legacy
+        # configs that still hold the literal string; do NOT add 'Hybrid' to choices
+        # or remove that branch without understanding that design. Cached/uncached is a
+        # DEBRID-only concept — usenet/NZB results bypass this gate entirely.
         "uncached_content_handling": {
             "type": "string",
-            "description": "Uncached content management in the program queue. None: Only take the best Cached result. Full: Take the best result, whether it's Cached or Uncached.",
+            "description": "DEBRID ONLY (no effect on usenet/NZB results). Uncached content management for debrid torrent results in the program queue. None: only take the best Cached result. Full: take the best result, cached or uncached. (A third 'Hybrid' mode is exposed in the UI and stored via the separate hybrid_mode toggle: try cached first, then fall back to uncached.)",
             "default": "None",
             "choices": ["None", "Full"]
         },


### PR DESCRIPTION
Round 2 of provider-parity fixes for the NzbDAV (usenet) backend, from a per-item audit of the deferred findings. **Every change is strictly provider-agnostic — debrid and decypharr behaviour is unchanged.** Each was independently verified before submission; the audit + per-item decision maps are tracked alongside.

## G1 — StuckPlex source delete routed through the usenet factory
The StuckPlex cleanup deleted `nzb:` items by inlining Decypharr's `DELETE /api/torrents` (Bearer). nzbdav doesn't implement that endpoint → silent no-op → the completed nzbdav job + its WebDAV content stay behind and Plex can re-import the stuck item. (The repair-orphan purge only covers `status=Failed` history entries, not the stuck-`Completed` ones StuckPlex targets, so this wasn't covered elsewhere.) Route the `nzb:` delete via `get_usenet_client().remove_nzb(hash, display)` — exists on both clients; Decypharr issues the same delete (plus a name fallback), nzbdav uses its SAB delete.

## §4 — library-maintenance presence safety net (read-only)
`run_plex_library_maintenance` checks a Collected item's on-disk presence only under `Plex.mounted_file_location`. On an nzbdav-only box left at the debrid default mount, a perfectly-present nzbdav file (which lives on the Usenet Provider mount) is judged **missing** → re-grab / `DELETE FROM media_items` / Plex removal of a good item. Add a **read-only** fallback: for `nzb:` items, before declaring missing, also check `Usenet Provider.mounted_file_location`. This can only flip *missing → present* (it sits behind `if not os.path.exists(...)`), so it can never cause a delete/re-grab; debrid/decypharr items skip the branch entirely. (Union-mount setups were already unaffected; this protects the direct-mount case.)

## H — reverse-parser honors filter `source` scoping
`filter_results` applies per-term filter `source` (`both|nzb|debrid`), but the reverse-parser (which assigns the *version* label) ignored it, so a term scoped to the other protocol could mislabel a version. `_calculate_match_score` / `parse_filename_for_version` now take an `is_nzb` flag (default `False`; default term source `both`) and gate `filter_in`/`filter_out` exactly like `filter_results`. A version whose only applicable `filter_in` terms are scoped to the other protocol is no longer wrongly DQ'd. Threaded `is_nzb` at the DB version-reparse sites via the `nzb:` prefix. Default-safe → byte-identical for existing configs. + tests.

## D — settings label clarity (no logic change)
`Scraping.uncached_content_handling` is a debrid-only concept (usenet/NZB results bypass the cache gate). Clarified the description as **debrid-only** and documented that `Hybrid` is a virtual UI value backed by the `hybrid_mode` toggle, with a code comment warning against naively "reconciling" the schema/UI choice mismatch (which would regress legacy configs).

## G2 — backfill task hygiene
`task_backfill_nzb_torrent_ids` is a Decypharr-only migration (`/api/torrents` + `/debrid/` paths). It now skips cleanly when the active usenet provider isn't Decypharr, instead of making failed requests and logging a misleading "Loaded 0 entries".

## Testing
- `pytest tests/test_reverse_parser_source_scope.py` (5) + existing nzbdav/stats suites — all green.
- Dogfooded on a live debrid+nzbdav instance: app starts clean, `parse_filename_for_version(..., is_nzb=True)` works, maintenance/run_program/database_routes import cleanly; debrid path unchanged.
