### PR TITLE
Remove character length validation for Trakt keys

### DIFF
--- a/routes/settings_validation_routes.py
+++ b/routes/settings_validation_routes.py
@@ -147,12 +147,6 @@ def validate_trakt_credentials(client_id, client_secret):
     if not client_id or not client_secret:
         return False, "Both Client ID and Client Secret are required"
     
-    # Validate format
-    if len(client_id) != 64:
-        return False, "Invalid Trakt Client ID format (must be 64 characters)"
-    if len(client_secret) != 64:
-        return False, "Invalid Trakt Client Secret format (must be 64 characters)"
-    
     try:
         # Try to get a device code - this validates both client ID and secret
         device_code_response = get_device_code(client_id, client_secret)


### PR DESCRIPTION
Trakt now issues 43-char keys which will fail the validation. Given that trakt is a required service, this makes it a blocker for anyone issued the new keys