### PR TITLE
Bump patchright to 1.61.2 to fix Docker build on Debian trixie

### DIFF
--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -50,5 +50,5 @@ Markdown==3.8
 Flask-Compress==1.15
 simple-websocket>=1.0.0
 psycopg2-binary
-patchright==1.52.5
+patchright==1.61.2
 pyvirtualdisplay==3.0


### PR DESCRIPTION
Bump patchright to 1.61.2 to fix Docker build on Debian trixie

patchright 1.52.5's --with-deps apt list references ttf-unifont and ttf-ubuntu-font-family, both removed from the trixie archive, so image builds fail at the browser-install step. Newer Playwright dep lists use the current fonts-*/t64 names.