### PR TITLE
Fix S00E00 symlinks for season packs labelled as a single episode

### DIFF
--- a/tests/test_recover_season_episode.py
+++ b/tests/test_recover_season_episode.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Unit tests for season/episode recovery from a release filename.
+
+Mirrors the self-contained style of test_filename_truncation.py: the functions
+under test live in utilities/local_library_scan.py, which pulls heavy project
+imports (database, settings, scraper). To keep the test runnable in isolation we
+copy the two pure helpers here verbatim. They depend only on os, re and PTT
+(parsett, already a project dependency).
+
+Regression target: season packs labelled as a single episode (e.g. FLUX WEB-DLs)
+and manually-assigned items reach get_symlink_path with season/episode == None/0,
+which made the template render 'Season 00 / S00E00'. These helpers recover the
+real SxxExx from the on-disk filename so the symlink lands in the correct folder.
+"""
+
+import unittest
+import sys
+import os
+import re
+from typing import Tuple, Optional, Any
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# --- functions copied verbatim from utilities/local_library_scan.py ---
+
+def _se_is_missing(value: Any) -> bool:
+    """A season/episode number counts as 'missing' if it is None or 0."""
+    if value is None:
+        return True
+    try:
+        return int(value) == 0
+    except (TypeError, ValueError):
+        return False
+
+
+def recover_season_episode_from_filename(filename: str) -> Tuple[Optional[int], Optional[int]]:
+    """Best-effort recovery of (season, episode) from a release filename."""
+    if not filename:
+        return None, None
+    base = os.path.basename(str(filename))
+    season = episode = None
+
+    # Primary: PTT (already a dependency, handles the long tail of naming schemes)
+    try:
+        from PTT import parse_title
+        parsed = parse_title(base)
+        seasons = parsed.get('seasons') or []
+        episodes = parsed.get('episodes') or []
+        if seasons:
+            season = int(seasons[0])
+        if episodes:
+            episode = int(episodes[0])
+    except Exception:
+        pass
+
+    # Backstop: explicit SxxExx / Sxx regex for anything PTT missed
+    if season is None or episode is None:
+        m = re.search(r'(?i)\bS(\d{1,3})(?:E(\d{1,3}))?\b', base)
+        if m:
+            if season is None and m.group(1):
+                season = int(m.group(1))
+            if episode is None and m.group(2):
+                episode = int(m.group(2))
+
+    return season, episode
+
+
+# --- tests ---
+
+class TestSeMissing(unittest.TestCase):
+    def test_missing_values(self):
+        for v in (None, 0, "0", 0.0):
+            self.assertTrue(_se_is_missing(v), f"{v!r} should be missing")
+
+    def test_present_values(self):
+        for v in (1, 5, "5", 12):
+            self.assertFalse(_se_is_missing(v), f"{v!r} should not be missing")
+
+    def test_unparseable_is_not_missing(self):
+        # A non-numeric, non-None value (e.g. multi-ep string 'E17-E18') is left alone.
+        self.assertFalse(_se_is_missing("E17-E18"))
+
+
+class TestRecoverSeasonEpisode(unittest.TestCase):
+    def test_flux_single_episode_label(self):
+        # The exact release from the bug report.
+        fn = ("For.All.Mankind.S05E10.This.Land.Is.Our.Land.2160p."
+              "ATVP.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-FLUX")
+        self.assertEqual(recover_season_episode_from_filename(fn), (5, 10))
+
+    def test_e01(self):
+        fn = "For.All.Mankind.S05E01.2160p.ATVP.WEB-DL.H.265-FLUX"
+        self.assertEqual(recover_season_episode_from_filename(fn), (5, 1))
+
+    def test_standard_sxxexx(self):
+        self.assertEqual(
+            recover_season_episode_from_filename("Severance.S02E07.1080p.WEB.h264-ETHEL"),
+            (2, 7),
+        )
+
+    def test_season_pack_without_episode(self):
+        # Whole-season pack: season recovered, episode stays None (template falls back to 0).
+        self.assertEqual(
+            recover_season_episode_from_filename("The.Bear.S03.1080p.WEB-DL-NTb"),
+            (3, None),
+        )
+
+    def test_alternate_numbering(self):
+        self.assertEqual(
+            recover_season_episode_from_filename("Show.Name.2x05.HDTV.x264"),
+            (2, 5),
+        )
+
+    def test_movie_returns_nothing(self):
+        self.assertEqual(
+            recover_season_episode_from_filename("Some.Movie.2019.1080p.BluRay.x264"),
+            (None, None),
+        )
+
+    def test_full_path_uses_basename(self):
+        fn = "/mnt/x/For All Mankind/Season 05/For.All.Mankind.S05E10-FLUX.mkv"
+        self.assertEqual(recover_season_episode_from_filename(fn), (5, 10))
+
+    def test_empty_and_none(self):
+        self.assertEqual(recover_season_episode_from_filename(""), (None, None))
+        self.assertEqual(recover_season_episode_from_filename(None), (None, None))
+
+    def test_integration_shape(self):
+        # Emulates the get_symlink_path branch: missing S/E get backfilled from filename.
+        s_num_val, e_num_val = 0, None  # what a season-pack/manual-assign item carries
+        fname = ("For.All.Mankind.S05E10.This.Land.Is.Our.Land.2160p."
+                 "ATVP.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-FLUX")
+        if _se_is_missing(s_num_val) or _se_is_missing(e_num_val):
+            rec_s, rec_e = recover_season_episode_from_filename(fname)
+            if _se_is_missing(s_num_val) and rec_s is not None:
+                s_num_val = rec_s
+            if _se_is_missing(e_num_val) and rec_e is not None:
+                e_num_val = rec_e
+        season_number = int(s_num_val if s_num_val is not None else 0)
+        episode_number = int(e_num_val if e_num_val is not None else 0)
+        # Before the fix this rendered Season 00 / S00E00.
+        self.assertEqual((season_number, episode_number), (5, 10))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Dict, Any, Optional, Callable
+from typing import List, Dict, Any, Optional, Callable, Tuple
 import os
 import sys  # Import sys module
 from utilities.settings import get_setting
@@ -497,6 +497,56 @@ def truncate_path_components(
     return sanitized
 
 
+def _se_is_missing(value: Any) -> bool:
+    """A season/episode number counts as 'missing' if it is None or 0."""
+    if value is None:
+        return True
+    try:
+        return int(value) == 0
+    except (TypeError, ValueError):
+        return False
+
+
+def recover_season_episode_from_filename(filename: str) -> Tuple[Optional[int], Optional[int]]:
+    """Best-effort recovery of (season, episode) from a release filename.
+
+    Season-pack releases that are labelled as a single episode (e.g. FLUX WEB-DLs)
+    and manually-assigned items frequently reach get_symlink_path with
+    season_number/episode_number == None/0, which makes the template render
+    'Season 00 / S00E00'. The real SxxExx almost always lives in the on-disk
+    filename, so parse it as a last resort. Returns (None, None) when nothing
+    usable is found. Never raises.
+    """
+    if not filename:
+        return None, None
+    base = os.path.basename(str(filename))
+    season = episode = None
+
+    # Primary: PTT (already a dependency, handles the long tail of naming schemes)
+    try:
+        from PTT import parse_title
+        parsed = parse_title(base)
+        seasons = parsed.get('seasons') or []
+        episodes = parsed.get('episodes') or []
+        if seasons:
+            season = int(seasons[0])
+        if episodes:
+            episode = int(episodes[0])
+    except Exception:
+        pass
+
+    # Backstop: explicit SxxExx / Sxx regex for anything PTT missed
+    if season is None or episode is None:
+        m = re.search(r'(?i)\bS(\d{1,3})(?:E(\d{1,3}))?\b', base)
+        if m:
+            if season is None and m.group(1):
+                season = int(m.group(1))
+            if episode is None and m.group(2):
+                episode = int(m.group(2))
+
+    return season, episode
+
+
 def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup: bool = False) -> str:
     """Get the full path for the symlink based on settings and metadata."""
     import json
@@ -806,7 +856,22 @@ def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup
         else: # episode
             s_num_val = item.get('season_number')
             e_num_val = item.get('episode_number')
-            
+
+            # Fallback: recover S/E from the on-disk filename when the item lacks them.
+            # Season packs labelled as a single episode and manually-assigned items often
+            # arrive with season/episode == None/0, which otherwise yields 'Season 00 / S00E00'.
+            if _se_is_missing(s_num_val) or _se_is_missing(e_num_val):
+                fname = (template_vars.get('original_filename')
+                         or item.get('filename_real_path')
+                         or item.get('filled_by_file') or '')
+                rec_s, rec_e = recover_season_episode_from_filename(fname)
+                if _se_is_missing(s_num_val) and rec_s is not None:
+                    logging.warning(f"[SymlinkPath] season_number missing on item; recovered S{rec_s:02d} from filename '{fname}'")
+                    s_num_val = rec_s
+                if _se_is_missing(e_num_val) and rec_e is not None:
+                    logging.warning(f"[SymlinkPath] episode_number missing on item; recovered E{rec_e:02d} from filename '{fname}'")
+                    e_num_val = rec_e
+
             episode_vars = {
                 'season_number': int(s_num_val if s_num_val is not None else 0),
                 'episode_number': int(e_num_val if e_num_val is not None else 0),


### PR DESCRIPTION
## Problem

Season-pack releases that are mislabelled as a single episode (notably FLUX WEB-DLs where the folder is `E01` but contains the whole season) and **manually assigned** items reach `get_symlink_path()` with `season_number`/`episode_number == None/0`. The episode template then renders `Season 00 / S00E00` and the file ends up in an empty `Season 00` folder.

Reported on Discord (CaptainMoody), with logs:

```
local_library_scan.py:get_symlink_path - [SymlinkPath] Template variables:
{'title': 'For All Mankind', 'year': 2019, ... 'season_number': 0, 'episode_number': 0,
 'episode_title': None,
 'original_filename': 'For.All.Mankind.S05E10.This.Land.Is.Our.Land.2160p.ATVP.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-FLUX'}
[SymlinkPath] Generated path: .../For All Mankind (2019)/Season 00/
  For All Mankind (2019) - S00E00 - None - tt7772588 - 2160p WEB -
  (For.All.Mankind.S05E10...-FLUX).mkv
```

Note the `original_filename` clearly contains `S05E10` — the info is there, the item metadata just doesn't carry it.

## Fix

Add a best-effort fallback in `get_symlink_path()` that recovers season/episode **from the on-disk filename** when the item's values are missing (`None`/`0`):

- Primary parse via `PTT.parse_title` (already a project dependency, used in `scraper/functions/*`).
- Explicit `SxxExx` / `Sxx` regex backstop for anything PTT misses.
- Applies **only** when the value is missing — items with valid metadata are untouched.
- Never raises; emits a `logging.warning` when it recovers a value so it's visible in logs.

This is the single choke-point for both the automatic and the manual-assign paths, so it fixes the empty `Season 00` symlink in both cases. For a true multi-file pack each file is processed with its own filename, so each lands in its correct `SxxExx`.

## Scope / non-goals

This addresses only the **symlink placement** (`S00E00` / empty `Season 00`). The separate complaint that *searching* for a season pack returns nothing (the scraper builds an episode-centric query) is a different code path and intentionally **not** part of this PR.

## Tests

`tests/test_recover_season_episode.py` — self-contained, mirrors the style of `tests/test_filename_truncation.py` (the helpers are copied in to avoid the module's heavy imports; they depend only on `os`, `re`, `PTT`). 12 cases, all green:

```
Ran 12 tests in 0.244s
OK
```

Covers: the exact FLUX release from the report, `S05E01`, standard `S02E07`, season-pack-without-episode (`S03` → `(3, None)`), `2x05` numbering, movies (→ `(None, None)`), full paths (uses basename), empty/None, and an integration-shape test reproducing the `0/None → 5/10` backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)