### PR TITLE
Fix Bazarr spoof series IDs and SignalR WebSocket (DOWN badges)

### DIFF
--- a/routes/bazarr_signalr.py
+++ b/routes/bazarr_signalr.py
@@ -262,12 +262,14 @@ def notify_media_collected(media_item: Dict[str, Any], media_type: str):
             from routes.bazarr_spoofing_routes import (
                 create_episode_file_resource,
                 create_series_resource,
-                generate_unique_id,
-                get_episodes_for_series
+                get_episodes_for_series,
+                normalize_show_id,
             )
-            # Get series info for the full event sequence
-            show_id = media_item.get('tmdb_id') or media_item.get('imdb_id')
-            series_id = generate_unique_id(show_id, 'series')
+            # Get series info for the full event sequence — same show_id
+            # contract as HTTP /api/v3/series (imdb preferred, blank ignored)
+            show_id = normalize_show_id(
+                media_item.get('imdb_id'), media_item.get('tmdb_id')
+            )
 
             # Build series resource for series events
             series_info = {
@@ -282,13 +284,16 @@ def notify_media_collected(media_item: Dict[str, Any], media_type: str):
 
             # Get all episodes for this series to build complete series resource
             try:
-                episodes = get_episodes_for_series(show_id)
+                episodes = get_episodes_for_series(show_id) if show_id else [media_item]
             except Exception:
                 episodes = [media_item]  # Fall back to just this episode
 
             series_resource = create_series_resource(series_info, episodes)
 
-            # Create episode file resource
+            # MUST reuse series_resource['id'] — never re-hash separately.
+            # HTTP create_series_resource uses TMDB as id when present; a
+            # separate generate_unique_id caused Bazarr FK failures.
+            series_id = series_resource['id']
             episode_file_resource = create_episode_file_resource(media_item, series_id)
 
             # Broadcast with full sequence (series events -> episode events)

--- a/routes/bazarr_spoofing_routes.py
+++ b/routes/bazarr_spoofing_routes.py
@@ -134,24 +134,25 @@ def get_collected_series() -> List[Dict[str, Any]]:
     conn.execute('PRAGMA query_only = ON')
     try:
         cursor = conn.cursor()
-        # Get unique shows with their metadata
+        # NULLIF so empty-string imdb_id falls through to tmdb (matches normalize_show_id)
         cursor.execute("""
             SELECT DISTINCT
-                COALESCE(imdb_id, tmdb_id) as show_id,
+                COALESCE(NULLIF(imdb_id, ''), NULLIF(CAST(tmdb_id AS TEXT), '')) as show_id,
                 imdb_id, tmdb_id, title, year, genres, runtime
             FROM media_items
             WHERE state = 'Collected'
             AND type = 'episode'
             AND (file_path IS NOT NULL OR location_on_disk IS NOT NULL)
-            GROUP BY COALESCE(imdb_id, tmdb_id), title
+            GROUP BY COALESCE(NULLIF(imdb_id, ''), NULLIF(CAST(tmdb_id AS TEXT), '')), title
         """)
 
         series_list = []
         for row in cursor.fetchall():
+            imdb_id, tmdb_id = row[1], row[2]
             series_list.append({
-                'show_id': row[0],
-                'imdb_id': row[1],
-                'tmdb_id': row[2],
+                'show_id': normalize_show_id(imdb_id, tmdb_id) or row[0],
+                'imdb_id': imdb_id,
+                'tmdb_id': tmdb_id,
                 'title': row[3],
                 'year': row[4],
                 'genres': row[5],
@@ -244,8 +245,30 @@ def get_all_collected_episodes() -> List[Dict[str, Any]]:
         conn.close()
 
 
+def _movie_row_to_dict(row) -> Dict[str, Any]:
+    return {
+        'id': row[0],
+        'imdb_id': row[1],
+        'tmdb_id': row[2],
+        'title': row[3],
+        'year': row[4],
+        'file_path': row[5],
+        'location_on_disk': row[6],
+        'genres': row[7],
+        'runtime': row[8],
+        'collected_at': row[9],
+        'version': row[10],
+        'filled_by_file': row[11],
+        'resolution': row[12]
+    }
+
+
 def get_movie_by_id(movie_id: int) -> Optional[Dict[str, Any]]:
-    """Get a specific movie by its ID."""
+    """Get a specific movie by its Radarr id (TMDB, else hashed media id).
+
+    Prefer tmdb_id match — never match media_items.id first, which collides
+    with TMDB ids and returns the wrong title.
+    """
     conn = get_db_connection()
     try:
         cursor = conn.cursor()
@@ -254,64 +277,76 @@ def get_movie_by_id(movie_id: int) -> Optional[Dict[str, Any]]:
                    location_on_disk, genres, runtime, collected_at, version,
                    filled_by_file, resolution
             FROM media_items
-            WHERE (id = ? OR tmdb_id = ? OR tmdb_id = ?)
-            AND state = 'Collected'
+            WHERE state = 'Collected'
             AND type = 'movie'
+            AND (tmdb_id = ? OR tmdb_id = ?)
             LIMIT 1
-        """, (movie_id, str(movie_id), movie_id))
+        """, (str(movie_id), movie_id))
 
         row = cursor.fetchone()
         if row:
-            return {
-                'id': row[0],
-                'imdb_id': row[1],
-                'tmdb_id': row[2],
-                'title': row[3],
-                'year': row[4],
-                'file_path': row[5],
-                'location_on_disk': row[6],
-                'genres': row[7],
-                'runtime': row[8],
-                'collected_at': row[9],
-                'version': row[10],
-                'filled_by_file': row[11],
-                'resolution': row[12]
-            }
-        return None
+            return _movie_row_to_dict(row)
     finally:
         conn.close()
 
+    # Fallback: hashed movie ids when TMDB is missing
+    for movie in get_collected_movies():
+        try:
+            tmdb_id = int(movie.get('tmdb_id') or 0)
+        except (ValueError, TypeError):
+            tmdb_id = 0
+        resolved = tmdb_id or generate_unique_id(movie.get('id'), 'movie')
+        if resolved == movie_id:
+            return movie
+    return None
+
 
 def get_series_by_id(series_id: int) -> Optional[Dict[str, Any]]:
-    """Get a specific series by its ID."""
+    """Resolve a Sonarr series id to show metadata.
+
+    Prefer tmdb_id match (not media_items.id — PK collisions with TMDB break
+    Bazarr FK inserts). Fall back to scanning collected shows for hashed
+    sonarr_series_id matches when TMDB is absent.
+    """
     conn = get_db_connection()
     try:
         cursor = conn.cursor()
         cursor.execute("""
             SELECT DISTINCT
-                COALESCE(imdb_id, tmdb_id) as show_id,
+                COALESCE(NULLIF(imdb_id, ''), NULLIF(CAST(tmdb_id AS TEXT), '')) as show_id,
                 imdb_id, tmdb_id, title, year, genres, runtime
             FROM media_items
-            WHERE (id = ? OR tmdb_id = ? OR tmdb_id = ? OR imdb_id = ?)
-            AND state = 'Collected'
+            WHERE state = 'Collected'
             AND type = 'episode'
+            AND (tmdb_id = ? OR tmdb_id = ?)
+            AND (file_path IS NOT NULL OR location_on_disk IS NOT NULL)
             LIMIT 1
-        """, (series_id, str(series_id), series_id, str(series_id)))
+        """, (str(series_id), series_id))
 
         row = cursor.fetchone()
         if row:
+            imdb_id, tmdb_id = row[1], row[2]
             return {
-                'show_id': row[0],
-                'imdb_id': row[1],
-                'tmdb_id': row[2],
+                'show_id': normalize_show_id(imdb_id, tmdb_id) or row[0],
+                'imdb_id': imdb_id,
+                'tmdb_id': tmdb_id,
                 'title': row[3],
                 'year': row[4],
                 'genres': row[5],
                 'runtime': row[6]
             }
-        return None
     finally:
         conn.close()
+
+    for series in get_collected_series():
+        if sonarr_series_id(series) == series_id:
+            result = dict(series)
+            result['show_id'] = (
+                normalize_show_id(result.get('imdb_id'), result.get('tmdb_id'))
+                or result.get('show_id')
+            )
+            return result
+    return None
 
 
 # ============================================================================
@@ -382,6 +417,36 @@ def generate_unique_id(base_id: Any, prefix: str = '') -> int:
     # Always use hash to ensure prefix is incorporated
     hash_input = f"{prefix}{base_id}".encode()
     return int(hashlib.md5(hash_input).hexdigest()[:8], 16)
+
+
+def normalize_show_id(imdb_id: Any = None, tmdb_id: Any = None) -> str:
+    """Normalize show identity for grouping and lookups.
+
+    Blank/whitespace strings are treated as missing. Prefer IMDB, then TMDB —
+    matching SQL COALESCE(NULLIF(imdb_id, ''), NULLIF(tmdb_id, '')).
+    """
+    def _clean(value: Any) -> str:
+        if value is None:
+            return ''
+        text = str(value).strip()
+        return text if text else ''
+
+    return _clean(imdb_id) or _clean(tmdb_id)
+
+
+def sonarr_series_id(item: Dict[str, Any]) -> int:
+    """Stable Sonarr series id used by every HTTP and SignalR path.
+
+    Use integer TMDB when present; otherwise a deterministic hash of show_id.
+    """
+    try:
+        tmdb_id = int(item.get('tmdb_id') or 0)
+    except (ValueError, TypeError):
+        tmdb_id = 0
+    if tmdb_id:
+        return tmdb_id
+    show_id = item.get('show_id') or normalize_show_id(item.get('imdb_id'), item.get('tmdb_id'))
+    return generate_unique_id(show_id, 'series')
 
 
 def generate_tvdb_id(tmdb_id: Any, title: str, episode_info: Optional[Dict[str, Any]] = None) -> int:
@@ -639,7 +704,7 @@ def create_series_resource(item: Dict[str, Any], episodes: List[Dict[str, Any]] 
         tmdb_id = int(item.get('tmdb_id') or 0)
     except (ValueError, TypeError):
         tmdb_id = 0
-    series_id = tmdb_id or generate_unique_id(item.get('show_id'), 'series')
+    series_id = sonarr_series_id(item)
     title = item.get('title', 'Unknown')
 
     # Generate consistent tvdbId for Bazarr compatibility
@@ -1130,16 +1195,17 @@ def get_series():
 
     try:
         series_list = get_collected_series()
-        # Load all episodes in one query and group by show_id
+        # Load all episodes in one query and group by normalized show_id
         all_episodes = get_all_collected_episodes()
         ep_map = {}
         for ep in all_episodes:
-            key = ep.get('imdb_id') or ep.get('tmdb_id') or ''
-            ep_map.setdefault(key, []).append(ep)
+            key = normalize_show_id(ep.get('imdb_id'), ep.get('tmdb_id'))
+            if key:
+                ep_map.setdefault(key, []).append(ep)
 
         result = []
         for s in series_list:
-            show_id = s.get('show_id', '')
+            show_id = normalize_show_id(s.get('imdb_id'), s.get('tmdb_id')) or s.get('show_id', '')
             episodes = ep_map.get(show_id, [])
             result.append(create_series_resource(s, episodes))
         return jsonify(result)
@@ -1402,6 +1468,9 @@ def signalr_negotiate():
 
     connection_id = f"cli_debrid-{int(time.time() * 1000)}"
 
+    # Bazarr's bundled signalrcore only implements WebSocket transport (it
+    # ignores availableTransports and always opens ws://). Advertise WebSockets
+    # and require the WS-capable Werkzeug handler in run_server().
     return jsonify({
         'connectionId': connection_id,
         'connectionToken': connection_id,
@@ -1414,10 +1483,6 @@ def signalr_negotiate():
             {
                 'transport': 'ServerSentEvents',
                 'transferFormats': ['Text']
-            },
-            {
-                'transport': 'LongPolling',
-                'transferFormats': ['Text', 'Binary']
             }
         ]
     })
@@ -1426,44 +1491,63 @@ def signalr_negotiate():
 @bazarr_bp.route('/signalr/messages', methods=['GET'])
 @bazarr_bp.route('/signalr', methods=['GET'])
 def signalr_messages():
-    """Handle SignalR message stream (WebSocket or Server-Sent Events fallback)."""
+    """Handle SignalR message stream (WebSocket preferred; SSE fallback)."""
     if not is_symlinked_mode() or not get_setting('Bazarr Integration', 'enabled', False):
         return jsonify({'error': 'Not found'}), 404
 
-    # Check if this is a WebSocket upgrade request
+    # Prefer the Werkzeug request-handler path for WebSockets (avoids Flask
+    # middleware blocking the 101). Keep this branch for non-standard servers.
     if request.headers.get('Upgrade', '').lower() == 'websocket':
-        return handle_signalr_websocket()
+        run_signalr_websocket_session(request.environ)
+        return ''
 
-    # Fall back to Server-Sent Events
     return handle_signalr_sse()
 
 
-def handle_signalr_websocket():
-    """Handle SignalR WebSocket connection (matches CineSync implementation)."""
+def run_signalr_websocket_session(environ) -> None:
+    """Run a SignalR JSON-protocol WebSocket session on an upgraded socket.
+
+    ``environ`` must include ``werkzeug.socket`` (injected by
+    ``WebSocketAwareHandler``) so simple_websocket can complete the handshake.
+    """
     try:
         from simple_websocket import Server, ConnectionClosed
     except ImportError:
-        # simple-websocket not available, fall back to SSE
-        logging.debug("[SignalR] WebSocket requested but simple-websocket not installed, using SSE")
-        return handle_signalr_sse()
+        logging.error("[SignalR] simple-websocket not installed")
+        return
+
+    from urllib.parse import parse_qs
+    qs = parse_qs(environ.get('QUERY_STRING') or '')
+    connection_id = (
+        (qs.get('id') or qs.get('connectionToken') or [None])[0]
+        or f"ws-{int(time.time() * 1000)}"
+    )
+
+    if not is_symlinked_mode() or not get_setting('Bazarr Integration', 'enabled', False):
+        logging.warning("[SignalR] WebSocket rejected: Bazarr integration disabled")
+        return
 
     try:
-        ws = Server.accept(request.environ)
+        ws = Server.accept(environ)
     except Exception as e:
         logging.error(f"[SignalR] WebSocket accept failed: {e}")
-        return handle_signalr_sse()
+        return
 
-    connection_id = f"ws-{int(time.time() * 1000)}"
-
-    # Register this connection for event broadcasting
     from routes.bazarr_signalr import register_connection, unregister_connection, get_pending_events
-    event_queue = register_connection(connection_id)
+    register_connection(connection_id)
 
     try:
-        # Send handshake response (matches CineSync: {"error":null}\x1e)
+        # Wait for client handshake: {"protocol":"json","version":1}\x1e
+        try:
+            first = ws.receive(timeout=10)
+            if first:
+                logging.debug(f"[SignalR] client handshake: {str(first)[:80]!r}")
+        except Exception:
+            pass
+
+        # Handshake response required by SignalR JSON protocol
         ws.send(json.dumps({"error": None}) + '\x1e')
 
-        # Send version message
         version = get_setting('Bazarr Integration', 'spoofed_version', '5.14.0.9383')
         version_msg = {
             'type': 1,
@@ -1476,26 +1560,23 @@ def handle_signalr_websocket():
 
         last_ping = time.time()
         while True:
-            # Check for incoming messages (non-blocking with short timeout)
             try:
                 data = ws.receive(timeout=0.1)
-                if data:
-                    # Handle ping/pong from client
-                    try:
-                        msg = json.loads(data.rstrip('\x1e'))
-                        if msg.get('type') == 6:  # Ping
-                            ws.send(json.dumps({'type': 6}) + '\x1e')
-                    except (json.JSONDecodeError, AttributeError):
-                        pass
             except Exception:
-                pass
+                data = None
 
-            # Check for events to broadcast
+            if data:
+                try:
+                    msg = json.loads(str(data).rstrip('\x1e'))
+                    if msg.get('type') == 6:  # Ping
+                        ws.send(json.dumps({'type': 6}) + '\x1e')
+                except (json.JSONDecodeError, AttributeError, TypeError):
+                    pass
+
             events = get_pending_events(connection_id, timeout=0.1)
             for event in events:
                 ws.send(json.dumps(event) + '\x1e')
 
-            # Send periodic ping (every 10 seconds like CineSync)
             if time.time() - last_ping > 10:
                 ws.send(json.dumps({'type': 6}) + '\x1e')
                 last_ping = time.time()
@@ -1507,24 +1588,23 @@ def handle_signalr_websocket():
     finally:
         unregister_connection(connection_id)
 
-    return ''
-
 
 def handle_signalr_sse():
     """Handle SignalR Server-Sent Events connection."""
-    connection_id = f"sse-{int(time.time() * 1000)}"
+    connection_id = (
+        request.args.get('id')
+        or request.args.get('connectionToken')
+        or f"sse-{int(time.time() * 1000)}"
+    )
 
-    # Register this connection for event broadcasting
     from routes.bazarr_signalr import register_connection, unregister_connection, get_pending_events
 
     def generate():
-        event_queue = register_connection(connection_id)
+        register_connection(connection_id)
 
         try:
-            # Send handshake response
             yield f'data: {json.dumps({"error": None})}\x1e\n\n'
 
-            # Send version message
             version = get_setting('Bazarr Integration', 'spoofed_version', '5.14.0.9383')
             version_msg = {
                 'type': 1,
@@ -1537,12 +1617,10 @@ def handle_signalr_sse():
 
             last_ping = time.time()
             while True:
-                # Check for events to broadcast
                 events = get_pending_events(connection_id, timeout=1.0)
                 for event in events:
                     yield f'data: {json.dumps(event)}\x1e\n\n'
 
-                # Send periodic ping (every 15 seconds)
                 if time.time() - last_ping > 15:
                     yield f'data: {json.dumps({"type": 6})}\x1e\n\n'
                     last_ping = time.time()
@@ -1558,6 +1636,7 @@ def handle_signalr_sse():
         headers={
             'Cache-Control': 'no-cache',
             'Connection': 'keep-alive',
+            'X-Accel-Buffering': 'no',
             'Access-Control-Allow-Origin': '*'
         }
     )

--- a/routes/program_operation_routes.py
+++ b/routes/program_operation_routes.py
@@ -191,11 +191,52 @@ def signal_handler(signum, frame):
 
 def run_server():
     from routes.extensions import app
-    
+    from werkzeug.serving import make_server, WSGIRequestHandler
+
     # Get port from environment variable or use default
     port = int(os.environ.get('CLI_DEBRID_PORT', 5000))
+
+    class WebSocketAwareHandler(WSGIRequestHandler):
+        """Threaded Werkzeug handler that supports SignalR WebSocket upgrades.
+
+        SignalR WebSocket sessions are handled here directly (not via Flask) so
+        app before_request / session middleware cannot block the 101 handshake.
+        """
+
+        protocol_version = "HTTP/1.1"
+
+        def make_environ(self):
+            environ = super().make_environ()
+            environ['werkzeug.socket'] = self.connection
+            return environ
+
+        def run_wsgi(self):
+            upgrade = (self.headers.get('Upgrade') or '').lower().strip()
+            path = (self.path or '').split('?', 1)[0]
+            if upgrade == 'websocket' and path in ('/signalr/messages', '/signalr'):
+                self.environ = environ = self.make_environ()
+                try:
+                    from routes.bazarr_spoofing_routes import run_signalr_websocket_session
+                    run_signalr_websocket_session(environ)
+                except (BrokenPipeError, ConnectionError, ConnectionResetError):
+                    pass
+                except Exception as e:
+                    logging.error(f"[SignalR] WebSocket handler error: {e}", exc_info=True)
+                return
+            return super().run_wsgi()
+
     try:
-        app.run(debug=True, use_reloader=False, host='0.0.0.0', port=port, threaded=True)
+        # Use make_server (not app.run) so we control the request handler and
+        # avoid the Flask debugger wrapper interfering with Upgrade requests.
+        logging.info(f"Starting Werkzeug threaded server with WebSocket support on 0.0.0.0:{port}")
+        server = make_server(
+            '0.0.0.0',
+            port,
+            app,
+            threaded=True,
+            request_handler=WebSocketAwareHandler,
+        )
+        server.serve_forever()
     except Exception as e:
         logging.error(f"Error running server: {str(e)}")
         cleanup_port(port)

--- a/tests/test_bazarr_series_id_contract.py
+++ b/tests/test_bazarr_series_id_contract.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Contract tests for Bazarr Sonarr series-id consistency.
+
+Loads production helpers from routes/bazarr_spoofing_routes.py without
+importing routes/__init__.py (avoids full Flask app bootstrap).
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+import unittest.mock
+from unittest.mock import MagicMock
+
+
+def _load_spoofing_module():
+    """Import bazarr_spoofing_routes.py directly with light dependency stubs."""
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+    # Stub heavy deps before loading the module file
+    flask_stub = MagicMock()
+    flask_stub.Blueprint = MagicMock(return_value=MagicMock())
+    flask_stub.jsonify = MagicMock()
+    flask_stub.request = MagicMock()
+    flask_stub.Response = MagicMock()
+    sys.modules['flask'] = flask_stub
+
+    if 'utilities.settings' not in sys.modules:
+        settings_mod = types.ModuleType('utilities.settings')
+        settings_mod.get_setting = MagicMock(return_value='')
+        settings_mod.set_setting = MagicMock()
+        settings_mod.load_config = MagicMock(return_value={})
+        sys.modules['utilities.settings'] = settings_mod
+        # Ensure parent package exists
+        if 'utilities' not in sys.modules:
+            utilities_pkg = types.ModuleType('utilities')
+            utilities_pkg.__path__ = [os.path.join(root, 'utilities')]
+            sys.modules['utilities'] = utilities_pkg
+
+    if 'utilities.release_parser' not in sys.modules:
+        rp = types.ModuleType('utilities.release_parser')
+
+        class _ReleaseParser:
+            @staticmethod
+            def parse_with_guessit(_s):
+                return {}
+
+            @staticmethod
+            def parse_with_regex(_s):
+                return {}
+
+            @staticmethod
+            def extract_release_group(_s):
+                return ''
+
+        rp.ReleaseParser = _ReleaseParser
+        sys.modules['utilities.release_parser'] = rp
+
+    if 'database.core' not in sys.modules:
+        if 'database' not in sys.modules:
+            db_pkg = types.ModuleType('database')
+            db_pkg.__path__ = [os.path.join(root, 'database')]
+            sys.modules['database'] = db_pkg
+        db_core = types.ModuleType('database.core')
+        db_core.get_db_connection = MagicMock()
+        sys.modules['database.core'] = db_core
+
+    module_path = os.path.join(root, 'routes', 'bazarr_spoofing_routes.py')
+    spec = importlib.util.spec_from_file_location(
+        'bazarr_spoofing_routes_under_test', module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+spoof = _load_spoofing_module()
+
+
+class TestNormalizeShowId(unittest.TestCase):
+    def test_prefers_imdb_over_tmdb(self):
+        self.assertEqual(
+            spoof.normalize_show_id('tt0066626', '1922'),
+            'tt0066626',
+        )
+
+    def test_empty_imdb_falls_through_to_tmdb(self):
+        self.assertEqual(spoof.normalize_show_id('', '1922'), '1922')
+        self.assertEqual(spoof.normalize_show_id('   ', 1922), '1922')
+        self.assertEqual(spoof.normalize_show_id(None, '1922'), '1922')
+
+    def test_both_missing(self):
+        self.assertEqual(spoof.normalize_show_id('', ''), '')
+        self.assertEqual(spoof.normalize_show_id(None, None), '')
+
+
+class TestSonarrSeriesId(unittest.TestCase):
+    def test_uses_tmdb_when_present(self):
+        item = {
+            'show_id': 'tt0066626',
+            'imdb_id': 'tt0066626',
+            'tmdb_id': '1922',
+            'title': 'All in the Family',
+        }
+        self.assertEqual(spoof.sonarr_series_id(item), 1922)
+
+    def test_hashes_when_no_tmdb(self):
+        item = {
+            'show_id': 'tt1234567',
+            'imdb_id': 'tt1234567',
+            'tmdb_id': None,
+            'title': 'No Tmdb Show',
+        }
+        expected = spoof.generate_unique_id('tt1234567', 'series')
+        self.assertEqual(spoof.sonarr_series_id(item), expected)
+        self.assertNotEqual(expected, 0)
+
+    def test_create_series_resource_matches_sonarr_series_id(self):
+        item = {
+            'show_id': 'tt0066626',
+            'imdb_id': 'tt0066626',
+            'tmdb_id': 1922,
+            'title': 'All in the Family',
+            'year': 1971,
+        }
+        resource = spoof.create_series_resource(item, [])
+        self.assertEqual(resource['id'], spoof.sonarr_series_id(item))
+        self.assertEqual(resource['id'], 1922)
+
+
+class TestEpisodeFileIdContract(unittest.TestCase):
+    def test_episode_file_id_differs_from_episode_id(self):
+        item = {
+            'id': 42,
+            'imdb_id': 'tt0066626',
+            'tmdb_id': '1922',
+            'title': 'All in the Family',
+            'episode_title': 'Pilot',
+            'season_number': 1,
+            'episode_number': 1,
+            'file_path': '/tv/All in the Family/Season 01/S01E01.mkv',
+            'collected_at': '2024-01-15T10:30:00Z',
+            'version': '1080p',
+        }
+        result = spoof.create_episode_resource(item, series_id=1922, series_title='All in the Family')
+        self.assertNotEqual(result['id'], result['episodeFileId'])
+        self.assertIn('episodeFile', result)
+        self.assertEqual(result['episodeFile']['id'], result['episodeFileId'])
+        self.assertEqual(result['episodeFile']['seriesId'], 1922)
+        self.assertTrue(result['hasFile'])
+
+
+class TestSignalRSeriesIdMatch(unittest.TestCase):
+    """SignalR must reuse create_series_resource id for episodeFile.seriesId."""
+
+    def test_series_and_episode_file_share_same_series_id_with_tmdb(self):
+        media_item = {
+            'id': 100,
+            'imdb_id': 'tt0066626',
+            'tmdb_id': '1922',
+            'title': 'All in the Family',
+            'year': 1971,
+            'season_number': 1,
+            'episode_number': 1,
+            'file_path': '/tv/All in the Family/Season 01/S01E01.mkv',
+            'collected_at': '2024-01-15T10:30:00Z',
+            'version': '1080p',
+        }
+        show_id = spoof.normalize_show_id(media_item.get('imdb_id'), media_item.get('tmdb_id'))
+        series_info = {
+            'show_id': show_id,
+            'imdb_id': media_item.get('imdb_id'),
+            'tmdb_id': media_item.get('tmdb_id'),
+            'title': media_item.get('title'),
+            'year': media_item.get('year'),
+        }
+        series_resource = spoof.create_series_resource(series_info, [media_item])
+        series_id = series_resource['id']
+        episode_file = spoof.create_episode_file_resource(media_item, series_id)
+
+        self.assertEqual(series_id, 1922)
+        self.assertEqual(episode_file['seriesId'], series_id)
+        # Old bug: hashed series id would not equal TMDB
+        hashed = spoof.generate_unique_id(show_id, 'series')
+        self.assertNotEqual(series_id, hashed)
+
+    def test_series_and_episode_file_share_same_series_id_without_tmdb(self):
+        media_item = {
+            'id': 101,
+            'imdb_id': 'tt1111111',
+            'tmdb_id': None,
+            'title': 'Hash Only Show',
+            'year': 2020,
+            'season_number': 1,
+            'episode_number': 1,
+            'file_path': '/tv/Hash Only Show/Season 01/S01E01.mkv',
+            'collected_at': '2024-01-15T10:30:00Z',
+        }
+        show_id = spoof.normalize_show_id(media_item.get('imdb_id'), media_item.get('tmdb_id'))
+        series_info = {
+            'show_id': show_id,
+            'imdb_id': media_item.get('imdb_id'),
+            'tmdb_id': media_item.get('tmdb_id'),
+            'title': media_item.get('title'),
+            'year': media_item.get('year'),
+        }
+        series_resource = spoof.create_series_resource(series_info, [media_item])
+        series_id = series_resource['id']
+        episode_file = spoof.create_episode_file_resource(media_item, series_id)
+
+        self.assertEqual(series_id, spoof.generate_unique_id(show_id, 'series'))
+        self.assertEqual(episode_file['seriesId'], series_id)
+
+
+class TestEmptyImdbEpisodeGrouping(unittest.TestCase):
+    def test_normalize_keys_align_for_empty_imdb(self):
+        """Series list and episode map must use the same key when imdb is ''."""
+        series_row = {
+            'imdb_id': '',
+            'tmdb_id': '1922',
+            'title': 'All in the Family',
+        }
+        episode_row = {
+            'imdb_id': '',
+            'tmdb_id': '1922',
+            'title': 'All in the Family',
+            'season_number': 1,
+            'episode_number': 1,
+        }
+        series_key = spoof.normalize_show_id(
+            series_row.get('imdb_id'), series_row.get('tmdb_id')
+        )
+        ep_key = spoof.normalize_show_id(
+            episode_row.get('imdb_id'), episode_row.get('tmdb_id')
+        )
+        self.assertEqual(series_key, ep_key)
+        self.assertEqual(series_key, '1922')
+
+        # Simulate ep_map lookup used by GET /api/v3/series
+        ep_map = {}
+        ep_map.setdefault(ep_key, []).append(episode_row)
+        self.assertEqual(len(ep_map.get(series_key, [])), 1)
+
+
+class TestGetSeriesByIdLookup(unittest.TestCase):
+    def test_hashed_id_resolved_via_collected_series_fallback(self):
+        series = {
+            'show_id': 'tt9990001',
+            'imdb_id': 'tt9990001',
+            'tmdb_id': None,
+            'title': 'Hash Show',
+            'year': 2021,
+            'genres': None,
+            'runtime': 40,
+        }
+        hashed_id = spoof.sonarr_series_id(series)
+
+        with unittest.mock.patch.object(
+            spoof, 'get_collected_series', return_value=[series]
+        ):
+            # Mock DB tmdb lookup to miss
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.fetchone.return_value = None
+            mock_conn.cursor.return_value = mock_cursor
+            mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+            mock_conn.__exit__ = MagicMock(return_value=False)
+
+            with unittest.mock.patch.object(
+                spoof, 'get_db_connection', return_value=mock_conn
+            ):
+                found = spoof.get_series_by_id(hashed_id)
+
+        self.assertIsNotNone(found)
+        self.assertEqual(found['imdb_id'], 'tt9990001')
+        self.assertEqual(found['show_id'], 'tt9990001')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Align Sonarr series IDs across HTTP spoof endpoints and SignalR events so Bazarr can sync/insert series and episode files consistently (TMDB-preferred IDs, empty IMDB handling, SignalR using `series_resource['id']`).
- Fix Series/Movies **DOWN** badges by completing Bazarr’s websocket-only SignalR handshake: Werkzeug `WebSocketAwareHandler` injects `werkzeug.socket`, handles `/signalr` upgrades outside Flask middleware, and runs the JSON hub session via `simple-websocket`.

## Runtime notes
- Requires `simple-websocket` (already in `requirements.txt`).
- The web server **must** use the new `make_server(..., request_handler=WebSocketAwareHandler)` path in `run_server()`. Stock `app.run(...)` alone will not clear DOWN badges, because Bazarr’s bundled signalrcore always opens WebSockets and ignores SSE-only negotiate responses.
- Verified locally: Bazarr logs `SignalR client for Sonarr/Radarr is connected and waiting for events` after deploy; HTTP sync already worked (shows/movies present).


## Test plan
- [ ] Enable Bazarr Integration in Symlinked/Local (or Plex) mode and point Bazarr Sonarr/Radarr at cli_debrid
- [ ] Confirm negotiate returns WebSockets in `availableTransports`
- [ ] Confirm Bazarr log shows SignalR connected for Sonarr and Radarr (DOWN badges clear)
- [ ] Confirm series/movie HTTP sync still works and series IDs stay consistent between `/api/v3/series` and SignalR episode-file events
- [ ] Optional: trigger a media event and confirm Bazarr receives SignalR `receiveMessage` traffic


Made with [Cursor](https://cursor.com)