### PR TITLE
fixes and improvements

### DIFF
--- a/content_checkers/overseerr.py
+++ b/content_checkers/overseerr.py
@@ -9,10 +9,83 @@ from datetime import datetime, timedelta
 DEFAULT_TAKE = 100
 REQUEST_TIMEOUT = 15  # seconds
 
+
+class OverseerrAuthError(Exception):
+    """Raised when Overseerr rejects the configured API key (401/403)."""
+    pass
+
 # Get db_content directory from environment variable with fallback
 DB_CONTENT_DIR = os.environ.get('USER_DB_CONTENT', '/user/db_content')
 OVERSEERR_CACHE_FILE = os.path.join(DB_CONTENT_DIR, 'overseerr_cache.pkl')
 CACHE_EXPIRY_DAYS = 7
+OVERSEERR_AUTH_STATE_FILE = os.path.join(DB_CONTENT_DIR, 'overseerr_auth_state.pkl')
+
+
+def _load_overseerr_auth_state() -> Dict[str, bool]:
+    """Per-source_id -> True if currently in a notified auth-failure state. Persisted
+    to disk so a program restart (e.g. after a settings save) doesn't cause a
+    duplicate notification for a failure the user already saw."""
+    try:
+        if os.path.exists(OVERSEERR_AUTH_STATE_FILE):
+            with open(OVERSEERR_AUTH_STATE_FILE, 'rb') as f:
+                return pickle.load(f)
+    except Exception as e:
+        logging.debug(f"Error loading Overseerr auth state: {e}. Starting fresh.")
+    return {}
+
+
+def _save_overseerr_auth_state(state: Dict[str, bool]):
+    try:
+        os.makedirs(os.path.dirname(OVERSEERR_AUTH_STATE_FILE), exist_ok=True)
+        with open(OVERSEERR_AUTH_STATE_FILE, 'wb') as f:
+            pickle.dump(state, f)
+    except Exception as e:
+        logging.debug(f"Error saving Overseerr auth state: {e}")
+
+
+def _notify_overseerr_auth_failure(source_id: str, display_name: str):
+    """Fire a notification only on the transition into an auth-failure state, so a
+    ~15-minute polling cycle doesn't spam a notification every run while the key
+    stays broken."""
+    state = _load_overseerr_auth_state()
+    if state.get(source_id):
+        return  # Already notified for this ongoing failure
+    state[source_id] = True
+    _save_overseerr_auth_state(state)
+    try:
+        from routes.notifications import store_notification
+        store_notification(
+            title="Overseerr Connection Failed",
+            message=(
+                f"'{display_name}' rejected the configured API key (401/403). "
+                f"Wanted content from this source will not be fetched until the API key is corrected in Settings."
+            ),
+            notification_type='error',
+            link="/settings"
+        )
+    except Exception as e:
+        logging.warning(f"Could not store Overseerr auth-failure notification: {e}")
+
+
+def _clear_overseerr_auth_failure(source_id: str, display_name: str):
+    """Called on a successful fetch — clears the notified state and, if we were
+    previously in a failure state, lets the user know it recovered."""
+    state = _load_overseerr_auth_state()
+    if not state.get(source_id):
+        return
+    del state[source_id]
+    _save_overseerr_auth_state(state)
+    try:
+        from routes.notifications import store_notification
+        store_notification(
+            title="Overseerr Connection Restored",
+            message=f"'{display_name}' is authenticating successfully again.",
+            notification_type='info',
+            link="/settings"
+        )
+    except Exception as e:
+        logging.warning(f"Could not store Overseerr auth-recovery notification: {e}")
+
 
 def parse_bool(value: Any) -> bool:
     """Safely parse various truthy/falsey representations into a boolean."""
