### PR TITLE
scraper: don't drop NZB season packs when the indexer reports no file count (Prowlarr never sends one)

### DIFF
--- a/scraper/functions/filter_results.py
+++ b/scraper/functions/filter_results.py
@@ -1191,20 +1191,25 @@ def filter_results(
                             result['filter_reason'] = f"Season pack not containing the requested season: {season}"
                             logging.info(f"Rejected: Season pack missing season {season} for '{original_title}' (Size: {result['size']:.2f}GB)")
                             continue
-                    # NZB-specific: reject incomplete season packs using the indexer's file count.
-                    # If the indexer reports fewer files than the expected episode count, the pack
-                    # is missing episodes and must be rejected — no partial packs allowed.
-                    # If nzb_files=0 (indexer didn't report file count) and we know the expected
-                    # episode count, also reject — an unverifiable pack is treated as incomplete.
+                    # NZB-specific: reject incomplete season packs using the indexer's file count
+                    # WHEN that count is actually reported. If the indexer reports fewer files than
+                    # the expected episode count, the pack is missing episodes — reject it.
+                    #
+                    # If nzb_files == 0 the indexer simply didn't report a count (e.g. Prowlarr never
+                    # populates the newznab `files` attr) — that is "unknown", NOT "zero/incomplete".
+                    # Rejecting it here drops 100% of such packs, including complete ones. Instead,
+                    # fall through to the SAME per-episode size heuristic that torrent packs already
+                    # use (total size / expected episodes vs the version's min_size_gb) — backed by
+                    # cli-debrid's per-file episode matching, which re-acquires any genuinely-missing
+                    # episodes via the normal Wanted→Scraping flow. Nothing NZB-specific is invented;
+                    # we just stop treating count-less NZB packs differently from every other result.
                     _nzb_files = result.get('nzb_files', 0)
                     _protocol = result.get('protocol', '')
                     if _protocol == 'nzb' and season and season_episode_counts:
                         _expected_eps = season_episode_counts.get(season, 0)
                         if _expected_eps > 0:
                             if _nzb_files == 0:
-                                result['filter_reason'] = f"Incomplete NZB season pack: indexer reported 0 files but season has {_expected_eps} episodes"
-                                logging.info(f"Rejected: NZB pack with 0 reported files (unverifiable) for '{original_title}' — season has {_expected_eps} episodes (Size: {result['size']:.2f}GB)")
-                                continue
+                                logging.debug(f"NZB pack '{original_title}': indexer reported no file count (unverifiable) — deferring to the size heuristic instead of rejecting")
                             elif _nzb_files < _expected_eps:
                                 result['filter_reason'] = f"Incomplete NZB season pack: {_nzb_files} files but season has {_expected_eps} episodes"
                                 logging.info(f"Rejected: Incomplete NZB pack ({_nzb_files}/{_expected_eps} files) for '{original_title}' (Size: {result['size']:.2f}GB)")


### PR DESCRIPTION
## Problem

The NZB season-pack guard (`scraper/functions/filter_results.py`) rejects a pack when `result['nzb_files'] < expected_episode_count`, **including the `nzb_files == 0` case**:

```
if _nzb_files == 0:
    ... "indexer reported 0 files (unverifiable)" ... continue   # reject
elif _nzb_files < _expected_eps:
    ... continue   # reject
```

But `nzb_files == 0` means the **indexer didn't report a count** — the newznab `files` attribute is optional, and **Prowlarr never populates it** (no `files` read anywhere in `scraper/prowlarr.py`). It does *not* mean the pack has zero files. So this drops **~100% of NZB season packs** on any Prowlarr-fed setup, including complete ones.

### Real-world impact
On a Prowlarr + NzbDAV instance this rejected **~141 packs** across the logs — legitimate full-season releases, e.g.:

```
NZB pack with 0 reported files (unverifiable) for 'The.Audacity.2026.S01.1080p.AMZN.WEB-DL.x265.HEVC.10bit.DDP.5.1-Vyndros' — season has 16 episodes
NZB pack with 0 reported files (unverifiable) for 'The.Audacity.S01.web.10bit.HEVC-d3g' — season has 16 episodes
NZB pack with 0 reported files (unverifiable) for 'Your.Friends.&.Neighbors.2025.S02.2160p.ATVP.WEB-DL.x265.HEVC.10bit.DDP.5.1-Vyndros' — season has 20 episodes
```

These are normal complete packs killed purely because the indexer didn't send a file count.

## Fix

When `nzb_files == 0` (unknown), **don't reject here** — fall through to the **same per-episode size heuristic that torrent packs already use** (`size_gb_for_filter = total_size_gb / num_episodes_in_pack`, compared to the version's `min_size_gb`). Keep the hard reject for `nzb_files > 0 and < expected` — that signal is valid when the indexer actually reports it.

**Nothing NZB-specific is invented** — count-less NZB packs simply stop being treated differently from every other result, and flow through the existing common path.

### Why this is safe (verified against the code)
- **Completeness is still checked**, via signals that *are* available for NZB:
  - **Size heuristic** divides by the **expected/claimed** episode count (from show metadata `season_episode_counts` / the release title), not the indexer's file count — so an incomplete pack's smaller total size yields a low per-episode average and is rejected by `min_size_gb` (same as torrents).
  - **Per-file reacquisition**: cli-debrid matches each pack file to its episode item (`checking_queue.py` *"match each item to its episode file"*, `adding_queue.py` *"related episodes matching parsed files"*); episodes a pack doesn't contain stay `Wanted` and are re-scraped — the standard *arr "download + reacquire missing" model.
- The size path is **not protocol-gated** and `total_size` is populated for NZB results, so usenet uses the exact same logic torrents do.

## Alternative (if strict-by-default is preferred)
Happy to instead gate this behind a new `Scraping` setting like `allow_unverifiable_nzb_packs` (default off), keeping today's strict behaviour by default and making the size-heuristic path opt-in. Let me know which you'd prefer.
