### PR TITLE
Fix upgrade items looping forever at state='Adding' when no state snapshot exists

### DIFF
--- a/queues/adding_queue.py
+++ b/queues/adding_queue.py
@@ -808,7 +808,10 @@ class AddingQueue:
                     upgrading_queue.add_failed_upgrade(item['id'], failed_info)
                     logging.info(f"Successfully reverted failed upgrade for {item_identifier}")
                 else:
-                    logging.error(f"Failed to restore previous state for {item_identifier} after adding queue failure")
+                    # No snapshot to restore; revert to Collected so the item doesn't loop forever at state='Adding'.
+                    logging.error(f"Failed to restore previous state for {item_identifier} after adding queue failure; reverting to Collected")
+                    if item_id:
+                        update_media_item(item_id, state='Collected', upgrading=False, upgrading_from=None)
 
                 # --- START EDIT: Check if failure was due to filter and remove torrent ---
                 if "matched filter-out list" in error:

--- a/queues/upgrading_queue.py
+++ b/queues/upgrading_queue.py
@@ -1222,8 +1222,9 @@ class UpgradingQueue:
                         # We might need to update the 'upgrading' flag back to False if restore_item_state doesn't
                         update_media_item(item['id'], upgrading=False)
                     else:
-                        logging.error(f"Failed to restore previous state for {item_identifier}, manual intervention may be needed")
-                        # Item might be stuck, consider moving to a failed state?
+                        # No snapshot to restore; revert to Collected instead of leaving it stuck mid-upgrade.
+                        logging.error(f"Failed to restore previous state for {item_identifier}; reverting to Collected")
+                        update_media_item(item['id'], state='Collected', upgrading=False, upgrading_from=None)
 
                     # Log failure to Upgrade Hub activity (after purge/not_wanted so we can include outcomes)
                     if pre_candidate is not None:


### PR DESCRIPTION
### Problem

An upgrade failure calls `UpgradingQueue.restore_item_state()`. When it returns `False` (snapshot stack already consumed), `_handle_failed_item()` only logs, then `remove_item()` + `return`s — the DB row is never changed. The item stays at `state='Adding'` and is reprocessed every cycle in a silent infinite loop (no backoff, never blacklisted, invisible to queue views). Real case: 2,544 identical errors in 25h for one stuck movie. The same latent gap sits at the sibling site in `hourly_scrape()`, already marked with a `# consider moving to a failed state?` TODO.

### Fix

At both sites, when restore fails, revert the item to `Collected` (its actual pre-upgrade state) and clear the upgrade flags. `update_media_item()` also refreshes `last_updated`, so it stops looping and no longer reads as stuck.

### Why this is safe

- Upgrades only run on already-`Collected` items and the original file isn't removed until an upgrade *succeeds*, so `Collected` is the correct restored state.
- `update_media_item()` is already imported and used for `upgrading=False` at both sites; the columns are existing. No new imports.
- Only the failure path changes; successful restores and non-upgrade failures are untouched.

Closes #441