@@ -173,6 +246,10 @@ def fetch_overseerr_wanted_content(overseerr_url: str, overseerr_api_key: str, t
                 break
 
         except api.exceptions.RequestException as e:
+            status_code = getattr(getattr(e, 'response', None), 'status_code', None)
+            if status_code in (401, 403):
+                logging.error(f"Error fetching wanted content from Overseerr: {e}")
+                raise OverseerrAuthError(f"Overseerr rejected the API key (HTTP {status_code})") from e
             logging.error(f"Error fetching wanted content from Overseerr: {e}")
             break
         except Exception as e:
@@ -184,27 +261,29 @@ def fetch_overseerr_wanted_content(overseerr_url: str, overseerr_api_key: str, t
 
 def get_wanted_from_overseerr(versions: Dict[str, bool]) -> List[Tuple[List[Dict[str, Any]], Dict[str, bool]]]:
     content_sources = get_all_settings().get('Content Sources', {})
-    overseerr_sources = [data for source, data in content_sources.items() if source.startswith('Overseerr') and data.get('enabled', False)]
+    overseerr_sources = [(source_id, data) for source_id, data in content_sources.items() if source_id.startswith('Overseerr') and data.get('enabled', False)]
     allow_partial = parse_bool(get_setting('Debug', 'allow_partial_overseerr_requests', 'False'))
     disable_caching = True  # Hardcoded to True
     logging.info(f"allow_partial: {allow_partial}")
-    
+
     all_wanted_items = []
     cache = {} if disable_caching else load_overseerr_cache()
     current_time = datetime.now()
-    
-    for source in overseerr_sources:
+
+    for source_id, source in overseerr_sources:
         overseerr_url = source.get('url')
         overseerr_api_key = source.get('api_key')
+        display_name = source.get('display_name') or source_id
         ignore_tags_str = source.get('ignore_tags', '')
         ignore_tags = {tag.strip().lower() for tag in ignore_tags_str.split(',') if tag.strip()} if ignore_tags_str else set()
-        
+
         if not overseerr_url or not overseerr_api_key:
             logging.error(f"Overseerr URL or API key not set for source: {source}. Please configure in settings.")
             continue
 
         try:
             wanted_content_raw = fetch_overseerr_wanted_content(overseerr_url, overseerr_api_key)
+            _clear_overseerr_auth_failure(source_id, display_name)
             wanted_items = []
             cache_skipped = 0
             ignored_by_tag = 0
@@ -276,6 +355,9 @@ def get_wanted_from_overseerr(versions: Dict[str, bool]) -> List[Tuple[List[Dict
                 logging.info(f"Ignored {ignored_by_tag} items from Overseerr source based on tags.")
             all_wanted_items.append((wanted_items, versions))
             logging.info(f"Retrieved {len(wanted_items)} wanted items from Overseerr source")
+        except OverseerrAuthError as e:
+            logging.error(f"Overseerr auth failure for source '{display_name}': {e}")
+            _notify_overseerr_auth_failure(source_id, display_name)
         except Exception as e:
             logging.error(f"Unexpected error while processing Overseerr source: {e}")
 

--- a/metadata/metadata.py
+++ b/metadata/metadata.py
@@ -339,11 +339,24 @@ def create_episode_item(show_item: Dict[str, Any], season_number: int, episode_n
             except ValueError:
                  logging.warning(f"Invalid show default airtime format: {default_airtime_str}. Using default 19:00.")
 
+    # 'year' is not always present on show metadata (e.g. unreleased/sparsely-documented
+    # shows) — fall back to deriving it from a release date rather than crashing.
+    show_year = show_item.get('year')
+    if not isinstance(show_year, int):
+        for _date_field in ('first_aired', 'release_date'):
+            _date_val = show_item.get(_date_field)
+            if _date_val and len(str(_date_val)) >= 4:
+                try:
+                    show_year = int(str(_date_val)[:4])
+                    break
+                except (ValueError, TypeError):
+                    pass
+
     episode_item = {
         'imdb_id': show_item['imdb_id'],
         'tmdb_id': show_item['tmdb_id'],
         'title': show_item['title'],
-        'year': show_item['year'],
+        'year': show_year,
         'season_number': int(season_number),
         'episode_number': int(episode_number),
         'episode_title': episode_data.get('title', f"Episode {episode_number}"),

--- a/queues/adding_queue.py
+++ b/queues/adding_queue.py
@@ -858,7 +858,10 @@ class AddingQueue:
                     upgrading_queue.add_failed_upgrade(item['id'], failed_info)
                     logging.info(f"Successfully reverted failed upgrade for {item_identifier}")
                 else:
-                    logging.error(f"Failed to restore previous state for {item_identifier} after adding queue failure")
+                    # No snapshot to restore; revert to Collected so the item doesn't loop forever at state='Adding'.
+                    logging.error(f"Failed to restore previous state for {item_identifier} after adding queue failure; reverting to Collected")
+                    if item_id:
+                        update_media_item(item_id, state='Collected', upgrading=False, upgrading_from=None)
 
                 # --- START EDIT: Check if failure was due to filter and remove torrent ---
                 if "matched filter-out list" in error:

--- a/queues/upgrading_queue.py
+++ b/queues/upgrading_queue.py
@@ -1222,8 +1222,9 @@ class UpgradingQueue:
                         # We might need to update the 'upgrading' flag back to False if restore_item_state doesn't
                         update_media_item(item['id'], upgrading=False)
                     else:
-                        logging.error(f"Failed to restore previous state for {item_identifier}, manual intervention may be needed")
-                        # Item might be stuck, consider moving to a failed state?
+                        # No snapshot to restore; revert to Collected instead of leaving it stuck mid-upgrade.
+                        logging.error(f"Failed to restore previous state for {item_identifier}; reverting to Collected")
+                        update_media_item(item['id'], state='Collected', upgrading=False, upgrading_from=None)
 
                     # Log failure to Upgrade Hub activity (after purge/not_wanted so we can include outcomes)
                     if pre_candidate is not None:

--- a/routes/bazarr_signalr.py
+++ b/routes/bazarr_signalr.py
@@ -262,12 +262,14 @@ def notify_media_collected(media_item: Dict[str, Any], media_type: str):
             from routes.bazarr_spoofing_routes import (
                 create_episode_file_resource,
                 create_series_resource,
-                generate_unique_id,
-                get_episodes_for_series
+                get_episodes_for_series,
+                normalize_show_id,
             )
-            # Get series info for the full event sequence
-            show_id = media_item.get('tmdb_id') or media_item.get('imdb_id')
-            series_id = generate_unique_id(show_id, 'series')
+            # Get series info for the full event sequence — same show_id
+            # contract as HTTP /api/v3/series (imdb preferred, blank ignored)
+            show_id = normalize_show_id(
+                media_item.get('imdb_id'), media_item.get('tmdb_id')
+            )
 
             # Build series resource for series events
             series_info = {
@@ -282,13 +284,16 @@ def notify_media_collected(media_item: Dict[str, Any], media_type: str):
 
             # Get all episodes for this series to build complete series resource
             try:
-                episodes = get_episodes_for_series(show_id)
+                episodes = get_episodes_for_series(show_id) if show_id else [media_item]
             except Exception:
                 episodes = [media_item]  # Fall back to just this episode
 
             series_resource = create_series_resource(series_info, episodes)
 
-            # Create episode file resource
+            # MUST reuse series_resource['id'] — never re-hash separately.
+            # HTTP create_series_resource uses TMDB as id when present; a
+            # separate generate_unique_id caused Bazarr FK failures.
+            series_id = series_resource['id']
             episode_file_resource = create_episode_file_resource(media_item, series_id)
 
             # Broadcast with full sequence (series events -> episode events)

--- a/routes/bazarr_spoofing_routes.py
+++ b/routes/bazarr_spoofing_routes.py
@@ -134,24 +134,25 @@ def get_collected_series() -> List[Dict[str, Any]]:
     conn.execute('PRAGMA query_only = ON')
     try:
         cursor = conn.cursor()
-        # Get unique shows with their metadata
+        # NULLIF so empty-string imdb_id falls through to tmdb (matches normalize_show_id)
         cursor.execute("""
             SELECT DISTINCT
-                COALESCE(imdb_id, tmdb_id) as show_id,
+                COALESCE(NULLIF(imdb_id, ''), NULLIF(CAST(tmdb_id AS TEXT), '')) as show_id,
                 imdb_id, tmdb_id, title, year, genres, runtime
             FROM media_items
             WHERE state = 'Collected'
             AND type = 'episode'
             AND (file_path IS NOT NULL OR location_on_disk IS NOT NULL)
-            GROUP BY COALESCE(imdb_id, tmdb_id), title
+            GROUP BY COALESCE(NULLIF(imdb_id, ''), NULLIF(CAST(tmdb_id AS TEXT), '')), title
         """)
 
         series_list = []
         for row in cursor.fetchall():
+            imdb_id, tmdb_id = row[1], row[2]
             series_list.append({
-                'show_id': row[0],
-                'imdb_id': row[1],
-                'tmdb_id': row[2],
+                'show_id': normalize_show_id(imdb_id, tmdb_id) or row[0],
+                'imdb_id': imdb_id,
+                'tmdb_id': tmdb_id,
                 'title': row[3],
                 'year': row[4],
                 'genres': row[5],
@@ -244,8 +245,30 @@ def get_all_collected_episodes() -> List[Dict[str, Any]]:
         conn.close()
 
 
+def _movie_row_to_dict(row) -> Dict[str, Any]:
+    return {
+        'id': row[0],
+        'imdb_id': row[1],
+        'tmdb_id': row[2],
+        'title': row[3],
+        'year': row[4],
+        'file_path': row[5],
+        'location_on_disk': row[6],
+        'genres': row[7],
+        'runtime': row[8],
+        'collected_at': row[9],
+        'version': row[10],
+        'filled_by_file': row[11],
+        'resolution': row[12]
+    }
+
+
 def get_movie_by_id(movie_id: int) -> Optional[Dict[str, Any]]:
-    """Get a specific movie by its ID."""
+    """Get a specific movie by its Radarr id (TMDB, else hashed media id).
+
+    Prefer tmdb_id match — never match media_items.id first, which collides
+    with TMDB ids and returns the wrong title.
+    """
     conn = get_db_connection()
     try:
         cursor = conn.cursor()
@@ -254,64 +277,76 @@ def get_movie_by_id(movie_id: int) -> Optional[Dict[str, Any]]:
                    location_on_disk, genres, runtime, collected_at, version,
                    filled_by_file, resolution
             FROM media_items
-            WHERE (id = ? OR tmdb_id = ? OR tmdb_id = ?)
-            AND state = 'Collected'
+            WHERE state = 'Collected'
             AND type = 'movie'
+            AND (tmdb_id = ? OR tmdb_id = ?)
             LIMIT 1
-        """, (movie_id, str(movie_id), movie_id))
+        """, (str(movie_id), movie_id))
 
         row = cursor.fetchone()
         if row:
-            return {
-                'id': row[0],
-                'imdb_id': row[1],
-                'tmdb_id': row[2],
-                'title': row[3],
-                'year': row[4],
-                'file_path': row[5],
-                'location_on_disk': row[6],
-                'genres': row[7],
-                'runtime': row[8],
-                'collected_at': row[9],
-                'version': row[10],
-                'filled_by_file': row[11],
-                'resolution': row[12]
-            }
-        return None
+            return _movie_row_to_dict(row)
     finally:
         conn.close()
 
+    # Fallback: hashed movie ids when TMDB is missing
+    for movie in get_collected_movies():
+        try:
+            tmdb_id = int(movie.get('tmdb_id') or 0)
+        except (ValueError, TypeError):
+            tmdb_id = 0
+        resolved = tmdb_id or generate_unique_id(movie.get('id'), 'movie')
+        if resolved == movie_id:
+            return movie
+    return None
+
 
 def get_series_by_id(series_id: int) -> Optional[Dict[str, Any]]:
-    """Get a specific series by its ID."""
+    """Resolve a Sonarr series id to show metadata.
+
+    Prefer tmdb_id match (not media_items.id — PK collisions with TMDB break
+    Bazarr FK inserts). Fall back to scanning collected shows for hashed
+    sonarr_series_id matches when TMDB is absent.
+    """
     conn = get_db_connection()
     try:
         cursor = conn.cursor()
         cursor.execute("""
             SELECT DISTINCT
-                COALESCE(imdb_id, tmdb_id) as show_id,
+                COALESCE(NULLIF(imdb_id, ''), NULLIF(CAST(tmdb_id AS TEXT), '')) as show_id,
                 imdb_id, tmdb_id, title, year, genres, runtime
             FROM media_items
-            WHERE (id = ? OR tmdb_id = ? OR tmdb_id = ? OR imdb_id = ?)
-            AND state = 'Collected'
+            WHERE state = 'Collected'
             AND type = 'episode'
+            AND (tmdb_id = ? OR tmdb_id = ?)
+            AND (file_path IS NOT NULL OR location_on_disk IS NOT NULL)
             LIMIT 1
-        """, (series_id, str(series_id), series_id, str(series_id)))
+        """, (str(series_id), series_id))
 
         row = cursor.fetchone()
         if row:
+            imdb_id, tmdb_id = row[1], row[2]
             return {
-                'show_id': row[0],
-                'imdb_id': row[1],
-                'tmdb_id': row[2],
+                'show_id': normalize_show_id(imdb_id, tmdb_id) or row[0],
+                'imdb_id': imdb_id,
+                'tmdb_id': tmdb_id,
                 'title': row[3],
                 'year': row[4],
                 'genres': row[5],
                 'runtime': row[6]
             }
-        return None
     finally:
         conn.close()
+
+    for series in get_collected_series():
+        if sonarr_series_id(series) == series_id:
+            result = dict(series)
+            result['show_id'] = (
+                normalize_show_id(result.get('imdb_id'), result.get('tmdb_id'))
+                or result.get('show_id')
+            )
+            return result
+    return None
 
 
 # ============================================================================
@@ -382,6 +417,36 @@ def generate_unique_id(base_id: Any, prefix: str = '') -> int:
     # Always use hash to ensure prefix is incorporated
     hash_input = f"{prefix}{base_id}".encode()
     return int(hashlib.md5(hash_input).hexdigest()[:8], 16)
+
+
+def normalize_show_id(imdb_id: Any = None, tmdb_id: Any = None) -> str:
+    """Normalize show identity for grouping and lookups.
+
+    Blank/whitespace strings are treated as missing. Prefer IMDB, then TMDB —
+    matching SQL COALESCE(NULLIF(imdb_id, ''), NULLIF(tmdb_id, '')).
+    """
+    def _clean(value: Any) -> str:
+        if value is None:
+            return ''
+        text = str(value).strip()
+        return text if text else ''
+
+    return _clean(imdb_id) or _clean(tmdb_id)
+
+
+def sonarr_series_id(item: Dict[str, Any]) -> int:
+    """Stable Sonarr series id used by every HTTP and SignalR path.
+
+    Use integer TMDB when present; otherwise a deterministic hash of show_id.
+    """
+    try:
+        tmdb_id = int(item.get('tmdb_id') or 0)
+    except (ValueError, TypeError):
+        tmdb_id = 0
+    if tmdb_id:
+        return tmdb_id
+    show_id = item.get('show_id') or normalize_show_id(item.get('imdb_id'), item.get('tmdb_id'))
+    return generate_unique_id(show_id, 'series')
 
 
 def generate_tvdb_id(tmdb_id: Any, title: str, episode_info: Optional[Dict[str, Any]] = None) -> int:
@@ -639,7 +704,7 @@ def create_series_resource(item: Dict[str, Any], episodes: List[Dict[str, Any]] 
         tmdb_id = int(item.get('tmdb_id') or 0)
     except (ValueError, TypeError):
         tmdb_id = 0
-    series_id = tmdb_id or generate_unique_id(item.get('show_id'), 'series')
+    series_id = sonarr_series_id(item)
     title = item.get('title', 'Unknown')
 
     # Generate consistent tvdbId for Bazarr compatibility
@@ -1130,16 +1195,17 @@ def get_series():
 
     try:
         series_list = get_collected_series()
-        # Load all episodes in one query and group by show_id
+        # Load all episodes in one query and group by normalized show_id
         all_episodes = get_all_collected_episodes()
         ep_map = {}
         for ep in all_episodes:
-            key = ep.get('imdb_id') or ep.get('tmdb_id') or ''
-            ep_map.setdefault(key, []).append(ep)
+            key = normalize_show_id(ep.get('imdb_id'), ep.get('tmdb_id'))
+            if key:
+                ep_map.setdefault(key, []).append(ep)
 
         result = []
         for s in series_list:
-            show_id = s.get('show_id', '')
+            show_id = normalize_show_id(s.get('imdb_id'), s.get('tmdb_id')) or s.get('show_id', '')
             episodes = ep_map.get(show_id, [])
             result.append(create_series_resource(s, episodes))
         return jsonify(result)
@@ -1402,6 +1468,9 @@ def signalr_negotiate():
 
     connection_id = f"cli_debrid-{int(time.time() * 1000)}"
 
+    # Bazarr's bundled signalrcore only implements WebSocket transport (it
+    # ignores availableTransports and always opens ws://). Advertise WebSockets
+    # and require the WS-capable Werkzeug handler in run_server().
     return jsonify({
         'connectionId': connection_id,
         'connectionToken': connection_id,
@@ -1414,10 +1483,6 @@ def signalr_negotiate():
             {
                 'transport': 'ServerSentEvents',
                 'transferFormats': ['Text']
-            },
-            {
-                'transport': 'LongPolling',
-                'transferFormats': ['Text', 'Binary']
             }
         ]
     })
@@ -1426,44 +1491,63 @@ def signalr_negotiate():
 @bazarr_bp.route('/signalr/messages', methods=['GET'])
 @bazarr_bp.route('/signalr', methods=['GET'])
 def signalr_messages():
-    """Handle SignalR message stream (WebSocket or Server-Sent Events fallback)."""
+    """Handle SignalR message stream (WebSocket preferred; SSE fallback)."""
     if not is_symlinked_mode() or not get_setting('Bazarr Integration', 'enabled', False):
         return jsonify({'error': 'Not found'}), 404
 
-    # Check if this is a WebSocket upgrade request
+    # Prefer the Werkzeug request-handler path for WebSockets (avoids Flask
+    # middleware blocking the 101). Keep this branch for non-standard servers.
     if request.headers.get('Upgrade', '').lower() == 'websocket':
-        return handle_signalr_websocket()
+        run_signalr_websocket_session(request.environ)
+        return ''
 
-    # Fall back to Server-Sent Events
     return handle_signalr_sse()
 
 
-def handle_signalr_websocket():
-    """Handle SignalR WebSocket connection (matches CineSync implementation)."""
+def run_signalr_websocket_session(environ) -> None:
+    """Run a SignalR JSON-protocol WebSocket session on an upgraded socket.
+
+    ``environ`` must include ``werkzeug.socket`` (injected by
+    ``WebSocketAwareHandler``) so simple_websocket can complete the handshake.
+    """
     try:
         from simple_websocket import Server, ConnectionClosed
     except ImportError:
-        # simple-websocket not available, fall back to SSE
-        logging.debug("[SignalR] WebSocket requested but simple-websocket not installed, using SSE")
-        return handle_signalr_sse()
+        logging.error("[SignalR] simple-websocket not installed")
+        return
+
+    from urllib.parse import parse_qs
+    qs = parse_qs(environ.get('QUERY_STRING') or '')
+    connection_id = (
+        (qs.get('id') or qs.get('connectionToken') or [None])[0]
+        or f"ws-{int(time.time() * 1000)}"
+    )
+
+    if not is_symlinked_mode() or not get_setting('Bazarr Integration', 'enabled', False):
+        logging.warning("[SignalR] WebSocket rejected: Bazarr integration disabled")
+        return
 
     try:
-        ws = Server.accept(request.environ)
+        ws = Server.accept(environ)
     except Exception as e:
         logging.error(f"[SignalR] WebSocket accept failed: {e}")
-        return handle_signalr_sse()
+        return
 
-    connection_id = f"ws-{int(time.time() * 1000)}"
-
-    # Register this connection for event broadcasting
     from routes.bazarr_signalr import register_connection, unregister_connection, get_pending_events
-    event_queue = register_connection(connection_id)
+    register_connection(connection_id)
 
     try:
-        # Send handshake response (matches CineSync: {"error":null}\x1e)
+        # Wait for client handshake: {"protocol":"json","version":1}\x1e
+        try:
+            first = ws.receive(timeout=10)
+            if first:
+                logging.debug(f"[SignalR] client handshake: {str(first)[:80]!r}")
+        except Exception:
+            pass
+
+        # Handshake response required by SignalR JSON protocol
         ws.send(json.dumps({"error": None}) + '\x1e')
 
-        # Send version message
         version = get_setting('Bazarr Integration', 'spoofed_version', '5.14.0.9383')
         version_msg = {
             'type': 1,
@@ -1476,26 +1560,23 @@ def handle_signalr_websocket():
 
         last_ping = time.time()
         while True:
-            # Check for incoming messages (non-blocking with short timeout)
             try:
                 data = ws.receive(timeout=0.1)
-                if data:
-                    # Handle ping/pong from client
-                    try:
-                        msg = json.loads(data.rstrip('\x1e'))
-                        if msg.get('type') == 6:  # Ping
-                            ws.send(json.dumps({'type': 6}) + '\x1e')
-                    except (json.JSONDecodeError, AttributeError):
-                        pass
             except Exception:
-                pass
+                data = None
 
-            # Check for events to broadcast
+            if data:
+                try:
+                    msg = json.loads(str(data).rstrip('\x1e'))
+                    if msg.get('type') == 6:  # Ping
+                        ws.send(json.dumps({'type': 6}) + '\x1e')
+                except (json.JSONDecodeError, AttributeError, TypeError):
+                    pass
+
             events = get_pending_events(connection_id, timeout=0.1)
             for event in events:
                 ws.send(json.dumps(event) + '\x1e')
 
-            # Send periodic ping (every 10 seconds like CineSync)
             if time.time() - last_ping > 10:
                 ws.send(json.dumps({'type': 6}) + '\x1e')
                 last_ping = time.time()
@@ -1507,24 +1588,23 @@ def handle_signalr_websocket():
     finally:
         unregister_connection(connection_id)
 
-    return ''
-
 
 def handle_signalr_sse():
     """Handle SignalR Server-Sent Events connection."""
-    connection_id = f"sse-{int(time.time() * 1000)}"
+    connection_id = (
+        request.args.get('id')
+        or request.args.get('connectionToken')
+        or f"sse-{int(time.time() * 1000)}"
+    )
 
-    # Register this connection for event broadcasting
     from routes.bazarr_signalr import register_connection, unregister_connection, get_pending_events
 
     def generate():
-        event_queue = register_connection(connection_id)
+        register_connection(connection_id)
 
         try:
-            # Send handshake response
             yield f'data: {json.dumps({"error": None})}\x1e\n\n'
 
-            # Send version message
             version = get_setting('Bazarr Integration', 'spoofed_version', '5.14.0.9383')
             version_msg = {
                 'type': 1,
@@ -1537,12 +1617,10 @@ def handle_signalr_sse():
 
             last_ping = time.time()
             while True:
-                # Check for events to broadcast
                 events = get_pending_events(connection_id, timeout=1.0)
                 for event in events:
                     yield f'data: {json.dumps(event)}\x1e\n\n'
 
-                # Send periodic ping (every 15 seconds)
                 if time.time() - last_ping > 15:
                     yield f'data: {json.dumps({"type": 6})}\x1e\n\n'
                     last_ping = time.time()
@@ -1558,6 +1636,7 @@ def handle_signalr_sse():
         headers={
             'Cache-Control': 'no-cache',
             'Connection': 'keep-alive',
+            'X-Accel-Buffering': 'no',
             'Access-Control-Allow-Origin': '*'
         }
     )

--- a/routes/program_operation_routes.py
+++ b/routes/program_operation_routes.py
@@ -191,11 +191,52 @@ def signal_handler(signum, frame):
 
 def run_server():
     from routes.extensions import app
-    
+    from werkzeug.serving import make_server, WSGIRequestHandler
+
     # Get port from environment variable or use default
     port = int(os.environ.get('CLI_DEBRID_PORT', 5000))
+
+    class WebSocketAwareHandler(WSGIRequestHandler):
+        """Threaded Werkzeug handler that supports SignalR WebSocket upgrades.
+
+        SignalR WebSocket sessions are handled here directly (not via Flask) so
+        app before_request / session middleware cannot block the 101 handshake.
+        """
+
+        protocol_version = "HTTP/1.1"
+
+        def make_environ(self):
+            environ = super().make_environ()
+            environ['werkzeug.socket'] = self.connection
+            return environ
+
+        def run_wsgi(self):
+            upgrade = (self.headers.get('Upgrade') or '').lower().strip()
+            path = (self.path or '').split('?', 1)[0]
+            if upgrade == 'websocket' and path in ('/signalr/messages', '/signalr'):
+                self.environ = environ = self.make_environ()
+                try:
+                    from routes.bazarr_spoofing_routes import run_signalr_websocket_session
+                    run_signalr_websocket_session(environ)
+                except (BrokenPipeError, ConnectionError, ConnectionResetError):
+                    pass
+                except Exception as e:
+                    logging.error(f"[SignalR] WebSocket handler error: {e}", exc_info=True)
+                return
+            return super().run_wsgi()
+
     try:
-        app.run(debug=True, use_reloader=False, host='0.0.0.0', port=port, threaded=True)
+        # Use make_server (not app.run) so we control the request handler and
+        # avoid the Flask debugger wrapper interfering with Upgrade requests.
+        logging.info(f"Starting Werkzeug threaded server with WebSocket support on 0.0.0.0:{port}")
+        server = make_server(
+            '0.0.0.0',
+            port,
+            app,
+            threaded=True,
+            request_handler=WebSocketAwareHandler,
+        )
+        server.serve_forever()
     except Exception as e:
         logging.error(f"Error running server: {str(e)}")
         cleanup_port(port)

--- a/routes/settings_validation_routes.py
+++ b/routes/settings_validation_routes.py
@@ -199,11 +199,13 @@ def validate_trakt_credentials(client_id, client_secret):
     if not client_id or not client_secret:
         return False, "Both Client ID and Client Secret are required"
     
-    # Validate format
-    if len(client_id) != 64:
-        return False, "Invalid Trakt Client ID format (must be 64 characters)"
-    if len(client_secret) != 64:
-        return False, "Invalid Trakt Client Secret format (must be 64 characters)"
+    # Validate basic sanity (Trakt has changed key lengths over time, so we
+    # avoid hardcoding an exact character count and only guard against
+    # obviously-wrong input, e.g. empty/placeholder text pasted by mistake).
+    if len(client_id.strip()) < 10:
+        return False, "Invalid Trakt Client ID format (too short)"
+    if len(client_secret.strip()) < 10:
+        return False, "Invalid Trakt Client Secret format (too short)"
     
     try:
         # Try to get a device code - this validates both client ID and secret


### PR DESCRIPTION
- FlixPatrol Cloudflare fix: FlixPatrol added a Cloudflare bot-challenge that blocked all Top 10 scraping; added an on-demand browser-based challenge solver that caches a short-lived clearance token so regular scraping stays lightweight
- Overseerr auth-failure notifications: a rejected/invalid Overseerr API key now surfaces a notification instead of silently starving the Wanted queue; clears automatically once the key is fixed
- Fixed a crash when a show's metadata is missing a release year (e.g. unreleased or sparsely-documented titles), which previously dropped all of that show's episodes on every scan
- Trakt key validation fix: removed the hardcoded 64-character format check on Trakt Client ID/Secret (Trakt has changed key lengths over time); replaced with a loose sanity check so valid keys of any length are accepted and real validation happens against Trakt's API — thanks to @petern-sc for reporting
- Fixed upgrade items looping forever at state='Adding' when no state snapshot exists to restore, instead correctly reverting to Collected — thanks to @LiamMcArdle
- Fixed Bazarr spoofed series ID consistency and completed the SignalR WebSocket handshake so Sonarr/Radarr connections no longer show as DOWN in Bazarr — thanks to @zab1996