### PR TITLE
Verify NZB playback replacements before cleanup

### DIFF
--- a/.github/workflows/minimal-nzb-playback-repair-image.yml
+++ b/.github/workflows/minimal-nzb-playback-repair-image.yml
@@ -1,0 +1,31 @@
+name: Minimal NZB playback repair test image
+
+on:
+  push:
+    branches: [minimal-nzb-playback-repair]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/zab1996/cli_debrid:minimal-nzb-playback-repair

--- a/database/core.py
+++ b/database/core.py
@@ -8,11 +8,14 @@ import logging
 import time
 import random
 import uuid
+import threading
 from datetime import datetime
 
 # --- Constants ---
 MAX_STORED_NOTIFICATIONS = 50 # Define max notifications to keep in DB
 DEFAULT_LONG_EXECUTION_THRESHOLD_SECONDS = 1.0 # Define a default threshold
+_wal_init_lock = threading.Lock()
+_wal_initialized_paths = set()
 
 # --- String Normalization ---
 def normalize_string(input_str):
@@ -183,8 +186,14 @@ def get_db_connection(db_path=None):
     # Increased timeout to 30 seconds for better concurrent access handling
     conn = sqlite3.connect(db_path, timeout=30)
 
-    # Enable WAL mode for concurrent reads during writes
-    conn.execute('PRAGMA journal_mode=WAL')
+    # journal_mode mutates database state and can itself contend with writers.
+    # Initialize it once per database path instead of on every connection.
+    normalized_db_path = os.path.abspath(db_path)
+    if normalized_db_path not in _wal_initialized_paths:
+        with _wal_init_lock:
+            if normalized_db_path not in _wal_initialized_paths:
+                conn.execute('PRAGMA journal_mode=WAL')
+                _wal_initialized_paths.add(normalized_db_path)
 
     # Set busy timeout at connection level (30 seconds)
     conn.execute('PRAGMA busy_timeout = 30000')

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -20,12 +20,20 @@ _worker_lock = threading.Lock()
 ELIGIBLE_REASONS = {
     'usenet_segment_missing', 'media_probe_failed', 'media_no_playable_stream',
 }
-# A stale_target ack response is only transient if the mount hasn't caught up
-# yet with a supersession decypharr already applied. If it's still stale
-# after this many exact-cleanup attempts, further retries won't help (the
-# target genuinely changed), so stop retrying and finish the repair without
-# the old-file cleanup rather than looping forever.
+# A stale_target ack response is usually just the mount not having caught up
+# yet with a supersession decypharr already applied, or transient contention
+# with a long-running decypharr health sweep touching the same entry — both
+# self-resolve, just not always within a couple of minutes. If it's still
+# stale after this many quick attempts, don't block the repair's own
+# finalization any further (the new file is already confirmed healthy) —
+# defer the old-file cleanup to the slower background retry
+# (retry_deferred_playback_cleanups) instead of abandoning it outright.
 STALE_TARGET_MAX_ATTEMPTS = 5
+# Once deferred, retry the same safety-checked ack on a much slower cadence
+# (minutes, not seconds) for a long time before concluding it's genuinely
+# unresolvable rather than just unlucky timing.
+CLEANUP_RETRY_BACKOFF_MINUTES = (15, 30, 60, 120)
+CLEANUP_GIVE_UP_HOURS = 48
 # A failed-job delete can be legitimately transient (mount briefly
 # unreachable), but a job that's simply gone from decypharr will never
 # succeed no matter how many times it's retried. Cap retries so a stale
@@ -118,6 +126,10 @@ def create_nzb_playback_repair_table():
             conn.execute(
                 "ALTER TABLE nzb_playback_repairs ADD COLUMN failed_job_attempts_json TEXT NOT NULL DEFAULT '{}'"
             )
+        if 'cleanup_status' not in columns:
+            conn.execute('ALTER TABLE nzb_playback_repairs ADD COLUMN cleanup_status TEXT')
+        if 'cleanup_first_pending_at' not in columns:
+            conn.execute('ALTER TABLE nzb_playback_repairs ADD COLUMN cleanup_first_pending_at TIMESTAMP')
         for column in ('old_guid', 'old_segment', 'old_normalized_title',
                        'candidate_guid', 'candidate_segment', 'candidate_normalized_title'):
             if column not in columns:
@@ -587,9 +599,9 @@ def process_pending_playback_repairs():
                     conn.close()
 
             targets = _json(repair['cleanup_targets_json'], [])
-            all_complete = True
+            all_actionable = True  # nothing left this fast pass needs to keep retrying
             for target in targets:
-                if target.get('status') == 'complete':
+                if target.get('status') == 'complete' or target.get('deferred'):
                     continue
                 log.info(
                     '[NZBPlayback] Requesting exact cleanup repair=%s old_uuid=%s file=%s',
@@ -602,7 +614,7 @@ def process_pending_playback_repairs():
                     body.get('code') or '', code, error or '',
                 )
                 if error or code >= 500 or (code == 409 and body.get('code') == 'repair_busy'):
-                    all_complete = False
+                    all_actionable = False
                     continue
                 if code == 200 and body.get('status') in ('removed', 'already_removed'):
                     target['status'] = 'complete'
@@ -611,29 +623,43 @@ def process_pending_playback_repairs():
                     attempts = target.get('stale_attempts', 0) + 1
                     target['stale_attempts'] = attempts
                     if attempts >= STALE_TARGET_MAX_ATTEMPTS:
+                        # New file is already confirmed healthy — don't hold the
+                        # repair's own finalization hostage to the old file's
+                        # cleanup any longer. Hand it off to the slower
+                        # background retry instead of abandoning it outright.
                         log.warning(
-                            '[NZBPlayback] Exact cleanup abandoning stale target repair=%s old_uuid=%s file=%s '
-                            'after %s attempts; finishing repair without old-file cleanup',
+                            '[NZBPlayback] Exact cleanup deferring stale target repair=%s old_uuid=%s file=%s '
+                            'to background retry after %s attempts; finalizing repair now',
                             repair['id'], target.get('info_hash') or '', target.get('file_name') or '', attempts,
                         )
-                        target['status'] = 'complete'
-                        target['skipped_cleanup'] = True
+                        target['deferred'] = True
+                        target['last_error'] = 'stale_target'
                         continue
-                    all_complete = False
+                    all_actionable = False
                     target['last_error'] = 'stale_target'
                     continue
-                all_complete = False
+                all_actionable = False
                 target['last_error'] = body.get('code') or f'HTTP {code}'
+            has_deferred = any(t.get('status') != 'complete' and t.get('deferred') for t in targets)
             conn = get_db_connection()
             try:
-                conn.execute(
-                    "UPDATE nzb_playback_repairs SET cleanup_targets_json=?,status=?,updated_at=CURRENT_TIMESTAMP WHERE id=?",
-                    (json.dumps(targets), 'cleanup_complete' if all_complete else 'verified', repair['id']),
-                )
+                if has_deferred:
+                    conn.execute(
+                        """UPDATE nzb_playback_repairs SET cleanup_targets_json=?,status=?,
+                           cleanup_status='pending',
+                           cleanup_first_pending_at=COALESCE(cleanup_first_pending_at,CURRENT_TIMESTAMP),
+                           updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+                        (json.dumps(targets), 'cleanup_complete' if all_actionable else 'verified', repair['id']),
+                    )
+                else:
+                    conn.execute(
+                        "UPDATE nzb_playback_repairs SET cleanup_targets_json=?,status=?,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                        (json.dumps(targets), 'cleanup_complete' if all_actionable else 'verified', repair['id']),
+                    )
                 conn.commit()
             finally:
                 conn.close()
-            if not all_complete:
+            if not all_actionable:
                 _schedule(repair['id'], 'exact_cleanup_pending', 15)
                 continue
             if not _finish_activity(repair, candidate, repair.get('candidate_title') or item.get('filled_by_title')):
@@ -647,3 +673,107 @@ def process_pending_playback_repairs():
                 log.warning('[NZBPlayback] Post-cleanup Plex refresh failed: %s', exc)
     finally:
         _worker_lock.release()
+
+
+def retry_deferred_playback_cleanups():
+    """Background retry for old-file cleanup deferred by the fast completion
+    worker after it exhausted its quick attempts on a repair that has already
+    finalized as replaced. Runs on a much slower cadence (minutes, not
+    seconds) so it can keep patiently retrying the same safety-checked ack
+    call for up to CLEANUP_GIVE_UP_HOURS without blocking — or being blocked
+    by — repair finalization, which already happened.
+    """
+    conn = get_db_connection()
+    try:
+        rows = conn.execute(
+            """SELECT * FROM nzb_playback_repairs
+               WHERE status='complete' AND cleanup_status='pending'
+                 AND (next_attempt_at IS NULL OR next_attempt_at<=CURRENT_TIMESTAMP)
+               ORDER BY updated_at LIMIT 12"""
+        ).fetchall()
+    finally:
+        conn.close()
+    if not rows:
+        return
+
+    for raw in rows:
+        repair = dict(raw)
+        targets = _json(repair['cleanup_targets_json'], [])
+        pending = [t for t in targets if t.get('status') != 'complete']
+        if not pending:
+            conn = get_db_connection()
+            try:
+                conn.execute(
+                    "UPDATE nzb_playback_repairs SET cleanup_status='complete',next_attempt_at=NULL,"
+                    "updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                    (repair['id'],),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+            continue
+
+        expired = False
+        first_pending_at = repair.get('cleanup_first_pending_at')
+        if first_pending_at:
+            try:
+                first_dt = datetime.strptime(first_pending_at, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+                expired = (datetime.now(timezone.utc) - first_dt) > timedelta(hours=CLEANUP_GIVE_UP_HOURS)
+            except Exception:
+                expired = False
+
+        for target in pending:
+            log.info(
+                '[NZBPlayback] Background retry: requesting exact cleanup repair=%s old_uuid=%s file=%s',
+                repair['id'], target.get('info_hash') or '', target.get('file_name') or '',
+            )
+            code, body, error = _mount_request('/api/repair/replacements/ack', target, 20)
+            log.info(
+                '[NZBPlayback] Background retry result repair=%s old_uuid=%s status=%s code=%s http=%s error=%s',
+                repair['id'], target.get('info_hash') or '', body.get('status') or '',
+                body.get('code') or '', code, error or '',
+            )
+            if code == 200 and body.get('status') in ('removed', 'already_removed'):
+                target['status'] = 'complete'
+                target.pop('deferred', None)
+                target.pop('last_error', None)
+                continue
+            target['last_error'] = body.get('code') or (error or f'HTTP {code}')
+            target['background_attempts'] = target.get('background_attempts', 0) + 1
+
+        still_pending = [t for t in targets if t.get('status') != 'complete']
+        conn = get_db_connection()
+        try:
+            if not still_pending:
+                log.info('[NZBPlayback] Background cleanup completed repair=%s after handoff', repair['id'])
+                conn.execute(
+                    "UPDATE nzb_playback_repairs SET cleanup_targets_json=?,cleanup_status='complete',"
+                    "next_attempt_at=NULL,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                    (json.dumps(targets), repair['id']),
+                )
+            elif expired:
+                log.warning(
+                    '[NZBPlayback] Giving up on background cleanup for repair=%s after %sh; '
+                    'old file(s) left behind: %s',
+                    repair['id'], CLEANUP_GIVE_UP_HOURS,
+                    [t.get('file_name') for t in still_pending],
+                )
+                conn.execute(
+                    "UPDATE nzb_playback_repairs SET cleanup_targets_json=?,cleanup_status='abandoned',"
+                    "next_attempt_at=NULL,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                    (json.dumps(targets), repair['id']),
+                )
+            else:
+                backoff_idx = min(
+                    max(t.get('background_attempts', 1) for t in still_pending) - 1,
+                    len(CLEANUP_RETRY_BACKOFF_MINUTES) - 1,
+                )
+                delay_minutes = CLEANUP_RETRY_BACKOFF_MINUTES[backoff_idx]
+                conn.execute(
+                    "UPDATE nzb_playback_repairs SET cleanup_targets_json=?,"
+                    "next_attempt_at=datetime('now',?),updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                    (json.dumps(targets), f'+{delay_minutes} minutes', repair['id']),
+                )
+            conn.commit()
+        finally:
+            conn.close()

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -39,6 +39,25 @@ CLEANUP_GIVE_UP_HOURS = 48
 # succeed no matter how many times it's retried. Cap retries so a stale
 # job ID doesn't block the repair's own old-file cleanup forever.
 FAILED_JOB_MAX_ATTEMPTS = 5
+# Verification-stage caps, before a candidate has been confirmed healthy —
+# unlike the cleanup-stage backstops above, there's no already-healthy new
+# file to protect here, so a candidate that can't be verified is rejected
+# (excluded, back to searching) rather than deferred.
+VERIFY_UNKNOWN_MAX_ATTEMPTS = 10   # ~5 min at the 30s unknown-status cadence
+VERIFY_STALE_TARGET_MAX_ATTEMPTS = 5    # ~75s at the 15s 409 cadence, matches STALE_TARGET_MAX_ATTEMPTS
+# repair_busy just means decypharr's own (possibly hours-long) sweep is
+# running — not a sign this candidate is bad, so give it a much longer
+# leash than stale_target before treating it as stuck.
+VERIFY_BUSY_MAX_ATTEMPTS = 240     # ~60 min at the 15s 409 cadence
+# The candidate-search retry loop (status='awaiting_candidate') never fully
+# gives up on its own — usenet content can reappear days after it's pulled —
+# but it should stop being silent about a title that isn't resolving.
+# First it becomes visible (skipped_max_attempts, matching the tooltip the
+# older debrid-side repair UI already uses) and slows down; only after a
+# much longer stretch with nothing found does it actually stop scheduling.
+CANDIDATE_SEARCH_VISIBILITY_ATTEMPTS = 24        # ~2h at the 5-minute search cadence
+CANDIDATE_SEARCH_SLOW_CADENCE_SECONDS = 1800     # 30 min, once past the visibility threshold
+CANDIDATE_SEARCH_GIVE_UP_DAYS = 7
 
 
 def _now():
@@ -134,6 +153,12 @@ def create_nzb_playback_repair_table():
                        'candidate_guid', 'candidate_segment', 'candidate_normalized_title'):
             if column not in columns:
                 conn.execute(f'ALTER TABLE nzb_playback_repairs ADD COLUMN {column} TEXT')
+        for column in ('verify_unknown_attempts', 'verify_stale_target_attempts', 'verify_busy_attempts',
+                       'candidate_search_attempts'):
+            if column not in columns:
+                conn.execute(f'ALTER TABLE nzb_playback_repairs ADD COLUMN {column} INTEGER NOT NULL DEFAULT 0')
+        if 'candidate_search_stuck_since' not in columns:
+            conn.execute('ALTER TABLE nzb_playback_repairs ADD COLUMN candidate_search_stuck_since TIMESTAMP')
         conn.commit()
     finally:
         conn.close()
@@ -286,6 +311,8 @@ def set_playback_candidate(item_id, result, job_id, title):
                SET candidate_info_hash=?,candidate_title=?,candidate_keys_json=?,
                    candidate_guid=?,candidate_segment=?,candidate_normalized_title=?,
                    status='awaiting_collection',next_attempt_at=NULL,last_error=NULL,
+                   verify_unknown_attempts=0,verify_stale_target_attempts=0,verify_busy_attempts=0,
+                   candidate_search_attempts=0,candidate_search_stuck_since=NULL,
                    updated_at=CURRENT_TIMESTAMP
                WHERE cli_debrid_id=? AND status!='complete'""",
             (job_id, title, json.dumps(sorted(keys)), guid, segment, normalized, item_id),
@@ -439,6 +466,48 @@ def _finish_activity(repair, candidate_uuid, title):
         conn.close()
 
 
+def _reject_verification_candidate(repair, reason):
+    """Give up on the active candidate after it fails to verify within the
+    attempt cap for its failure mode, and fall back to candidate search —
+    same reset shape as the existing 'verification found broken' path, but
+    with nothing to add to cleanup_targets since no replacement was ever
+    confirmed healthy.
+    """
+    excluded = set(_json(repair['excluded_keys_json'], [])) | set(_json(repair['candidate_keys_json'], []))
+    conn = get_db_connection()
+    try:
+        conn.execute(
+            """UPDATE nzb_playback_repairs SET status='awaiting_candidate',
+               excluded_keys_json=?,candidate_info_hash=NULL,candidate_title=NULL,
+               candidate_guid=NULL,candidate_segment=NULL,candidate_normalized_title=NULL,
+               verify_unknown_attempts=0,verify_stale_target_attempts=0,verify_busy_attempts=0,
+               next_attempt_at=NULL,lease_owner=NULL,lease_until=NULL,
+               last_error=?,updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+            (json.dumps(sorted(excluded)), reason, repair['id']),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    log.warning(
+        '[NZBPlayback] Rejecting candidate after repeated verification failures repair=%s item=%s reason=%s',
+        repair['id'], repair['cli_debrid_id'], reason,
+    )
+
+
+def _bump_attempt(repair_id, column):
+    """Increment one of the verify-stage attempt counters and return the new value."""
+    conn = get_db_connection()
+    try:
+        conn.execute(
+            f"UPDATE nzb_playback_repairs SET {column}={column}+1,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+            (repair_id,),
+        )
+        conn.commit()
+        return conn.execute(f"SELECT {column} FROM nzb_playback_repairs WHERE id=?", (repair_id,)).fetchone()[0]
+    finally:
+        conn.close()
+
+
 def process_pending_playback_repairs():
     """Complete only already-started repairs; never scans or starts the backlog."""
     if not _worker_lock.acquire(blocking=False):
@@ -493,11 +562,68 @@ def process_pending_playback_repairs():
                     '[NZBPlayback] Candidate search retry repair=%s item=%s outcome=%s',
                     repair['id'], repair['cli_debrid_id'], outcome,
                 )
-                # set_playback_candidate() (called on a 'submitted' outcome)
-                # updates status but doesn't clear the lease this pass just
-                # took — always reschedule so the row isn't stuck holding
-                # that 10-minute claim lease before collection-wait can run.
-                _schedule(repair['id'], outcome, 15 if outcome == 'submitted' else 300)
+                if outcome == 'submitted':
+                    # set_playback_candidate() already reset the search-attempt
+                    # counters and updates status, but doesn't clear the lease
+                    # this pass just took — always reschedule so the row isn't
+                    # stuck holding that 10-minute claim lease before
+                    # collection-wait can run.
+                    _schedule(repair['id'], outcome, 15)
+                    continue
+
+                attempts = _bump_attempt(repair['id'], 'candidate_search_attempts')
+                stuck_since = repair.get('candidate_search_stuck_since')
+                if attempts >= CANDIDATE_SEARCH_VISIBILITY_ATTEMPTS and not stuck_since:
+                    stuck_since = _now()
+                    conn = get_db_connection()
+                    try:
+                        conn.execute(
+                            "UPDATE nzb_playback_repairs SET candidate_search_stuck_since=? WHERE id=?",
+                            (stuck_since, repair['id']),
+                        )
+                        if repair.get('activity_id'):
+                            conn.execute(
+                                """UPDATE nzb_repair_activity SET outcome='skipped_max_attempts',
+                                   updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+                                (repair['activity_id'],),
+                            )
+                        conn.commit()
+                    finally:
+                        conn.close()
+                    log.warning(
+                        '[NZBPlayback] No healthy candidate found after %s attempts, flagging for visibility '
+                        'repair=%s item=%s',
+                        attempts, repair['id'], repair['cli_debrid_id'],
+                    )
+
+                if stuck_since:
+                    stuck_dt = datetime.strptime(stuck_since, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+                    if datetime.now(timezone.utc) - stuck_dt >= timedelta(days=CANDIDATE_SEARCH_GIVE_UP_DAYS):
+                        conn = get_db_connection()
+                        try:
+                            if repair.get('activity_id'):
+                                conn.execute(
+                                    """UPDATE nzb_repair_activity SET outcome='abandoned_after_retries',
+                                       updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+                                    (repair['activity_id'],),
+                                )
+                            conn.execute(
+                                """UPDATE nzb_playback_repairs SET status='complete',completed_at=CURRENT_TIMESTAMP,
+                                   next_attempt_at=NULL,lease_owner=NULL,lease_until=NULL,
+                                   last_error='abandoned_after_retries',updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+                                (repair['id'],),
+                            )
+                            conn.commit()
+                        finally:
+                            conn.close()
+                        log.warning(
+                            '[NZBPlayback] Giving up after %s days with no healthy candidate found repair=%s item=%s',
+                            CANDIDATE_SEARCH_GIVE_UP_DAYS, repair['id'], repair['cli_debrid_id'],
+                        )
+                        continue
+                    _schedule(repair['id'], outcome, CANDIDATE_SEARCH_SLOW_CADENCE_SECONDS)
+                    continue
+                _schedule(repair['id'], outcome, 300)
                 continue
             if not item or item.get('state') != 'Collected':
                 log.debug(
@@ -533,10 +659,25 @@ def process_pending_playback_repairs():
                     _schedule(repair['id'], error or f'HTTP {code}', 60)
                     continue
                 if code == 409:
-                    _schedule(repair['id'], body.get('code') or 'repair_busy', 15)
+                    busy_code = body.get('code') or 'repair_busy'
+                    if busy_code == 'stale_target':
+                        attempts = _bump_attempt(repair['id'], 'verify_stale_target_attempts')
+                        if attempts >= VERIFY_STALE_TARGET_MAX_ATTEMPTS:
+                            _reject_verification_candidate(repair, 'verify_stale_target_max_attempts')
+                            continue
+                    else:
+                        attempts = _bump_attempt(repair['id'], 'verify_busy_attempts')
+                        if attempts >= VERIFY_BUSY_MAX_ATTEMPTS:
+                            _reject_verification_candidate(repair, 'verify_busy_max_attempts')
+                            continue
+                    _schedule(repair['id'], busy_code, 15)
                     continue
                 status = body.get('status')
                 if status == 'unknown':
+                    attempts = _bump_attempt(repair['id'], 'verify_unknown_attempts')
+                    if attempts >= VERIFY_UNKNOWN_MAX_ATTEMPTS:
+                        _reject_verification_candidate(repair, body.get('reason') or 'verify_unknown_max_attempts')
+                        continue
                     _schedule(repair['id'], body.get('reason') or 'verification_unknown', 30)
                     continue
                 if status == 'broken':

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -20,6 +20,17 @@ _worker_lock = threading.Lock()
 ELIGIBLE_REASONS = {
     'usenet_segment_missing', 'media_probe_failed', 'media_no_playable_stream',
 }
+# A stale_target ack response is only transient if the mount hasn't caught up
+# yet with a supersession decypharr already applied. If it's still stale
+# after this many exact-cleanup attempts, further retries won't help (the
+# target genuinely changed), so stop retrying and finish the repair without
+# the old-file cleanup rather than looping forever.
+STALE_TARGET_MAX_ATTEMPTS = 5
+# A failed-job delete can be legitimately transient (mount briefly
+# unreachable), but a job that's simply gone from decypharr will never
+# succeed no matter how many times it's retried. Cap retries so a stale
+# job ID doesn't block the repair's own old-file cleanup forever.
+FAILED_JOB_MAX_ATTEMPTS = 5
 
 
 def _now():
@@ -75,6 +86,7 @@ def create_nzb_playback_repair_table():
                 excluded_keys_json TEXT NOT NULL DEFAULT '[]',
                 cleanup_targets_json TEXT NOT NULL DEFAULT '[]',
                 failed_job_ids_json TEXT NOT NULL DEFAULT '[]',
+                failed_job_attempts_json TEXT NOT NULL DEFAULT '{}',
                 candidate_info_hash TEXT,
                 candidate_title TEXT,
                 candidate_guid TEXT,
@@ -102,6 +114,10 @@ def create_nzb_playback_repair_table():
             conn.execute('ALTER TABLE nzb_playback_repairs ADD COLUMN lease_owner TEXT')
         if 'lease_until' not in columns:
             conn.execute('ALTER TABLE nzb_playback_repairs ADD COLUMN lease_until TIMESTAMP')
+        if 'failed_job_attempts_json' not in columns:
+            conn.execute(
+                "ALTER TABLE nzb_playback_repairs ADD COLUMN failed_job_attempts_json TEXT NOT NULL DEFAULT '{}'"
+            )
         for column in ('old_guid', 'old_segment', 'old_normalized_title',
                        'candidate_guid', 'candidate_segment', 'candidate_normalized_title'):
             if column not in columns:
@@ -200,6 +216,24 @@ def candidate_is_excluded(item_id, result):
             (item_id,),
         ).fetchone()
         return bool(row and candidate_keys(result) & set(_json(row[0], [])))
+    finally:
+        conn.close()
+
+
+def has_active_exact_repair(item_id, old_info_hash, old_file_name):
+    """Return whether the exact old mounted file already has an active repair."""
+    if not item_id or not old_info_hash or not old_file_name:
+        return False
+    conn = get_db_connection()
+    try:
+        row = conn.execute(
+            """SELECT 1 FROM nzb_playback_repairs
+               WHERE cli_debrid_id=? AND old_info_hash=? AND old_file_name=?
+                 AND status!='complete'
+               LIMIT 1""",
+            (int(item_id), old_info_hash, old_file_name),
+        ).fetchone()
+        return bool(row)
     finally:
         conn.close()
 
@@ -355,7 +389,20 @@ def _finish_activity(repair, candidate_uuid, title):
                       updated_at=CURRENT_TIMESTAMP WHERE id=?""",
             (repair['id'],),
         )
+        # A health scan may have encountered the retained old file after its
+        # media row switched to the provisional candidate. Remove only those
+        # duplicate reports that identify this exact original provider entry.
+        conn.execute(
+            """DELETE FROM nzb_repair_activity
+               WHERE id!=? AND outcome='not_found'
+                 AND broken_nzb_id=? AND broken_nzb_title=?""",
+            (repair['activity_id'], repair['old_info_hash'], repair['old_entry_name']),
+        )
         conn.commit()
+        log.info(
+            '[NZBPlayback] Repair finalized item=%s candidate=%s activity=%s',
+            repair['cli_debrid_id'], candidate_uuid, repair['activity_id'],
+        )
         return True
     except Exception:
         conn.rollback()
@@ -368,6 +415,7 @@ def _finish_activity(repair, candidate_uuid, title):
 def process_pending_playback_repairs():
     """Complete only already-started repairs; never scans or starts the backlog."""
     if not _worker_lock.acquire(blocking=False):
+        log.debug('[NZBPlayback] Completion worker already active; skipping overlapping pass')
         return
     try:
         lease_owner = uuid.uuid4().hex
@@ -397,8 +445,18 @@ def process_pending_playback_repairs():
                 conn.close()
             if not claimed:
                 continue
+            log.info(
+                '[NZBPlayback] Claimed repair=%s item=%s stage=%s candidate=%s',
+                repair['id'], repair['cli_debrid_id'], repair['status'],
+                repair.get('candidate_info_hash') or '',
+            )
             item = _media_item(repair['cli_debrid_id'])
             if not item or item.get('state') != 'Collected':
+                log.debug(
+                    '[NZBPlayback] Waiting for collection repair=%s item=%s state=%s',
+                    repair['id'], repair['cli_debrid_id'],
+                    item.get('state') if item else 'missing',
+                )
                 _schedule(repair['id'], 'awaiting_collection', 15)
                 continue
             candidate = repair.get('candidate_info_hash') or ''
@@ -411,9 +469,18 @@ def process_pending_playback_repairs():
                 continue
 
             if repair['status'] not in ('verified', 'cleanup_complete'):
+                log.info(
+                    '[NZBPlayback] Requesting replacement verification repair=%s item=%s candidate=%s',
+                    repair['id'], repair['cli_debrid_id'], candidate,
+                )
                 code, body, error = _mount_request(
                     '/api/repair/replacements/verify',
                     {'cli_debrid_id': repair['cli_debrid_id'], 'info_hash': candidate}, 75)
+                log.info(
+                    '[NZBPlayback] Replacement verification result repair=%s status=%s reason=%s http=%s error=%s',
+                    repair['id'], body.get('status') or '', body.get('reason') or body.get('code') or '',
+                    code, error or '',
+                )
                 if error or code >= 500:
                     _schedule(repair['id'], error or f'HTTP {code}', 60)
                     continue
@@ -465,16 +532,28 @@ def process_pending_playback_repairs():
                 repair['status'] = 'verified'
 
             failed_jobs = _json(repair['failed_job_ids_json'], [])
+            failed_job_attempts = _json(repair['failed_job_attempts_json'], {})
             remaining_jobs = []
             for failed_job_id in failed_jobs:
-                if not client.remove_nzb_exact(failed_job_id):
-                    remaining_jobs.append(failed_job_id)
+                if client.remove_nzb_exact(failed_job_id):
+                    failed_job_attempts.pop(failed_job_id, None)
+                    continue
+                attempts = failed_job_attempts.get(failed_job_id, 0) + 1
+                if attempts >= FAILED_JOB_MAX_ATTEMPTS:
+                    log.warning(
+                        '[NZBPlayback] Abandoning undeletable failed job repair=%s job=%s after %s attempts',
+                        repair['id'], failed_job_id, attempts,
+                    )
+                    failed_job_attempts.pop(failed_job_id, None)
+                    continue
+                failed_job_attempts[failed_job_id] = attempts
+                remaining_jobs.append(failed_job_id)
             if remaining_jobs:
                 conn = get_db_connection()
                 try:
                     conn.execute(
-                        "UPDATE nzb_playback_repairs SET failed_job_ids_json=?,updated_at=CURRENT_TIMESTAMP WHERE id=?",
-                        (json.dumps(remaining_jobs), repair['id']),
+                        "UPDATE nzb_playback_repairs SET failed_job_ids_json=?,failed_job_attempts_json=?,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                        (json.dumps(remaining_jobs), json.dumps(failed_job_attempts), repair['id']),
                     )
                     conn.commit()
                 finally:
@@ -485,7 +564,7 @@ def process_pending_playback_repairs():
                 conn = get_db_connection()
                 try:
                     conn.execute(
-                        "UPDATE nzb_playback_repairs SET failed_job_ids_json='[]',updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                        "UPDATE nzb_playback_repairs SET failed_job_ids_json='[]',failed_job_attempts_json='{}',updated_at=CURRENT_TIMESTAMP WHERE id=?",
                         (repair['id'],),
                     )
                     conn.commit()
@@ -497,15 +576,39 @@ def process_pending_playback_repairs():
             for target in targets:
                 if target.get('status') == 'complete':
                     continue
+                log.info(
+                    '[NZBPlayback] Requesting exact cleanup repair=%s old_uuid=%s file=%s',
+                    repair['id'], target.get('info_hash') or '', target.get('file_name') or '',
+                )
                 code, body, error = _mount_request('/api/repair/replacements/ack', target, 20)
+                log.info(
+                    '[NZBPlayback] Exact cleanup result repair=%s old_uuid=%s status=%s code=%s http=%s error=%s',
+                    repair['id'], target.get('info_hash') or '', body.get('status') or '',
+                    body.get('code') or '', code, error or '',
+                )
                 if error or code >= 500 or (code == 409 and body.get('code') == 'repair_busy'):
                     all_complete = False
                     continue
                 if code == 200 and body.get('status') in ('removed', 'already_removed'):
                     target['status'] = 'complete'
-                else:
+                    continue
+                if code == 409 and body.get('code') == 'stale_target':
+                    attempts = target.get('stale_attempts', 0) + 1
+                    target['stale_attempts'] = attempts
+                    if attempts >= STALE_TARGET_MAX_ATTEMPTS:
+                        log.warning(
+                            '[NZBPlayback] Exact cleanup abandoning stale target repair=%s old_uuid=%s file=%s '
+                            'after %s attempts; finishing repair without old-file cleanup',
+                            repair['id'], target.get('info_hash') or '', target.get('file_name') or '', attempts,
+                        )
+                        target['status'] = 'complete'
+                        target['skipped_cleanup'] = True
+                        continue
                     all_complete = False
-                    target['last_error'] = body.get('code') or f'HTTP {code}'
+                    target['last_error'] = 'stale_target'
+                    continue
+                all_complete = False
+                target['last_error'] = body.get('code') or f'HTTP {code}'
             conn = get_db_connection()
             try:
                 conn.execute(

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -1,0 +1,531 @@
+"""Durable, minimal state for NZB playback-failure replacement.
+
+This module deliberately owns one table.  It does not depend on the older
+experimental replacement-saga tables and never starts a new library repair.
+"""
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from database.core import get_db_connection, retry_on_db_lock
+
+log = logging.getLogger(__name__)
+_worker_lock = threading.Lock()
+ELIGIBLE_REASONS = {
+    'usenet_segment_missing', 'media_probe_failed', 'media_no_playable_stream',
+}
+
+
+def _now():
+    return datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+
+
+def _json(value, default):
+    try:
+        parsed = json.loads(value or '')
+        return parsed if isinstance(parsed, type(default)) else default
+    except Exception:
+        return default
+
+
+def normalize_release(value):
+    return re.sub(r'[^a-z0-9]+', '', (value or '').lower())
+
+
+def candidate_keys(result):
+    title = result.get('original_title') or result.get('title') or ''
+    url = result.get('nzb_url') or result.get('magnet') or ''
+    guid = str(result.get('guid') or result.get('nzb_guid') or '').strip().lower()
+    match = re.search(r'(?:id=|/)([0-9a-f]{20,})(?:[.&/?]|$)', url, re.I)
+    if match:
+        guid = match.group(1).lower()
+    segment = str(result.get('segment_id') or result.get('nzb_segment_id') or '').strip()
+    content = result.get('_prefetched_nzb') or ''
+    if content:
+        try:
+            from database.not_wanted_magnets import extract_nzb_segment_id
+            segment = segment or extract_nzb_segment_id(content) or ''
+        except Exception:
+            pass
+    return {key for key in (f't:{normalize_release(title)}' if title else '',
+                            f'g:{guid}' if guid else '',
+                            f's:{segment}' if segment else '') if key}
+
+
+def create_nzb_playback_repair_table():
+    conn = get_db_connection()
+    try:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS nzb_playback_repairs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                cli_debrid_id INTEGER NOT NULL,
+                old_info_hash TEXT NOT NULL,
+                old_entry_name TEXT NOT NULL,
+                old_file_name TEXT NOT NULL,
+                old_reason TEXT NOT NULL,
+                old_guid TEXT,
+                old_segment TEXT,
+                old_normalized_title TEXT,
+                excluded_keys_json TEXT NOT NULL DEFAULT '[]',
+                cleanup_targets_json TEXT NOT NULL DEFAULT '[]',
+                failed_job_ids_json TEXT NOT NULL DEFAULT '[]',
+                candidate_info_hash TEXT,
+                candidate_title TEXT,
+                candidate_guid TEXT,
+                candidate_segment TEXT,
+                candidate_normalized_title TEXT,
+                candidate_keys_json TEXT NOT NULL DEFAULT '[]',
+                status TEXT NOT NULL DEFAULT 'awaiting_candidate',
+                activity_id INTEGER,
+                next_attempt_at TIMESTAMP,
+                lease_owner TEXT,
+                lease_until TIMESTAMP,
+                last_error TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                completed_at TIMESTAMP
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_nzb_playback_active_item
+              ON nzb_playback_repairs(cli_debrid_id)
+              WHERE status != 'complete';
+            CREATE INDEX IF NOT EXISTS idx_nzb_playback_due
+              ON nzb_playback_repairs(status, next_attempt_at);
+        """)
+        columns = {row[1] for row in conn.execute('PRAGMA table_info(nzb_playback_repairs)')}
+        if 'lease_owner' not in columns:
+            conn.execute('ALTER TABLE nzb_playback_repairs ADD COLUMN lease_owner TEXT')
+        if 'lease_until' not in columns:
+            conn.execute('ALTER TABLE nzb_playback_repairs ADD COLUMN lease_until TIMESTAMP')
+        for column in ('old_guid', 'old_segment', 'old_normalized_title',
+                       'candidate_guid', 'candidate_segment', 'candidate_normalized_title'):
+            if column not in columns:
+                conn.execute(f'ALTER TABLE nzb_playback_repairs ADD COLUMN {column} TEXT')
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _target(entry):
+    return {
+        'entry_name': entry['entry_name'], 'file_name': entry['file_name'],
+        'info_hash': entry['info_hash'], 'cli_debrid_id': int(entry['cli_debrid_id']),
+        'reason': entry['reason'], 'status': 'pending',
+    }
+
+
+@retry_on_db_lock(max_attempts=4, initial_wait=0.1, backoff_factor=2)
+def begin_playback_repair(item, entry, triggered_by='manual'):
+    """Create repair + activity atomically before any candidate is submitted."""
+    if entry.get('reason') not in ELIGIBLE_REASONS:
+        return None
+    item_id = int(item['id'])
+    conn = get_db_connection()
+    try:
+        conn.execute('BEGIN IMMEDIATE')
+        existing = conn.execute(
+            "SELECT * FROM nzb_playback_repairs WHERE cli_debrid_id=? AND status!='complete'",
+            (item_id,),
+        ).fetchone()
+        if existing:
+            row = dict(existing)
+            targets = _json(row['cleanup_targets_json'], [])
+            exact = _target(entry)
+            if not any(t.get('info_hash') == exact['info_hash'] and
+                       t.get('file_name') == exact['file_name'] for t in targets):
+                targets.append(exact)
+            excluded = set(_json(row['excluded_keys_json'], []))
+            excluded.add(f"t:{normalize_release(entry.get('entry_name'))}")
+            conn.execute(
+                "UPDATE nzb_playback_repairs SET cleanup_targets_json=?, excluded_keys_json=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                (json.dumps(targets), json.dumps(sorted(excluded)), row['id']),
+            )
+            conn.commit()
+            return row['id']
+
+        cursor = conn.execute(
+            """INSERT INTO nzb_repair_activity
+               (item_id,title,media_type,season_number,episode_number,broken_nzb_id,
+                broken_nzb_title,outcome,triggered_by,repair_attempts,last_repair_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (item_id, item.get('title'), item.get('type'), item.get('season_number'),
+             item.get('episode_number'), entry['info_hash'], entry['entry_name'],
+             'replacement_pending', triggered_by, 0, _now()),
+        )
+        activity_id = cursor.lastrowid
+        excluded = {f"t:{normalize_release(entry['entry_name'])}"}
+        original_release = (item.get('original_scraped_torrent_title') or
+                            item.get('filled_by_title') or item.get('debrid_folder_name') or '')
+        if original_release:
+            excluded.add(f"t:{normalize_release(original_release)}")
+        if entry.get('segment_id'):
+            excluded.add(f"s:{entry['segment_id']}")
+        cursor = conn.execute(
+            """INSERT INTO nzb_playback_repairs
+               (cli_debrid_id,old_info_hash,old_entry_name,old_file_name,old_reason,
+                old_guid,old_segment,old_normalized_title,excluded_keys_json,
+                cleanup_targets_json,activity_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+            (item_id, entry['info_hash'], entry['entry_name'], entry['file_name'],
+             entry['reason'], item.get('filled_by_magnet') or '', entry.get('segment_id') or '',
+             normalize_release(original_release or entry['entry_name']), json.dumps(sorted(excluded)),
+             json.dumps([_target(entry)]), activity_id),
+        )
+        conn.commit()
+        return cursor.lastrowid
+    except sqlite3.OperationalError as exc:
+        conn.rollback()
+        if 'database is locked' in str(exc).lower():
+            raise
+        log.exception('[NZBPlayback] Could not persist repair before submission')
+        return None
+    except Exception:
+        conn.rollback()
+        log.exception('[NZBPlayback] Could not persist repair before submission')
+        return None
+    finally:
+        conn.close()
+
+
+def candidate_is_excluded(item_id, result):
+    conn = get_db_connection()
+    try:
+        row = conn.execute(
+            "SELECT excluded_keys_json FROM nzb_playback_repairs WHERE cli_debrid_id=? AND status!='complete'",
+            (item_id,),
+        ).fetchone()
+        return bool(row and candidate_keys(result) & set(_json(row[0], [])))
+    finally:
+        conn.close()
+
+
+@retry_on_db_lock(max_attempts=4, initial_wait=0.1, backoff_factor=2)
+def record_failed_candidate(item_id, result, job_id=''):
+    conn = get_db_connection()
+    try:
+        row = conn.execute(
+            "SELECT id,excluded_keys_json,failed_job_ids_json FROM nzb_playback_repairs WHERE cli_debrid_id=? AND status!='complete'",
+            (item_id,),
+        ).fetchone()
+        if not row:
+            return
+        excluded = set(_json(row[1], [])) | candidate_keys(result)
+        jobs = set(_json(row[2], []))
+        if job_id:
+            jobs.add(job_id)
+        conn.execute(
+            "UPDATE nzb_playback_repairs SET excluded_keys_json=?,failed_job_ids_json=?,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+            (json.dumps(sorted(excluded)), json.dumps(sorted(jobs)), row[0]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@retry_on_db_lock(max_attempts=4, initial_wait=0.1, backoff_factor=2)
+def set_playback_candidate(item_id, result, job_id, title):
+    keys = candidate_keys(result)
+    guid = next((key[2:] for key in keys if key.startswith('g:')), '')
+    segment = next((key[2:] for key in keys if key.startswith('s:')), '')
+    normalized = normalize_release(result.get('original_title') or result.get('title') or title)
+    conn = get_db_connection()
+    try:
+        cursor = conn.execute(
+            """UPDATE nzb_playback_repairs
+               SET candidate_info_hash=?,candidate_title=?,candidate_keys_json=?,
+                   candidate_guid=?,candidate_segment=?,candidate_normalized_title=?,
+                   status='awaiting_collection',next_attempt_at=NULL,last_error=NULL,
+                   updated_at=CURRENT_TIMESTAMP
+               WHERE cli_debrid_id=? AND status!='complete'""",
+            (job_id, title, json.dumps(sorted(keys)), guid, segment, normalized, item_id),
+        )
+        conn.commit()
+        return cursor.rowcount == 1
+    finally:
+        conn.close()
+
+
+@retry_on_db_lock(max_attempts=4, initial_wait=0.1, backoff_factor=2)
+def reject_active_candidate(item_id, job_id, reason='candidate_failed'):
+    """Return a failed provisional replacement to its exact original source."""
+    conn = get_db_connection()
+    try:
+        conn.execute('BEGIN IMMEDIATE')
+        row = conn.execute(
+            "SELECT * FROM nzb_playback_repairs WHERE cli_debrid_id=? AND status!='complete'",
+            (item_id,),
+        ).fetchone()
+        if not row or (row['candidate_info_hash'] or '').lower() != (job_id or '').lower():
+            conn.rollback()
+            return False
+        excluded = set(_json(row['excluded_keys_json'], [])) | set(_json(row['candidate_keys_json'], []))
+        failed_jobs = set(_json(row['failed_job_ids_json'], []))
+        if job_id:
+            failed_jobs.add(job_id)
+        conn.execute(
+            """UPDATE nzb_playback_repairs SET status='awaiting_candidate',candidate_info_hash=NULL,
+                      candidate_title=NULL,candidate_guid=NULL,candidate_segment=NULL,
+                      candidate_normalized_title=NULL,excluded_keys_json=?,failed_job_ids_json=?,last_error=?,
+                      next_attempt_at=NULL,lease_owner=NULL,lease_until=NULL,updated_at=CURRENT_TIMESTAMP
+               WHERE id=?""",
+            (json.dumps(sorted(excluded)), json.dumps(sorted(failed_jobs)), reason, row['id']),
+        )
+        conn.execute(
+            """UPDATE media_items SET state='Collected',filled_by_torrent_id=?,filled_by_file=?,
+                      filled_by_title=?,debrid_folder_name=? WHERE id=? AND filled_by_torrent_id=?""",
+            (f"nzb:{row['old_info_hash']}", row['old_file_name'], row['old_entry_name'],
+             row['old_entry_name'], item_id, f'nzb:{job_id}'),
+        )
+        conn.commit()
+        return True
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _mount_request(path, payload, timeout):
+    import requests
+    from utilities.settings import get_setting
+    base = get_setting('Usenet Provider', 'url', '').rstrip('/')
+    token = get_setting('Usenet Provider', 'api_token', '')
+    headers = {'Authorization': f'Bearer {token}'} if token else {}
+    try:
+        response = requests.post(base + path, json=payload, headers=headers, timeout=timeout)
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+        return response.status_code, body, ''
+    except Exception as exc:
+        return 0, {}, str(exc)
+
+
+@retry_on_db_lock(max_attempts=4, initial_wait=0.1, backoff_factor=2)
+def _schedule(repair_id, message, seconds):
+    conn = get_db_connection()
+    try:
+        when = (datetime.now(timezone.utc) + timedelta(seconds=seconds)).strftime('%Y-%m-%d %H:%M:%S')
+        conn.execute(
+            "UPDATE nzb_playback_repairs SET next_attempt_at=?,last_error=?,lease_owner=NULL,lease_until=NULL,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+            (when, str(message)[:1000], repair_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _media_item(item_id):
+    from database.database_reading import get_media_item_by_id
+    row = get_media_item_by_id(item_id)
+    return dict(row) if row else None
+
+
+def _source_uuid(item):
+    value = str(item.get('filled_by_torrent_id') or '')
+    return value[4:] if value.startswith('nzb:') else value
+
+
+def _symlink_matches(item, entry_name, file_name):
+    link = item.get('location_on_disk') or ''
+    if not link or not os.path.islink(link):
+        return False
+    target = os.path.normpath(os.path.realpath(link))
+    return os.path.basename(target) == file_name and os.path.basename(os.path.dirname(target)) == entry_name
+
+
+def _finish_activity(repair, candidate_uuid, title):
+    conn = get_db_connection()
+    try:
+        conn.execute('BEGIN IMMEDIATE')
+        conn.execute(
+            """UPDATE nzb_repair_activity SET replacement_nzb_id=?,replacement_title=?,
+                      outcome='replaced',updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+            (candidate_uuid, title, repair['activity_id']),
+        )
+        conn.execute(
+            """UPDATE nzb_playback_repairs SET status='complete',completed_at=CURRENT_TIMESTAMP,
+                      next_attempt_at=NULL,lease_owner=NULL,lease_until=NULL,last_error=NULL,
+                      updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+            (repair['id'],),
+        )
+        conn.commit()
+        return True
+    except Exception:
+        conn.rollback()
+        log.exception('[NZBPlayback] Final activity transaction failed for repair %s', repair['id'])
+        return False
+    finally:
+        conn.close()
+
+
+def process_pending_playback_repairs():
+    """Complete only already-started repairs; never scans or starts the backlog."""
+    if not _worker_lock.acquire(blocking=False):
+        return
+    try:
+        lease_owner = uuid.uuid4().hex
+        conn = get_db_connection()
+        try:
+            rows = conn.execute(
+                """SELECT * FROM nzb_playback_repairs
+                   WHERE status IN ('awaiting_collection','awaiting_verification','verified','cleanup_complete')
+                     AND (next_attempt_at IS NULL OR next_attempt_at<=CURRENT_TIMESTAMP)
+                     AND (lease_until IS NULL OR lease_until<=CURRENT_TIMESTAMP)
+                   ORDER BY updated_at LIMIT 12"""
+            ).fetchall()
+        finally:
+            conn.close()
+        for raw in rows:
+            repair = dict(raw)
+            conn = get_db_connection()
+            try:
+                claimed = conn.execute(
+                    """UPDATE nzb_playback_repairs SET lease_owner=?,lease_until=datetime('now','+10 minutes')
+                       WHERE id=? AND status IN ('awaiting_collection','awaiting_verification','verified','cleanup_complete')
+                         AND (lease_until IS NULL OR lease_until<=CURRENT_TIMESTAMP)""",
+                    (lease_owner, repair['id']),
+                ).rowcount
+                conn.commit()
+            finally:
+                conn.close()
+            if not claimed:
+                continue
+            item = _media_item(repair['cli_debrid_id'])
+            if not item or item.get('state') != 'Collected':
+                _schedule(repair['id'], 'awaiting_collection', 15)
+                continue
+            candidate = repair.get('candidate_info_hash') or ''
+            if not candidate or _source_uuid(item).lower() != candidate.lower():
+                _schedule(repair['id'], 'candidate_source_changed', 30)
+                continue
+            client = __import__('usenet', fromlist=['get_usenet_client']).get_usenet_client()
+            if not client.register_cli_ids_for_item(candidate, repair['cli_debrid_id']):
+                _schedule(repair['id'], 'replacement_not_ready', 30)
+                continue
+
+            if repair['status'] not in ('verified', 'cleanup_complete'):
+                code, body, error = _mount_request(
+                    '/api/repair/replacements/verify',
+                    {'cli_debrid_id': repair['cli_debrid_id'], 'info_hash': candidate}, 75)
+                if error or code >= 500:
+                    _schedule(repair['id'], error or f'HTTP {code}', 60)
+                    continue
+                if code == 409:
+                    _schedule(repair['id'], body.get('code') or 'repair_busy', 15)
+                    continue
+                status = body.get('status')
+                if status == 'unknown':
+                    _schedule(repair['id'], body.get('reason') or 'verification_unknown', 30)
+                    continue
+                if status == 'broken':
+                    failed = {
+                        'entry_name': body.get('entry_name'), 'file_name': body.get('file_name'),
+                        'info_hash': candidate, 'cli_debrid_id': repair['cli_debrid_id'],
+                        'reason': body.get('reason'), 'status': 'pending',
+                    }
+                    targets = _json(repair['cleanup_targets_json'], [])
+                    targets.append(failed)
+                    excluded = set(_json(repair['excluded_keys_json'], [])) | set(_json(repair['candidate_keys_json'], []))
+                    conn = get_db_connection()
+                    try:
+                        conn.execute(
+                            """UPDATE nzb_playback_repairs SET status='awaiting_candidate',
+                               cleanup_targets_json=?,excluded_keys_json=?,candidate_info_hash=NULL,
+                               candidate_title=NULL,candidate_guid=NULL,candidate_segment=NULL,
+                               candidate_normalized_title=NULL,next_attempt_at=NULL,lease_owner=NULL,lease_until=NULL,
+                               last_error=?,updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+                            (json.dumps(targets), json.dumps(sorted(excluded)), body.get('reason'), repair['id']),
+                        )
+                        conn.commit()
+                    finally:
+                        conn.close()
+                    continue
+                if status != 'healthy' or not body.get('entry_name') or not body.get('file_name'):
+                    _schedule(repair['id'], 'invalid_verification_response', 60)
+                    continue
+                if not _symlink_matches(item, body['entry_name'], body['file_name']):
+                    _schedule(repair['id'], 'replacement_symlink_not_ready', 15)
+                    continue
+                conn = get_db_connection()
+                try:
+                    conn.execute(
+                        "UPDATE nzb_playback_repairs SET status='verified',last_error=NULL,next_attempt_at=NULL,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                        (repair['id'],),
+                    )
+                    conn.commit()
+                finally:
+                    conn.close()
+                repair['status'] = 'verified'
+
+            failed_jobs = _json(repair['failed_job_ids_json'], [])
+            remaining_jobs = []
+            for failed_job_id in failed_jobs:
+                if not client.remove_nzb_exact(failed_job_id):
+                    remaining_jobs.append(failed_job_id)
+            if remaining_jobs:
+                conn = get_db_connection()
+                try:
+                    conn.execute(
+                        "UPDATE nzb_playback_repairs SET failed_job_ids_json=?,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                        (json.dumps(remaining_jobs), repair['id']),
+                    )
+                    conn.commit()
+                finally:
+                    conn.close()
+                _schedule(repair['id'], 'failed_job_cleanup_pending', 30)
+                continue
+            if failed_jobs:
+                conn = get_db_connection()
+                try:
+                    conn.execute(
+                        "UPDATE nzb_playback_repairs SET failed_job_ids_json='[]',updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                        (repair['id'],),
+                    )
+                    conn.commit()
+                finally:
+                    conn.close()
+
+            targets = _json(repair['cleanup_targets_json'], [])
+            all_complete = True
+            for target in targets:
+                if target.get('status') == 'complete':
+                    continue
+                code, body, error = _mount_request('/api/repair/replacements/ack', target, 20)
+                if error or code >= 500 or (code == 409 and body.get('code') == 'repair_busy'):
+                    all_complete = False
+                    continue
+                if code == 200 and body.get('status') in ('removed', 'already_removed'):
+                    target['status'] = 'complete'
+                else:
+                    all_complete = False
+                    target['last_error'] = body.get('code') or f'HTTP {code}'
+            conn = get_db_connection()
+            try:
+                conn.execute(
+                    "UPDATE nzb_playback_repairs SET cleanup_targets_json=?,status=?,updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                    (json.dumps(targets), 'cleanup_complete' if all_complete else 'verified', repair['id']),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+            if not all_complete:
+                _schedule(repair['id'], 'exact_cleanup_pending', 15)
+                continue
+            if not _finish_activity(repair, candidate, repair.get('candidate_title') or item.get('filled_by_title')):
+                _schedule(repair['id'], 'activity_finalization_pending', 15)
+                continue
+            try:
+                from utilities.plex_functions import plex_update_item
+                plex_update_item({'full_path': os.path.dirname(item.get('location_on_disk') or ''),
+                                  'location_on_disk': os.path.dirname(item.get('location_on_disk') or '')})
+            except Exception as exc:
+                log.warning('[NZBPlayback] Post-cleanup Plex refresh failed: %s', exc)
+    finally:
+        _worker_lock.release()

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -651,14 +651,19 @@ def process_pending_playback_repairs():
                         # item (normally prevented by has_active_exact_repair
                         # guarding the general repair engine — this is the
                         # backstop for if that race happens some other way).
-                        # Don't guess at cleanup for a candidate we no longer
-                        # own; just stop, and let a fresh health scan pick
-                        # the original broken file back up if it's still
-                        # actually broken.
+                        # Don't guess at cleanup for the NEW candidate we no
+                        # longer own, but the ORIGINAL broken file this
+                        # repair started against is still known exactly
+                        # (cleanup_targets_json) and independent of whatever
+                        # replaced it — hand it to the same background
+                        # cleanup retry a normal successful repair uses,
+                        # rather than leaving it referenced nowhere.
                         conn = get_db_connection()
                         try:
                             conn.execute(
                                 """UPDATE nzb_playback_repairs SET status='complete',completed_at=CURRENT_TIMESTAMP,
+                                   cleanup_status='pending',
+                                   cleanup_first_pending_at=COALESCE(cleanup_first_pending_at,CURRENT_TIMESTAMP),
                                    next_attempt_at=NULL,lease_owner=NULL,lease_until=NULL,
                                    last_error='superseded_externally',updated_at=CURRENT_TIMESTAMP WHERE id=?""",
                                 (repair['id'],),
@@ -668,7 +673,7 @@ def process_pending_playback_repairs():
                             conn.close()
                         log.warning(
                             '[NZBPlayback] Item %s replaced by something outside this repair (now %s); '
-                            'stopping without cleanup repair=%s',
+                            'deferring original old-file cleanup to background retry repair=%s',
                             repair['cli_debrid_id'], current_source, repair['id'],
                         )
                         continue

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -367,10 +367,25 @@ def _source_uuid(item):
 
 
 def _symlink_matches(item, entry_name, file_name):
+    """Confirm location_on_disk actually points at the given replacement file.
+
+    Symlinked/Local mode: location_on_disk is a cli_debrid-created symlink (or,
+    on Windows, a hardlink — os.path.islink() is False for those too) whose
+    target reveals the real mounted path.
+
+    Plex mode: location_on_disk is already the real mounted file path as
+    reported by Plex's own API — there is no cli_debrid-owned symlink to
+    resolve, so it's checked directly.
+    """
     link = item.get('location_on_disk') or ''
-    if not link or not os.path.islink(link):
+    if not link:
         return False
-    target = os.path.normpath(os.path.realpath(link))
+    if os.path.islink(link):
+        target = os.path.normpath(os.path.realpath(link))
+    elif os.path.exists(link):
+        target = os.path.normpath(link)
+    else:
+        return False
     return os.path.basename(target) == file_name and os.path.basename(os.path.dirname(target)) == entry_name
 
 

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -58,6 +58,13 @@ VERIFY_BUSY_MAX_ATTEMPTS = 240     # ~60 min at the 15s 409 cadence
 CANDIDATE_SEARCH_VISIBILITY_ATTEMPTS = 24        # ~2h at the 5-minute search cadence
 CANDIDATE_SEARCH_SLOW_CADENCE_SECONDS = 1800     # 30 min, once past the visibility threshold
 CANDIDATE_SEARCH_GIVE_UP_DAYS = 7
+# A submitted candidate's info_hash can stop matching the item's current
+# filled_by_torrent_id if something outside this repair changes it —
+# normally prevented by has_active_exact_repair() guarding the general
+# repair engine, but kept as a backstop in case that race happens for some
+# other reason. ~5 min at the 30s mismatch cadence, matching
+# VERIFY_UNKNOWN_MAX_ATTEMPTS.
+CANDIDATE_SOURCE_MISMATCH_MAX_ATTEMPTS = 10
 
 
 def _now():
@@ -154,7 +161,7 @@ def create_nzb_playback_repair_table():
             if column not in columns:
                 conn.execute(f'ALTER TABLE nzb_playback_repairs ADD COLUMN {column} TEXT')
         for column in ('verify_unknown_attempts', 'verify_stale_target_attempts', 'verify_busy_attempts',
-                       'candidate_search_attempts'):
+                       'candidate_search_attempts', 'source_mismatch_attempts'):
             if column not in columns:
                 conn.execute(f'ALTER TABLE nzb_playback_repairs ADD COLUMN {column} INTEGER NOT NULL DEFAULT 0')
         if 'candidate_search_stuck_since' not in columns:
@@ -312,7 +319,7 @@ def set_playback_candidate(item_id, result, job_id, title):
                    candidate_guid=?,candidate_segment=?,candidate_normalized_title=?,
                    status='awaiting_collection',next_attempt_at=NULL,last_error=NULL,
                    verify_unknown_attempts=0,verify_stale_target_attempts=0,verify_busy_attempts=0,
-                   candidate_search_attempts=0,candidate_search_stuck_since=NULL,
+                   candidate_search_attempts=0,candidate_search_stuck_since=NULL,source_mismatch_attempts=0,
                    updated_at=CURRENT_TIMESTAMP
                WHERE cli_debrid_id=? AND status!='complete'""",
             (job_id, title, json.dumps(sorted(keys)), guid, segment, normalized, item_id),
@@ -481,6 +488,7 @@ def _reject_verification_candidate(repair, reason):
                excluded_keys_json=?,candidate_info_hash=NULL,candidate_title=NULL,
                candidate_guid=NULL,candidate_segment=NULL,candidate_normalized_title=NULL,
                verify_unknown_attempts=0,verify_stale_target_attempts=0,verify_busy_attempts=0,
+               source_mismatch_attempts=0,
                next_attempt_at=NULL,lease_owner=NULL,lease_until=NULL,
                last_error=?,updated_at=CURRENT_TIMESTAMP WHERE id=?""",
             (json.dumps(sorted(excluded)), reason, repair['id']),
@@ -635,6 +643,37 @@ def process_pending_playback_repairs():
                 continue
             candidate = repair.get('candidate_info_hash') or ''
             if not candidate or _source_uuid(item).lower() != candidate.lower():
+                attempts = _bump_attempt(repair['id'], 'source_mismatch_attempts')
+                if attempts >= CANDIDATE_SOURCE_MISMATCH_MAX_ATTEMPTS:
+                    current_source = _source_uuid(item).lower()
+                    if current_source and current_source != (repair['old_info_hash'] or '').lower():
+                        # Something outside this repair already replaced the
+                        # item (normally prevented by has_active_exact_repair
+                        # guarding the general repair engine — this is the
+                        # backstop for if that race happens some other way).
+                        # Don't guess at cleanup for a candidate we no longer
+                        # own; just stop, and let a fresh health scan pick
+                        # the original broken file back up if it's still
+                        # actually broken.
+                        conn = get_db_connection()
+                        try:
+                            conn.execute(
+                                """UPDATE nzb_playback_repairs SET status='complete',completed_at=CURRENT_TIMESTAMP,
+                                   next_attempt_at=NULL,lease_owner=NULL,lease_until=NULL,
+                                   last_error='superseded_externally',updated_at=CURRENT_TIMESTAMP WHERE id=?""",
+                                (repair['id'],),
+                            )
+                            conn.commit()
+                        finally:
+                            conn.close()
+                        log.warning(
+                            '[NZBPlayback] Item %s replaced by something outside this repair (now %s); '
+                            'stopping without cleanup repair=%s',
+                            repair['cli_debrid_id'], current_source, repair['id'],
+                        )
+                        continue
+                    _reject_verification_candidate(repair, 'candidate_source_changed_max_attempts')
+                    continue
                 _schedule(repair['id'], 'candidate_source_changed', 30)
                 continue
             client = __import__('usenet', fromlist=['get_usenet_client']).get_usenet_client()

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -450,7 +450,7 @@ def process_pending_playback_repairs():
         try:
             rows = conn.execute(
                 """SELECT * FROM nzb_playback_repairs
-                   WHERE status IN ('awaiting_collection','awaiting_verification','verified','cleanup_complete')
+                   WHERE status IN ('awaiting_candidate','awaiting_collection','awaiting_verification','verified','cleanup_complete')
                      AND (next_attempt_at IS NULL OR next_attempt_at<=CURRENT_TIMESTAMP)
                      AND (lease_until IS NULL OR lease_until<=CURRENT_TIMESTAMP)
                    ORDER BY updated_at LIMIT 12"""
@@ -463,7 +463,7 @@ def process_pending_playback_repairs():
             try:
                 claimed = conn.execute(
                     """UPDATE nzb_playback_repairs SET lease_owner=?,lease_until=datetime('now','+10 minutes')
-                       WHERE id=? AND status IN ('awaiting_collection','awaiting_verification','verified','cleanup_complete')
+                       WHERE id=? AND status IN ('awaiting_candidate','awaiting_collection','awaiting_verification','verified','cleanup_complete')
                          AND (lease_until IS NULL OR lease_until<=CURRENT_TIMESTAMP)""",
                     (lease_owner, repair['id']),
                 ).rowcount
@@ -478,6 +478,27 @@ def process_pending_playback_repairs():
                 repair.get('candidate_info_hash') or '',
             )
             item = _media_item(repair['cli_debrid_id'])
+            if repair['status'] == 'awaiting_candidate':
+                # The last accepted candidate was itself verified broken. Reuse
+                # the exact same scrape/submit/exclude pipeline that produced
+                # the first candidate to keep searching until a healthy
+                # replacement is found, instead of stalling here forever —
+                # nothing else in this module reads this status.
+                if not item:
+                    _schedule(repair['id'], 'item_missing', 300)
+                    continue
+                from usenet.repair_engine import find_and_submit_playback_candidate
+                outcome = find_and_submit_playback_candidate(repair, item)
+                log.info(
+                    '[NZBPlayback] Candidate search retry repair=%s item=%s outcome=%s',
+                    repair['id'], repair['cli_debrid_id'], outcome,
+                )
+                # set_playback_candidate() (called on a 'submitted' outcome)
+                # updates status but doesn't clear the lease this pass just
+                # took — always reschedule so the row isn't stuck holding
+                # that 10-minute claim lease before collection-wait can run.
+                _schedule(repair['id'], outcome, 15 if outcome == 'submitted' else 300)
+                continue
             if not item or item.get('state') != 'Collected':
                 log.debug(
                     '[NZBPlayback] Waiting for collection repair=%s item=%s state=%s',

--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -800,8 +800,26 @@ def process_pending_playback_repairs():
                     all_actionable = False
                     target['last_error'] = 'stale_target'
                     continue
+                attempts = target.get('generic_attempts', 0) + 1
+                target['generic_attempts'] = attempts
+                reason = body.get('code') or f'HTTP {code}'
+                if attempts >= STALE_TARGET_MAX_ATTEMPTS:
+                    # Same reasoning as the stale_target case above: the new
+                    # file is already confirmed healthy, so a persistent
+                    # non-stale, non-5xx cleanup failure shouldn't hold the
+                    # repair's own finalization hostage either — defer to
+                    # the slower background retry instead of retrying
+                    # inline forever.
+                    log.warning(
+                        '[NZBPlayback] Exact cleanup deferring persistent failure repair=%s old_uuid=%s file=%s '
+                        'reason=%s to background retry after %s attempts; finalizing repair now',
+                        repair['id'], target.get('info_hash') or '', target.get('file_name') or '', reason, attempts,
+                    )
+                    target['deferred'] = True
+                    target['last_error'] = reason
+                    continue
                 all_actionable = False
-                target['last_error'] = body.get('code') or f'HTTP {code}'
+                target['last_error'] = reason
             has_deferred = any(t.get('status') != 'complete' and t.get('deferred') for t in targets)
             conn = get_db_connection()
             try:

--- a/database/nzb_repair_activity.py
+++ b/database/nzb_repair_activity.py
@@ -35,6 +35,7 @@ def create_nzb_repair_activity_table() -> None:
                 repair_attempts      INTEGER DEFAULT 0,
                 last_repair_at       TIMESTAMP,
                 next_repair_at       TIMESTAMP,
+                updated_at           TIMESTAMP,
                 created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
             CREATE INDEX IF NOT EXISTS idx_nzb_repair_created
@@ -57,6 +58,10 @@ def create_nzb_repair_activity_table() -> None:
             pass
         try:
             conn.execute("ALTER TABLE nzb_repair_activity ADD COLUMN next_repair_at TIMESTAMP")
+        except Exception:
+            pass
+        try:
+            conn.execute("ALTER TABLE nzb_repair_activity ADD COLUMN updated_at TIMESTAMP")
         except Exception:
             pass
         conn.commit()

--- a/database/schema_management.py
+++ b/database/schema_management.py
@@ -4,6 +4,7 @@ from .torrent_tracking import create_torrent_tracking_table
 from .content_source_retry import create_retry_queue_table
 from .upgrade_hub_activity import create_upgrade_hub_activity_table
 from .nzb_repair_activity import create_nzb_repair_activity_table
+from .nzb_playback_repair import create_nzb_playback_repair_table
 import sqlite3
 import os
 
@@ -14,6 +15,7 @@ def create_database():
     create_retry_queue_table()
     create_upgrade_hub_activity_table()
     create_nzb_repair_activity_table()
+    create_nzb_playback_repair_table()
     #TODO: create_upgrading_table()
 
     # Add statistics-specific indexes

--- a/database/schema_management.py
+++ b/database/schema_management.py
@@ -854,6 +854,10 @@ def verify_database():
     migrate_schema()
     create_torrent_tracking_table()
     create_nzb_repair_activity_table()
+    # verify_database() is the startup path for existing installations.
+    # create_database() is only used for a brand-new database, so keeping the
+    # playback table solely there leaves upgraded databases without it.
+    create_nzb_playback_repair_table()
 
     # Ensure overlay_removal_queue table exists (handles post-delete without restart)
     try:

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -527,6 +527,7 @@ class ProgramRunner:
             'task_update_queue_views',
             'task_send_notifications',
             'task_nzb_health_check',
+            'task_nzb_playback_repair_completion',
             # Essential Periodic Tasks
             'task_check_service_connectivity',
             'task_heartbeat',

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -327,6 +327,7 @@ class ProgramRunner:
             'task_push_pending_climount_tags': 5 * 60, # Run every 5 minutes — catches tags changed on cli_debrid side only
             'task_nzb_health_check': 10,             # Run every 10 seconds — polls NZB items in Adding
             'task_nzb_playback_repair_completion': 15, # Confirm only already-started playback repairs
+            'task_nzb_playback_cleanup_retry': 20 * 60, # Background retry for old-file cleanup deferred after finalization
             'task_backfill_plex_guids': 24 * 60 * 60,    # Run once (disabled by default)
             'task_backfill_plex_ms_item_id': 24 * 60 * 60, # Run once (disabled by default)
             # --- END EDIT ---
@@ -528,6 +529,7 @@ class ProgramRunner:
             'task_send_notifications',
             'task_nzb_health_check',
             'task_nzb_playback_repair_completion',
+            'task_nzb_playback_cleanup_retry',
             # Essential Periodic Tasks
             'task_check_service_connectivity',
             'task_heartbeat',
@@ -4711,6 +4713,15 @@ class ProgramRunner:
             process_pending_playback_repairs()
         except Exception as exc:
             logging.error('[NZBPlayback] Completion task failed: %s', exc, exc_info=True)
+
+    def task_nzb_playback_cleanup_retry(self):
+        """Slow-cadence background retry for old-file cleanup deferred by the
+        fast completion worker — repairs already finalized as replaced."""
+        try:
+            from database.nzb_playback_repair import retry_deferred_playback_cleanups
+            retry_deferred_playback_cleanups()
+        except Exception as exc:
+            logging.error('[NZBPlayback] Cleanup retry task failed: %s', exc, exc_info=True)
 
     def task_repair_broken_nzbs(self, triggered_by: str = 'scheduled'):
         """Scan cli_mount for broken NZBs and attempt to repair them via re-scrape."""

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -326,6 +326,7 @@ class ProgramRunner:
             'task_sync_cli_mount_changes': 5 * 60, # Run every 5 minutes
             'task_push_pending_climount_tags': 5 * 60, # Run every 5 minutes — catches tags changed on cli_debrid side only
             'task_nzb_health_check': 10,             # Run every 10 seconds — polls NZB items in Adding
+            'task_nzb_playback_repair_completion': 15, # Confirm only already-started playback repairs
             'task_backfill_plex_guids': 24 * 60 * 60,    # Run once (disabled by default)
             'task_backfill_plex_ms_item_id': 24 * 60 * 60, # Run once (disabled by default)
             # --- END EDIT ---
@@ -3574,6 +3575,19 @@ class ProgramRunner:
                         logging.debug(f'[NZB] {torrent_id} still queued/unknown — waiting')
                         continue
                     elif progress == -2:
+                        try:
+                            from database.nzb_playback_repair import reject_active_candidate
+                            if reject_active_candidate(item_id, job_id, 'provider_job_missing'):
+                                logging.warning(
+                                    '[NZBPlayback] Provisional candidate %s disappeared; original retained and candidate excluded',
+                                    job_id,
+                                )
+                                adding_queue.remove_item(item)
+                                continue
+                        except Exception as _playback_ghost_err:
+                            logging.error('[NZBPlayback] Could not persist missing candidate %s: %s',
+                                          job_id, _playback_ghost_err, exc_info=True)
+                            continue
                         # Ghost job — never existed in cli_mount or already purged.
                         # Move primary item AND all siblings to Wanted (not retry in Adding)
                         # so they re-scrape fresh. Do NOT retry from scrape_results here
@@ -3603,6 +3617,19 @@ class ProgramRunner:
                                 logging.error(f'[NZB] Failed to move ghost item {_gi.get("id")} to Wanted: {_gi_err}')
                         continue
                     elif progress == -1:
+                        try:
+                            from database.nzb_playback_repair import reject_active_candidate
+                            if reject_active_candidate(item_id, job_id, 'provider_job_failed'):
+                                logging.warning(
+                                    '[NZBPlayback] Provisional candidate %s failed; original retained and candidate excluded',
+                                    job_id,
+                                )
+                                adding_queue.remove_item(item)
+                                continue
+                        except Exception as _playback_fail_err:
+                            logging.error('[NZBPlayback] Could not persist failed candidate %s: %s',
+                                          job_id, _playback_fail_err, exc_info=True)
+                            continue
                         logging.warning(f'[NZB] {torrent_id} failed in cli_mount — adding to not-wanted and moving back to Scraping')
                         try:
                             from database.not_wanted_magnets import add_to_not_wanted_nzb_guid as _add_guid, add_to_not_wanted_nzb_segment as _add_seg
@@ -3734,6 +3761,19 @@ class ProgramRunner:
                             except Exception:
                                 pass
                             logging.debug(f'[NZB] {torrent_id} progress={progress}% — waiting')
+                            continue
+                        try:
+                            from database.nzb_playback_repair import reject_active_candidate
+                            if reject_active_candidate(item_id, job_id, 'provider_job_timeout'):
+                                logging.warning(
+                                    '[NZBPlayback] Provisional candidate %s timed out; original retained and candidate excluded',
+                                    job_id,
+                                )
+                                adding_queue.remove_item(item)
+                                continue
+                        except Exception as _playback_timeout_err:
+                            logging.error('[NZBPlayback] Could not persist timed-out candidate %s: %s',
+                                          job_id, _playback_timeout_err, exc_info=True)
                             continue
                         # Download timed out — treat like a failed job: add URL to not-wanted,
                         # delete from cli_mount, try next scrape result or move to Wanted.
@@ -4662,6 +4702,14 @@ class ProgramRunner:
 
         except Exception as e:
             logging.error(f'[PlexGUIDBackfill] Task error: {e}', exc_info=True)
+
+    def task_nzb_playback_repair_completion(self):
+        """Verify and clean only active NZB playback repairs; never scans the backlog."""
+        try:
+            from database.nzb_playback_repair import process_pending_playback_repairs
+            process_pending_playback_repairs()
+        except Exception as exc:
+            logging.error('[NZBPlayback] Completion task failed: %s', exc, exc_info=True)
 
     def task_repair_broken_nzbs(self, triggered_by: str = 'scheduled'):
         """Scan cli_mount for broken NZBs and attempt to repair them via re-scrape."""
@@ -10279,4 +10327,3 @@ def run_program():
 
 if __name__ == "__main__":
     run_program()
-

--- a/templates/debrid_manager.html
+++ b/templates/debrid_manager.html
@@ -4479,6 +4479,9 @@ function _buildOutcomeTooltip(r) {
             lines.push('Broken file successfully replaced with a new NZB download.');
             if (r.replacement_title) lines.push('New: ' + r.replacement_title);
             break;
+        case 'replacement_pending':
+            lines.push('A candidate is being collected and must pass article and playback validation before cleanup.');
+            break;
         case 'reinserted':
             lines.push('cli_mount link resolver re-triggered for this entry.');
             break;
@@ -4523,11 +4526,12 @@ function _usenetRenderActivity(rows, container, pagination) {
 
     rows.forEach((r, idx) => {
         const bg = idx % 2 === 0 ? 'transparent' : 'rgba(128,128,128,0.04)';
-        const outcomeColor = r.outcome === 'replaced' ? '#00d4aa' : r.outcome === 'not_found' ? '#ffaa44' : r.outcome === 'plex_deleted' ? '#4488ff' : r.outcome === 'reinserted' ? '#a78bfa' : '#ff4444';
-        const outcomeLabel = r.outcome === 'replaced' ? 'Replaced' : r.outcome === 'not_found' ? 'Not Found' : r.outcome === 'plex_deleted' ? 'Plex Deleted' : r.outcome === 'reinserted' ? 'Re-inserted' : (r.outcome || '—');
+        const outcomeColor = r.outcome === 'replaced' ? '#00d4aa' : r.outcome === 'replacement_pending' ? '#ffaa44' : r.outcome === 'not_found' ? '#ffaa44' : r.outcome === 'plex_deleted' ? '#4488ff' : r.outcome === 'reinserted' ? '#a78bfa' : '#ff4444';
+        const outcomeLabel = r.outcome === 'replaced' ? 'Replaced' : r.outcome === 'replacement_pending' ? 'Pending verification' : r.outcome === 'not_found' ? 'Not Found' : r.outcome === 'plex_deleted' ? 'Plex Deleted' : r.outcome === 'reinserted' ? 'Re-inserted' : (r.outcome || '—');
         const outcomeTooltip = _buildOutcomeTooltip(r);
         const epSub = r.season_number ? `<br><span style="font-size:11px;color:#888">S${String(r.season_number).padStart(2,'0')}E${String(r.episode_number||0).padStart(2,'0')}</span>` : '';
-        const ts = r.created_at ? new Date(r.created_at + (r.created_at.endsWith('Z') ? '' : 'Z')).toLocaleString() : '—';
+        const activityTime = r.updated_at || r.created_at;
+        const ts = activityTime ? new Date(activityTime + (activityTime.endsWith('Z') ? '' : 'Z')).toLocaleString() : '—';
         const brokenTitle = r.broken_nzb_title || r.broken_nzb_id || '—';
         const replTitle = (r.replacement_title && r.replacement_title !== '—') ? r.replacement_title : null;
         const candidateCell = _renderActivityCandidateCell(brokenTitle, replTitle, r.broken_nzb_id);

--- a/tests/test_climount_client_remove.py
+++ b/tests/test_climount_client_remove.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Unit tests for CliMountClient.remove_nzb_exact / remove_nzb 404 handling.
+
+routes.api_tracker.api.delete() calls response.raise_for_status(), so an
+error response (4xx/5xx) surfaces as a raised exception carrying a
+`.response` with the real status code, not a returned Response object.
+These tests simulate that exactly and confirm a 404 ("already gone") is
+treated as success rather than falling through to the generic-failure path.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class _FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+class _FakeHTTPError(Exception):
+    def __init__(self, status_code):
+        super().__init__(f'{status_code} Client Error')
+        self.response = _FakeResponse(status_code)
+
+
+def _load(status_map, connection_error_urls=frozenset()):
+    """Load climount_client.py fresh with routes.api_tracker.api.delete()
+    stubbed to mimic raise_for_status(): a mapped status >=400 raises
+    _FakeHTTPError, anything else returns a Response with that status.
+    """
+    if 'utilities' not in sys.modules:
+        sys.modules['utilities'] = types.ModuleType('utilities')
+    uss = types.ModuleType('utilities.settings')
+    uss.get_setting = lambda *a, **k: {'enabled': True, 'url': 'http://x:8383', 'api_token': 't'}
+    sys.modules['utilities.settings'] = uss
+
+    if 'routes' not in sys.modules:
+        sys.modules['routes'] = types.ModuleType('routes')
+    rta = types.ModuleType('routes.api_tracker')
+    calls = []
+
+    def fake_delete(url, **kwargs):
+        calls.append(url)
+        if url in connection_error_urls:
+            raise ConnectionError('connection refused')
+        status = status_map.get(url, 200)
+        if status >= 400:
+            raise _FakeHTTPError(status)
+        return _FakeResponse(status)
+
+    rta.api = types.SimpleNamespace(delete=fake_delete, get=None, post=None)
+    sys.modules['routes.api_tracker'] = rta
+
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                         'usenet', 'climount_client.py')
+    spec = importlib.util.spec_from_file_location('climount_client_remove_test', path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m, calls
+
+
+class TestRemoveNzbExact(unittest.TestCase):
+    def test_404_is_treated_as_already_removed(self):
+        url = 'http://x:8383/api/browse/torrents/stale-hash'
+        m, calls = _load(status_map={url: 404})
+        client = m.CliMountClient()
+        self.assertTrue(client.remove_nzb_exact('stale-hash'))
+        self.assertEqual(calls, [url])
+
+    def test_200_is_success(self):
+        url = 'http://x:8383/api/browse/torrents/live-hash'
+        m, _ = _load(status_map={url: 200})
+        client = m.CliMountClient()
+        self.assertTrue(client.remove_nzb_exact('live-hash'))
+
+    def test_500_is_failure(self):
+        url = 'http://x:8383/api/browse/torrents/broken-hash'
+        m, _ = _load(status_map={url: 500})
+        client = m.CliMountClient()
+        self.assertFalse(client.remove_nzb_exact('broken-hash'))
+
+    def test_connection_error_is_failure(self):
+        url = 'http://x:8383/api/browse/torrents/unreachable-hash'
+        m, _ = _load(status_map={}, connection_error_urls={url})
+        client = m.CliMountClient()
+        self.assertFalse(client.remove_nzb_exact('unreachable-hash'))
+
+
+class TestRemoveNzb(unittest.TestCase):
+    def test_primary_404_is_treated_as_already_gone(self):
+        url = 'http://x:8383/api/browse/torrents/stale-hash'
+        m, calls = _load(status_map={url: 404})
+        client = m.CliMountClient()
+        self.assertTrue(client.remove_nzb('stale-hash'))
+        # Only the primary browse-delete should fire — no fallback needed.
+        self.assertEqual(calls, [url])
+
+    def test_primary_500_falls_back_to_queue_delete(self):
+        primary = 'http://x:8383/api/browse/torrents/broken-hash'
+        fallback = 'http://x:8383/api/torrents'
+        m, calls = _load(status_map={primary: 500, fallback: 200})
+        client = m.CliMountClient()
+        self.assertTrue(client.remove_nzb('broken-hash'))
+        self.assertEqual(calls, [primary, fallback])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -154,6 +154,74 @@ class TestNZBPlaybackRepair(unittest.TestCase):
         self.assertEqual(repair['status'], 'awaiting_candidate')
         self.assertIn('new-uuid', repair['failed_job_ids_json'])
 
+    def _install_fake_repair_engine(self, func):
+        usenet_module = sys.modules.get('usenet') or types.ModuleType('usenet')
+        repair_engine_module = types.ModuleType('usenet.repair_engine')
+        repair_engine_module.find_and_submit_playback_candidate = func
+        usenet_module.repair_engine = repair_engine_module
+        old_usenet = sys.modules.get('usenet')
+        old_repair_engine = sys.modules.get('usenet.repair_engine')
+        sys.modules['usenet'] = usenet_module
+        sys.modules['usenet.repair_engine'] = repair_engine_module
+        def _restore():
+            if old_usenet is not None:
+                sys.modules['usenet'] = old_usenet
+            else:
+                sys.modules.pop('usenet', None)
+            if old_repair_engine is not None:
+                sys.modules['usenet.repair_engine'] = old_repair_engine
+            else:
+                sys.modules.pop('usenet.repair_engine', None)
+        self.addCleanup(_restore)
+
+    def test_awaiting_candidate_reuses_search_pipeline_on_success(self):
+        """A candidate found broken must go back through the same search
+        pipeline automatically — status='awaiting_candidate' is not a
+        dead end — and a successful re-submission should be rescheduled
+        quickly rather than sitting on the claim's 10-minute lease."""
+        playback.begin_playback_repair(self.item, self.target)
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['status'], 'awaiting_candidate')
+
+        calls = []
+
+        def fake_retry(repair_row, item):
+            calls.append((repair_row['id'], item['id']))
+            return 'submitted'
+
+        self._install_fake_repair_engine(fake_retry)
+        old_item = playback._media_item
+        playback._media_item = lambda _id: dict(self.item)
+        self.addCleanup(lambda: setattr(playback, '_media_item', old_item))
+
+        playback.process_pending_playback_repairs()
+
+        self.assertEqual(calls, [(repair['id'], 7)])
+        with self.connect() as conn:
+            updated = conn.execute('SELECT * FROM nzb_playback_repairs WHERE id=?', (repair['id'],)).fetchone()
+        self.assertEqual(updated['last_error'], 'submitted')
+        self.assertIsNotNone(updated['next_attempt_at'])
+        self.assertIsNone(updated['lease_until'])
+
+    def test_awaiting_candidate_reschedules_when_no_replacement_found(self):
+        playback.begin_playback_repair(self.item, self.target)
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+
+        self._install_fake_repair_engine(lambda repair_row, item: 'no_replacement')
+        old_item = playback._media_item
+        playback._media_item = lambda _id: dict(self.item)
+        self.addCleanup(lambda: setattr(playback, '_media_item', old_item))
+
+        playback.process_pending_playback_repairs()
+
+        with self.connect() as conn:
+            updated = conn.execute('SELECT * FROM nzb_playback_repairs WHERE id=?', (repair['id'],)).fetchone()
+        self.assertEqual(updated['status'], 'awaiting_candidate')
+        self.assertEqual(updated['last_error'], 'no_replacement')
+        self.assertIsNotNone(updated['next_attempt_at'])
+
     def test_healthy_candidate_cleans_exact_target_then_finalizes_activity(self):
         playback.begin_playback_repair(self.item, self.target)
         with self.connect() as conn:

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -708,7 +708,10 @@ class TestNZBPlaybackRepair(unittest.TestCase):
     def test_source_mismatch_stops_without_cleanup_when_superseded_externally(self):
         """If the item now points at neither our candidate nor the original
         broken hash, something else already replaced it (e.g. the general
-        repair engine winning a race) — stop without guessing at cleanup."""
+        repair engine winning a race) — stop guessing at the NEW candidate,
+        but still hand the ORIGINAL broken file's cleanup (known exactly,
+        independent of whatever replaced it) to the background retry rather
+        than leaving it referenced nowhere."""
         self._prep_verifying_candidate()
         with self.connect() as conn:
             conn.execute("UPDATE media_items SET filled_by_torrent_id='nzb:someone-elses-uuid'")
@@ -726,10 +729,40 @@ class TestNZBPlaybackRepair(unittest.TestCase):
         self.assertEqual(repair['status'], 'complete')
         self.assertEqual(repair['last_error'], 'superseded_externally')
         self.assertIsNone(repair['next_attempt_at'])
-        # Must not touch cleanup_targets_json — no cleanup attempt for a
-        # candidate this repair no longer owns.
+        # Handed off to the background cleanup retry, same as a normal
+        # successful repair — not left dangling with nothing watching it.
+        self.assertEqual(repair['cleanup_status'], 'pending')
+        self.assertIsNotNone(repair['cleanup_first_pending_at'])
         targets = _json_module.loads(repair['cleanup_targets_json'])
         self.assertEqual(targets[0]['status'], 'pending')
+
+    def test_superseded_externally_cleanup_is_picked_up_by_background_retry(self):
+        """The deferred cleanup queued by the superseded_externally path
+        must actually be reachable by retry_deferred_playback_cleanups,
+        not just flagged and forgotten."""
+        self._prep_verifying_candidate()
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET filled_by_torrent_id='nzb:someone-elses-uuid'")
+            conn.commit()
+        for _ in range(playback.CANDIDATE_SOURCE_MISMATCH_MAX_ATTEMPTS):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['last_error'], 'superseded_externally')
+
+        old_request = playback._mount_request
+        playback._mount_request = lambda path, payload, timeout: (200, {'status': 'removed'}, '')
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+
+        playback.retry_deferred_playback_cleanups()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['cleanup_status'], 'complete')
+        targets = _json_module.loads(repair['cleanup_targets_json'])
+        self.assertEqual(targets[0]['status'], 'complete')
 
 
 if __name__ == '__main__':

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -288,6 +288,125 @@ class TestNZBPlaybackRepair(unittest.TestCase):
         self.assertEqual(repair['failed_job_ids_json'], '[]')
         self.assertEqual(repair['failed_job_attempts_json'], '{}')
 
+    def test_persistent_stale_target_defers_to_background_cleanup_retry(self):
+        """A persistently-stale exact-cleanup ack must not block the repair
+        from finalizing as replaced — it should defer the old-file cleanup to
+        the background retry instead of blocking or abandoning it outright."""
+        playback.begin_playback_repair(self.item, self.target)
+        candidate = {'title': 'Working.Release', 'guid': 'GUID-3'}
+        playback.set_playback_candidate(7, candidate, 'new-uuid', 'Working.Release')
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET state='Collected',filled_by_torrent_id='nzb:new-uuid',filled_by_file='new.mkv'")
+
+        client = _Client()
+        usenet_module = types.ModuleType('usenet')
+        usenet_module.get_usenet_client = lambda: client
+        old_usenet = sys.modules.get('usenet')
+        sys.modules['usenet'] = usenet_module
+        self.addCleanup(lambda: sys.modules.__setitem__('usenet', old_usenet) if old_usenet else sys.modules.pop('usenet', None))
+        old_item = playback._media_item
+        old_symlink = playback._symlink_matches
+        old_request = playback._mount_request
+        playback._media_item = lambda _id: dict(self.connect().execute('SELECT * FROM media_items WHERE id=7').fetchone())
+        playback._symlink_matches = lambda *args: True
+
+        ack_should_succeed = {'value': False}
+
+        def request(path, payload, timeout):
+            if path.endswith('/verify'):
+                return 200, {'status': 'healthy', 'entry_name': 'Working.Release', 'file_name': 'new.mkv'}, ''
+            if ack_should_succeed['value']:
+                return 200, {'status': 'removed'}, ''
+            return 409, {'code': 'stale_target'}, ''
+
+        playback._mount_request = request
+        self.addCleanup(lambda: setattr(playback, '_media_item', old_item))
+        self.addCleanup(lambda: setattr(playback, '_symlink_matches', old_symlink))
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+        plex_module = types.ModuleType('utilities.plex_functions')
+        plex_module.plex_update_item = lambda item: True
+        old_plex = sys.modules.get('utilities.plex_functions')
+        sys.modules['utilities.plex_functions'] = plex_module
+        self.addCleanup(lambda: sys.modules.__setitem__('utilities.plex_functions', old_plex) if old_plex else sys.modules.pop('utilities.plex_functions', None))
+
+        for attempt in range(1, playback.STALE_TARGET_MAX_ATTEMPTS):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+            self.assertNotEqual(repair['status'], 'complete', f'should not complete after attempt {attempt}')
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+
+        # The attempt that hits STALE_TARGET_MAX_ATTEMPTS must defer cleanup
+        # and finalize the repair as replaced in the SAME pass — not block on
+        # or permanently abandon the old-file cleanup.
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+            activity = conn.execute(
+                'SELECT * FROM nzb_repair_activity WHERE id=?', (repair['activity_id'],)
+            ).fetchone()
+        self.assertEqual(repair['status'], 'complete')
+        self.assertEqual(activity['outcome'], 'replaced')
+        self.assertEqual(repair['cleanup_status'], 'pending')
+        self.assertIsNotNone(repair['cleanup_first_pending_at'])
+        targets = _json_module.loads(repair['cleanup_targets_json'])
+        self.assertEqual(len(targets), 1)
+        self.assertTrue(targets[0]['deferred'])
+        self.assertNotEqual(targets[0]['status'], 'complete')
+
+        # Background retry keeps failing the same way — must NOT mark it
+        # complete or abandoned yet; just reschedule further out.
+        playback.retry_deferred_playback_cleanups()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['cleanup_status'], 'pending')
+        self.assertIsNotNone(repair['next_attempt_at'])
+
+        # Once decypharr stops returning stale_target, the background retry
+        # (running independently of the fast completion loop) finishes the
+        # old-file cleanup without needing the repair to be reopened.
+        ack_should_succeed['value'] = True
+        with self.connect() as conn:
+            conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+            conn.commit()
+        playback.retry_deferred_playback_cleanups()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['cleanup_status'], 'complete')
+        targets = _json_module.loads(repair['cleanup_targets_json'])
+        self.assertEqual(targets[0]['status'], 'complete')
+
+    def test_expired_deferred_cleanup_is_abandoned_not_retried_forever(self):
+        playback.begin_playback_repair(self.item, self.target)
+        candidate = {'title': 'Working.Release', 'guid': 'GUID-3'}
+        playback.set_playback_candidate(7, candidate, 'new-uuid', 'Working.Release')
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET state='Collected',filled_by_torrent_id='nzb:new-uuid',filled_by_file='new.mkv'")
+            conn.execute(
+                """UPDATE nzb_playback_repairs SET status='complete',cleanup_status='pending',
+                   cleanup_first_pending_at=datetime('now','-49 hours'),
+                   cleanup_targets_json=?""",
+                (_json_module.dumps([{
+                    'entry_name': 'Old.Release', 'file_name': 'old.mkv', 'info_hash': 'old-uuid',
+                    'cli_debrid_id': 7, 'reason': 'media_probe_failed', 'status': 'pending',
+                    'deferred': True, 'stale_attempts': playback.STALE_TARGET_MAX_ATTEMPTS,
+                    'background_attempts': 3,
+                }]),),
+            )
+            conn.commit()
+
+        old_request = playback._mount_request
+        playback._mount_request = lambda path, payload, timeout: (409, {'code': 'stale_target'}, '')
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+
+        playback.retry_deferred_playback_cleanups()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['cleanup_status'], 'abandoned')
+        self.assertIsNone(repair['next_attempt_at'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -38,6 +38,44 @@ class _Client:
         return True
 
 
+class TestSymlinkMatches(unittest.TestCase):
+    """_symlink_matches must work for both Symlinked/Local (symlink) and
+    Plex mode (real file path reported by Plex's API, never a symlink)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__('shutil').rmtree(self.tmpdir, ignore_errors=True))
+        self.entry_dir = os.path.join(self.tmpdir, 'Show.S01E01.Entry.Name')
+        os.makedirs(self.entry_dir)
+        self.real_file = os.path.join(self.entry_dir, 'Show.S01E01.mkv')
+        with open(self.real_file, 'w') as f:
+            f.write('data')
+
+    def test_symlinked_local_mode(self):
+        link = os.path.join(self.tmpdir, 'link.mkv')
+        os.symlink(self.real_file, link)
+        self.assertTrue(playback._symlink_matches(
+            {'location_on_disk': link}, 'Show.S01E01.Entry.Name', 'Show.S01E01.mkv'))
+
+    def test_plex_mode_real_file_no_symlink(self):
+        # Plex mode: location_on_disk is the real mounted path directly, as
+        # reported by Plex's API — never a symlink.
+        self.assertTrue(playback._symlink_matches(
+            {'location_on_disk': self.real_file}, 'Show.S01E01.Entry.Name', 'Show.S01E01.mkv'))
+
+    def test_plex_mode_wrong_file_does_not_match(self):
+        self.assertFalse(playback._symlink_matches(
+            {'location_on_disk': self.real_file}, 'Show.S01E01.Entry.Name', 'Different.File.mkv'))
+
+    def test_missing_path_returns_false(self):
+        self.assertFalse(playback._symlink_matches(
+            {'location_on_disk': os.path.join(self.tmpdir, 'does-not-exist.mkv')},
+            'Show.S01E01.Entry.Name', 'Show.S01E01.mkv'))
+
+    def test_empty_location_returns_false(self):
+        self.assertFalse(playback._symlink_matches({}, 'Show.S01E01.Entry.Name', 'Show.S01E01.mkv'))
+
+
 class TestNZBPlaybackRepair(unittest.TestCase):
     def test_candidate_keys_prefer_original_release_title(self):
         keys = playback.candidate_keys({

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -475,6 +475,151 @@ class TestNZBPlaybackRepair(unittest.TestCase):
         self.assertEqual(repair['cleanup_status'], 'abandoned')
         self.assertIsNone(repair['next_attempt_at'])
 
+    def _prep_verifying_candidate(self):
+        playback.begin_playback_repair(self.item, self.target)
+        candidate = {'title': 'Working.Release', 'guid': 'GUID-3'}
+        playback.set_playback_candidate(7, candidate, 'new-uuid', 'Working.Release')
+        with self.connect() as conn:
+            conn.execute(
+                "UPDATE media_items SET state='Collected',filled_by_torrent_id='nzb:new-uuid',filled_by_file='new.mkv'")
+
+        client = _Client()
+        usenet_module = types.ModuleType('usenet')
+        usenet_module.get_usenet_client = lambda: client
+        old_usenet = sys.modules.get('usenet')
+        sys.modules['usenet'] = usenet_module
+        self.addCleanup(lambda: sys.modules.__setitem__('usenet', old_usenet) if old_usenet else sys.modules.pop('usenet', None))
+        old_item = playback._media_item
+        playback._media_item = lambda _id: dict(self.connect().execute('SELECT * FROM media_items WHERE id=7').fetchone())
+        self.addCleanup(lambda: setattr(playback, '_media_item', old_item))
+
+    def test_verify_stale_target_rejects_candidate_after_max_attempts(self):
+        """A verify-stage stale_target that never clears must not loop
+        forever — unlike the ack-stage stale_target case, there's no
+        confirmed-healthy replacement to protect yet, so the candidate
+        itself is rejected and search resumes."""
+        self._prep_verifying_candidate()
+        old_request = playback._mount_request
+        playback._mount_request = lambda path, payload, timeout: (409, {'code': 'stale_target'}, '')
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+
+        for attempt in range(1, playback.VERIFY_STALE_TARGET_MAX_ATTEMPTS):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+            self.assertNotEqual(repair['status'], 'awaiting_candidate', f'should not reject before attempt {attempt}')
+            self.assertEqual(repair['verify_stale_target_attempts'], attempt)
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['status'], 'awaiting_candidate')
+        self.assertIsNone(repair['candidate_info_hash'])
+        self.assertEqual(repair['last_error'], 'verify_stale_target_max_attempts')
+        self.assertEqual(repair['verify_stale_target_attempts'], 0)
+
+    def test_verify_unknown_rejects_candidate_after_max_attempts(self):
+        self._prep_verifying_candidate()
+        old_request = playback._mount_request
+        playback._mount_request = lambda path, payload, timeout: (
+            200, {'status': 'unknown', 'reason': 'replacement_not_ready'}, '')
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+
+        for attempt in range(1, playback.VERIFY_UNKNOWN_MAX_ATTEMPTS):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+            self.assertNotEqual(repair['status'], 'awaiting_candidate', f'should not reject before attempt {attempt}')
+            self.assertEqual(repair['verify_unknown_attempts'], attempt)
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['status'], 'awaiting_candidate')
+        self.assertIsNone(repair['candidate_info_hash'])
+        self.assertEqual(repair['last_error'], 'replacement_not_ready')
+        self.assertEqual(repair['verify_unknown_attempts'], 0)
+
+    def test_verify_busy_does_not_reject_within_short_window(self):
+        """repair_busy just means decypharr's own sweep is running — a few
+        attempts of that must not burn through the same short fuse as a
+        genuinely stale candidate."""
+        self._prep_verifying_candidate()
+        old_request = playback._mount_request
+        playback._mount_request = lambda path, payload, timeout: (409, {'code': 'repair_busy'}, '')
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+
+        for _ in range(playback.VERIFY_STALE_TARGET_MAX_ATTEMPTS + 5):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertNotEqual(repair['status'], 'awaiting_candidate')
+        self.assertIsNotNone(repair['candidate_info_hash'])
+        self.assertEqual(repair['verify_busy_attempts'], playback.VERIFY_STALE_TARGET_MAX_ATTEMPTS + 5)
+
+    def test_candidate_search_flags_visibility_then_gives_up_after_days(self):
+        """No healthy candidate ever found: stays silent until the
+        visibility threshold, then flags itself in the activity log and
+        slows down, then eventually stops scheduling after the hard
+        give-up window rather than retrying forever."""
+        playback.begin_playback_repair(self.item, self.target)
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+
+        self._install_fake_repair_engine(lambda repair_row, item: 'no_replacement')
+        old_item = playback._media_item
+        playback._media_item = lambda _id: dict(self.item)
+        self.addCleanup(lambda: setattr(playback, '_media_item', old_item))
+
+        for attempt in range(1, playback.CANDIDATE_SEARCH_VISIBILITY_ATTEMPTS):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+        with self.connect() as conn:
+            updated = conn.execute('SELECT * FROM nzb_playback_repairs WHERE id=?', (repair['id'],)).fetchone()
+            activity = conn.execute('SELECT * FROM nzb_repair_activity WHERE id=?', (repair['activity_id'],)).fetchone()
+        self.assertIsNone(updated['candidate_search_stuck_since'])
+        self.assertEqual(activity['outcome'], 'replacement_pending')
+
+        # The attempt that reaches the visibility threshold must flag the
+        # activity log so this isn't silently invisible, without stopping.
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            updated = conn.execute('SELECT * FROM nzb_playback_repairs WHERE id=?', (repair['id'],)).fetchone()
+            activity = conn.execute('SELECT * FROM nzb_repair_activity WHERE id=?', (repair['activity_id'],)).fetchone()
+        self.assertIsNotNone(updated['candidate_search_stuck_since'])
+        self.assertEqual(activity['outcome'], 'skipped_max_attempts')
+        self.assertEqual(updated['status'], 'awaiting_candidate')
+        self.assertIsNotNone(updated['next_attempt_at'])
+
+        # Force the stuck-since timestamp far enough in the past to cross
+        # the hard give-up threshold, then confirm it stops scheduling.
+        with self.connect() as conn:
+            conn.execute(
+                "UPDATE nzb_playback_repairs SET candidate_search_stuck_since=datetime('now', ?),"
+                "next_attempt_at=NULL WHERE id=?",
+                (f'-{playback.CANDIDATE_SEARCH_GIVE_UP_DAYS + 1} days', repair['id']),
+            )
+            conn.commit()
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            updated = conn.execute('SELECT * FROM nzb_playback_repairs WHERE id=?', (repair['id'],)).fetchone()
+            activity = conn.execute('SELECT * FROM nzb_repair_activity WHERE id=?', (repair['activity_id'],)).fetchone()
+        self.assertEqual(updated['status'], 'complete')
+        self.assertEqual(activity['outcome'], 'abandoned_after_retries')
+        self.assertIsNone(updated['next_attempt_at'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -1,3 +1,4 @@
+import json as _json_module
 import os
 import sqlite3
 import sys
@@ -92,6 +93,8 @@ class TestNZBPlaybackRepair(unittest.TestCase):
 
     def test_original_and_failed_candidate_stay_excluded(self):
         self.assertTrue(playback.begin_playback_repair(self.item, self.target))
+        self.assertTrue(playback.has_active_exact_repair(7, 'old-uuid', 'old.mkv'))
+        self.assertFalse(playback.has_active_exact_repair(7, 'old-uuid', 'other.mkv'))
         original = {'title': 'Original.Release'}
         failed = {'title': 'Another.Release', 'guid': 'GUID-1'}
         self.assertTrue(playback.candidate_is_excluded(7, original))
@@ -115,6 +118,13 @@ class TestNZBPlaybackRepair(unittest.TestCase):
 
     def test_healthy_candidate_cleans_exact_target_then_finalizes_activity(self):
         playback.begin_playback_repair(self.item, self.target)
+        with self.connect() as conn:
+            conn.execute(
+                """INSERT INTO nzb_repair_activity
+                   (broken_nzb_id,broken_nzb_title,outcome)
+                   VALUES ('old-uuid','Old.Release','not_found'),
+                          ('unrelated-uuid','Old.Release','not_found')"""
+            )
         candidate = {'title': 'Working.Release', 'guid': 'GUID-3'}
         playback.set_playback_candidate(7, candidate, 'new-uuid', 'Working.Release')
         with self.connect() as conn:
@@ -152,12 +162,93 @@ class TestNZBPlaybackRepair(unittest.TestCase):
         playback.process_pending_playback_repairs()
         with self.connect() as conn:
             repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
-            activity = conn.execute('SELECT * FROM nzb_repair_activity').fetchone()
+            activity = conn.execute(
+                'SELECT * FROM nzb_repair_activity WHERE id=?',
+                (repair['activity_id'],),
+            ).fetchone()
+            duplicate = conn.execute(
+                """SELECT COUNT(*) FROM nzb_repair_activity
+                   WHERE broken_nzb_id='old-uuid' AND broken_nzb_title='Old.Release'
+                     AND outcome='not_found'"""
+            ).fetchone()[0]
+            unrelated = conn.execute(
+                """SELECT COUNT(*) FROM nzb_repair_activity
+                   WHERE broken_nzb_id='unrelated-uuid' AND outcome='not_found'"""
+            ).fetchone()[0]
         self.assertEqual(repair['status'], 'complete')
         self.assertEqual(activity['outcome'], 'replaced')
         self.assertEqual(activity['replacement_nzb_id'], 'new-uuid')
+        self.assertEqual(duplicate, 0)
+        self.assertEqual(unrelated, 1)
         self.assertEqual([call[0] for call in calls], [
             '/api/repair/replacements/verify', '/api/repair/replacements/ack'])
+
+
+    def test_undeletable_failed_job_is_abandoned_after_max_attempts(self):
+        playback.begin_playback_repair(self.item, self.target)
+        playback.set_playback_candidate(7, {'title': 'Candidate.Release', 'guid': 'GUID-2'}, 'bad-uuid', 'Candidate.Release')
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET state='Adding',filled_by_torrent_id='nzb:bad-uuid'")
+        self.assertTrue(playback.reject_active_candidate(7, 'bad-uuid'))
+
+        playback.set_playback_candidate(7, {'title': 'Working.Release', 'guid': 'GUID-3'}, 'new-uuid', 'Working.Release')
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET state='Collected',filled_by_torrent_id='nzb:new-uuid',filled_by_file='new.mkv'")
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertIn('bad-uuid', repair['failed_job_ids_json'])
+
+        class _UndeletableJobClient(_Client):
+            def remove_nzb_exact(self, info_hash):
+                self.deleted.append(info_hash)
+                return info_hash != 'bad-uuid'
+
+        client = _UndeletableJobClient()
+        usenet_module = types.ModuleType('usenet')
+        usenet_module.get_usenet_client = lambda: client
+        old_usenet = sys.modules.get('usenet')
+        sys.modules['usenet'] = usenet_module
+        self.addCleanup(lambda: sys.modules.__setitem__('usenet', old_usenet) if old_usenet else sys.modules.pop('usenet', None))
+        old_item = playback._media_item
+        old_symlink = playback._symlink_matches
+        old_request = playback._mount_request
+        playback._media_item = lambda _id: dict(self.connect().execute('SELECT * FROM media_items WHERE id=7').fetchone())
+        playback._symlink_matches = lambda *args: True
+
+        def request(path, payload, timeout):
+            if path.endswith('/verify'):
+                return 200, {'status': 'healthy', 'entry_name': 'Working.Release', 'file_name': 'new.mkv'}, ''
+            return 200, {'status': 'removed'}, ''
+
+        playback._mount_request = request
+        self.addCleanup(lambda: setattr(playback, '_media_item', old_item))
+        self.addCleanup(lambda: setattr(playback, '_symlink_matches', old_symlink))
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+        plex_module = types.ModuleType('utilities.plex_functions')
+        plex_module.plex_update_item = lambda item: True
+        old_plex = sys.modules.get('utilities.plex_functions')
+        sys.modules['utilities.plex_functions'] = plex_module
+        self.addCleanup(lambda: sys.modules.__setitem__('utilities.plex_functions', old_plex) if old_plex else sys.modules.pop('utilities.plex_functions', None))
+
+        for attempt in range(1, playback.FAILED_JOB_MAX_ATTEMPTS):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+            self.assertNotEqual(repair['status'], 'complete', f'should not complete after attempt {attempt}')
+            self.assertIn('bad-uuid', repair['failed_job_ids_json'])
+            self.assertEqual(_json_module.loads(repair['failed_job_attempts_json'])['bad-uuid'], attempt)
+            # Simulate the 30s retry schedule elapsing so the next call re-claims it.
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+
+        # The next attempt hits FAILED_JOB_MAX_ATTEMPTS and abandons the job,
+        # letting the repair proceed to its own old-file cleanup and finish.
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['status'], 'complete')
+        self.assertEqual(repair['failed_job_ids_json'], '[]')
+        self.assertEqual(repair['failed_job_attempts_json'], '{}')
 
 
 if __name__ == '__main__':

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -678,6 +678,59 @@ class TestNZBPlaybackRepair(unittest.TestCase):
         self.assertEqual(activity['outcome'], 'abandoned_after_retries')
         self.assertIsNone(updated['next_attempt_at'])
 
+    def test_source_mismatch_rejects_candidate_after_max_attempts_when_reverted(self):
+        """If the item is back on the original broken hash (not replaced by
+        anything else), a persistent candidate/source mismatch after the cap
+        is treated like a bad candidate: reject and resume searching."""
+        self._prep_verifying_candidate()
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET filled_by_torrent_id='nzb:old-uuid'")
+            conn.commit()
+
+        for attempt in range(1, playback.CANDIDATE_SOURCE_MISMATCH_MAX_ATTEMPTS):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+            self.assertNotEqual(repair['status'], 'awaiting_candidate', f'should not reject before attempt {attempt}')
+            self.assertEqual(repair['source_mismatch_attempts'], attempt)
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['status'], 'awaiting_candidate')
+        self.assertIsNone(repair['candidate_info_hash'])
+        self.assertEqual(repair['last_error'], 'candidate_source_changed_max_attempts')
+        self.assertEqual(repair['source_mismatch_attempts'], 0)
+
+    def test_source_mismatch_stops_without_cleanup_when_superseded_externally(self):
+        """If the item now points at neither our candidate nor the original
+        broken hash, something else already replaced it (e.g. the general
+        repair engine winning a race) — stop without guessing at cleanup."""
+        self._prep_verifying_candidate()
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET filled_by_torrent_id='nzb:someone-elses-uuid'")
+            conn.commit()
+
+        for _ in range(playback.CANDIDATE_SOURCE_MISMATCH_MAX_ATTEMPTS - 1):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['status'], 'complete')
+        self.assertEqual(repair['last_error'], 'superseded_externally')
+        self.assertIsNone(repair['next_attempt_at'])
+        # Must not touch cleanup_targets_json — no cleanup attempt for a
+        # candidate this repair no longer owns.
+        targets = _json_module.loads(repair['cleanup_targets_json'])
+        self.assertEqual(targets[0]['status'], 'pending')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -446,6 +446,64 @@ class TestNZBPlaybackRepair(unittest.TestCase):
         targets = _json_module.loads(repair['cleanup_targets_json'])
         self.assertEqual(targets[0]['status'], 'complete')
 
+    def test_persistent_generic_cleanup_failure_also_defers_after_max_attempts(self):
+        """A persistent non-stale, non-5xx cleanup failure (e.g. an
+        unexpected 4xx) must be treated the same as stale_target — capped
+        and deferred to the background retry — instead of retrying inline
+        forever, since it sits in the same fallback branch."""
+        playback.begin_playback_repair(self.item, self.target)
+        candidate = {'title': 'Working.Release', 'guid': 'GUID-3'}
+        playback.set_playback_candidate(7, candidate, 'new-uuid', 'Working.Release')
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET state='Collected',filled_by_torrent_id='nzb:new-uuid',filled_by_file='new.mkv'")
+
+        client = _Client()
+        usenet_module = types.ModuleType('usenet')
+        usenet_module.get_usenet_client = lambda: client
+        old_usenet = sys.modules.get('usenet')
+        sys.modules['usenet'] = usenet_module
+        self.addCleanup(lambda: sys.modules.__setitem__('usenet', old_usenet) if old_usenet else sys.modules.pop('usenet', None))
+        old_item = playback._media_item
+        old_symlink = playback._symlink_matches
+        old_request = playback._mount_request
+        playback._media_item = lambda _id: dict(self.connect().execute('SELECT * FROM media_items WHERE id=7').fetchone())
+        playback._symlink_matches = lambda *args: True
+
+        def request(path, payload, timeout):
+            if path.endswith('/verify'):
+                return 200, {'status': 'healthy', 'entry_name': 'Working.Release', 'file_name': 'new.mkv'}, ''
+            return 400, {'code': 'bad_request'}, ''
+
+        playback._mount_request = request
+        self.addCleanup(lambda: setattr(playback, '_media_item', old_item))
+        self.addCleanup(lambda: setattr(playback, '_symlink_matches', old_symlink))
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+        plex_module = types.ModuleType('utilities.plex_functions')
+        plex_module.plex_update_item = lambda item: True
+        old_plex = sys.modules.get('utilities.plex_functions')
+        sys.modules['utilities.plex_functions'] = plex_module
+        self.addCleanup(lambda: sys.modules.__setitem__('utilities.plex_functions', old_plex) if old_plex else sys.modules.pop('utilities.plex_functions', None))
+
+        for attempt in range(1, playback.STALE_TARGET_MAX_ATTEMPTS):
+            playback.process_pending_playback_repairs()
+            with self.connect() as conn:
+                repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+            self.assertNotEqual(repair['status'], 'complete', f'should not complete after attempt {attempt}')
+            targets = _json_module.loads(repair['cleanup_targets_json'])
+            self.assertEqual(targets[0]['generic_attempts'], attempt)
+            with self.connect() as conn:
+                conn.execute('UPDATE nzb_playback_repairs SET next_attempt_at=NULL')
+                conn.commit()
+
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(repair['status'], 'complete')
+        self.assertEqual(repair['cleanup_status'], 'pending')
+        targets = _json_module.loads(repair['cleanup_targets_json'])
+        self.assertTrue(targets[0]['deferred'])
+        self.assertEqual(targets[0]['last_error'], 'bad_request')
+
     def test_expired_deferred_cleanup_is_abandoned_not_retried_forever(self):
         playback.begin_playback_repair(self.item, self.target)
         candidate = {'title': 'Working.Release', 'guid': 'GUID-3'}

--- a/tests/test_nzb_playback_repair.py
+++ b/tests/test_nzb_playback_repair.py
@@ -1,0 +1,164 @@
+import os
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+import importlib.util
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+database_package = types.ModuleType('database')
+database_package.__path__ = [os.path.join(ROOT, 'database')]
+sys.modules.setdefault('database', database_package)
+core_spec = importlib.util.spec_from_file_location('database.core', os.path.join(ROOT, 'database', 'core.py'))
+core_module = importlib.util.module_from_spec(core_spec)
+sys.modules['database.core'] = core_module
+core_spec.loader.exec_module(core_module)
+playback_spec = importlib.util.spec_from_file_location(
+    'database.nzb_playback_repair', os.path.join(ROOT, 'database', 'nzb_playback_repair.py'))
+playback = importlib.util.module_from_spec(playback_spec)
+sys.modules['database.nzb_playback_repair'] = playback
+playback_spec.loader.exec_module(playback)
+
+
+class _Client:
+    def __init__(self):
+        self.registered = []
+        self.deleted = []
+
+    def register_cli_ids_for_item(self, info_hash, item_id):
+        self.registered.append((info_hash, item_id))
+        return True
+
+    def remove_nzb_exact(self, info_hash):
+        self.deleted.append(info_hash)
+        return True
+
+
+class TestNZBPlaybackRepair(unittest.TestCase):
+    def test_candidate_keys_prefer_original_release_title(self):
+        keys = playback.candidate_keys({
+            'title': 'cli-mount-renamed-release',
+            'original_title': 'Indexer Original Release',
+        })
+        self.assertIn('t:indexeroriginalrelease', keys)
+        self.assertNotIn('t:climountrenamedrelease', keys)
+
+    def setUp(self):
+        handle, self.path = tempfile.mkstemp(suffix='.db')
+        os.close(handle)
+        self.addCleanup(lambda: os.unlink(self.path) if os.path.exists(self.path) else None)
+
+        def connect():
+            conn = sqlite3.connect(self.path)
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        self.connect = connect
+        self.original_connect = playback.get_db_connection
+        playback.get_db_connection = connect
+        self.addCleanup(lambda: setattr(playback, 'get_db_connection', self.original_connect))
+        with connect() as conn:
+            conn.executescript("""
+                CREATE TABLE media_items (
+                    id INTEGER PRIMARY KEY, state TEXT, filled_by_torrent_id TEXT,
+                    filled_by_file TEXT, filled_by_title TEXT, debrid_folder_name TEXT,
+                    location_on_disk TEXT
+                );
+                CREATE TABLE nzb_repair_activity (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT, item_id INTEGER, title TEXT,
+                    media_type TEXT, season_number INTEGER, episode_number INTEGER,
+                    broken_nzb_id TEXT, broken_nzb_title TEXT, replacement_nzb_id TEXT,
+                    replacement_title TEXT, outcome TEXT, triggered_by TEXT,
+                    repair_attempts INTEGER, last_repair_at TIMESTAMP, updated_at TIMESTAMP
+                );
+                INSERT INTO media_items VALUES
+                    (7,'Collected','nzb:old-uuid','old.mkv','Old.Release','Old.Release','/plex/item.mkv');
+            """)
+        playback.create_nzb_playback_repair_table()
+        self.item = {
+            'id': 7, 'state': 'Collected', 'filled_by_torrent_id': 'nzb:old-uuid',
+            'filled_by_file': 'old.mkv', 'filled_by_title': 'Old.Release',
+            'debrid_folder_name': 'Old.Release', 'location_on_disk': '/plex/item.mkv',
+            'title': 'Show', 'type': 'episode', 'season_number': 1, 'episode_number': 2,
+            'original_scraped_torrent_title': 'Original.Release',
+        }
+        self.target = {
+            'entry_name': 'Old.Release', 'file_name': 'old.mkv', 'info_hash': 'old-uuid',
+            'cli_debrid_id': 7, 'reason': 'media_probe_failed', 'segment_id': 'old-segment',
+        }
+
+    def test_original_and_failed_candidate_stay_excluded(self):
+        self.assertTrue(playback.begin_playback_repair(self.item, self.target))
+        original = {'title': 'Original.Release'}
+        failed = {'title': 'Another.Release', 'guid': 'GUID-1'}
+        self.assertTrue(playback.candidate_is_excluded(7, original))
+        playback.record_failed_candidate(7, failed, 'failed-uuid')
+        self.assertTrue(playback.candidate_is_excluded(7, failed))
+
+    def test_failed_active_candidate_restores_original(self):
+        playback.begin_playback_repair(self.item, self.target)
+        candidate = {'title': 'Candidate.Release', 'guid': 'GUID-2'}
+        playback.set_playback_candidate(7, candidate, 'new-uuid', 'Candidate.Release')
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET state='Adding',filled_by_torrent_id='nzb:new-uuid'")
+        self.assertTrue(playback.reject_active_candidate(7, 'new-uuid'))
+        with self.connect() as conn:
+            item = conn.execute('SELECT * FROM media_items WHERE id=7').fetchone()
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+        self.assertEqual(item['state'], 'Collected')
+        self.assertEqual(item['filled_by_torrent_id'], 'nzb:old-uuid')
+        self.assertEqual(repair['status'], 'awaiting_candidate')
+        self.assertIn('new-uuid', repair['failed_job_ids_json'])
+
+    def test_healthy_candidate_cleans_exact_target_then_finalizes_activity(self):
+        playback.begin_playback_repair(self.item, self.target)
+        candidate = {'title': 'Working.Release', 'guid': 'GUID-3'}
+        playback.set_playback_candidate(7, candidate, 'new-uuid', 'Working.Release')
+        with self.connect() as conn:
+            conn.execute("UPDATE media_items SET state='Collected',filled_by_torrent_id='nzb:new-uuid',filled_by_file='new.mkv'")
+
+        client = _Client()
+        usenet_module = types.ModuleType('usenet')
+        usenet_module.get_usenet_client = lambda: client
+        old_usenet = sys.modules.get('usenet')
+        sys.modules['usenet'] = usenet_module
+        self.addCleanup(lambda: sys.modules.__setitem__('usenet', old_usenet) if old_usenet else sys.modules.pop('usenet', None))
+        old_item = playback._media_item
+        old_symlink = playback._symlink_matches
+        old_request = playback._mount_request
+        playback._media_item = lambda _id: dict(self.connect().execute('SELECT * FROM media_items WHERE id=7').fetchone())
+        playback._symlink_matches = lambda *args: True
+        calls = []
+
+        def request(path, payload, timeout):
+            calls.append((path, payload))
+            if path.endswith('/verify'):
+                return 200, {'status': 'healthy', 'entry_name': 'Working.Release', 'file_name': 'new.mkv'}, ''
+            return 200, {'status': 'removed'}, ''
+
+        playback._mount_request = request
+        self.addCleanup(lambda: setattr(playback, '_media_item', old_item))
+        self.addCleanup(lambda: setattr(playback, '_symlink_matches', old_symlink))
+        self.addCleanup(lambda: setattr(playback, '_mount_request', old_request))
+        plex_module = types.ModuleType('utilities.plex_functions')
+        plex_module.plex_update_item = lambda item: True
+        old_plex = sys.modules.get('utilities.plex_functions')
+        sys.modules['utilities.plex_functions'] = plex_module
+        self.addCleanup(lambda: sys.modules.__setitem__('utilities.plex_functions', old_plex) if old_plex else sys.modules.pop('utilities.plex_functions', None))
+
+        playback.process_pending_playback_repairs()
+        with self.connect() as conn:
+            repair = conn.execute('SELECT * FROM nzb_playback_repairs').fetchone()
+            activity = conn.execute('SELECT * FROM nzb_repair_activity').fetchone()
+        self.assertEqual(repair['status'], 'complete')
+        self.assertEqual(activity['outcome'], 'replaced')
+        self.assertEqual(activity['replacement_nzb_id'], 'new-uuid')
+        self.assertEqual([call[0] for call in calls], [
+            '/api/repair/replacements/verify', '/api/repair/replacements/ack'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_nzb_playback_scheduler.py
+++ b/tests/test_nzb_playback_scheduler.py
@@ -1,0 +1,56 @@
+import ast
+import os
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestNZBPlaybackScheduler(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(ROOT, 'queues', 'run_program.py')
+        with open(path, 'r', encoding='utf-8') as handle:
+            cls.tree = ast.parse(handle.read())
+
+    def _assigned_literal(self, attribute, literal_type):
+        for node in ast.walk(self.tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if any(isinstance(target, ast.Attribute) and target.attr == attribute
+                   for target in node.targets) and isinstance(node.value, literal_type):
+                return node.value
+        self.fail(f'No literal assignment found for self.{attribute}')
+
+    def test_completion_task_is_enabled_at_fifteen_seconds(self):
+        intervals = self._assigned_literal('task_intervals', ast.Dict)
+        values = {
+            key.value: value
+            for key, value in zip(intervals.keys, intervals.values)
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+        enabled = self._assigned_literal('enabled_tasks', ast.Set)
+        enabled_names = {
+            item.value for item in enabled.elts
+            if isinstance(item, ast.Constant) and isinstance(item.value, str)
+        }
+
+        self.assertEqual(
+            ast.literal_eval(values['task_nzb_playback_repair_completion']), 15,
+        )
+        self.assertIn('task_nzb_playback_repair_completion', enabled_names)
+
+        completion = next(
+            node for node in ast.walk(self.tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == 'task_nzb_playback_repair_completion'
+        )
+        referenced_names = {
+            node.id for node in ast.walk(completion) if isinstance(node, ast.Name)
+        }
+        self.assertIn('process_pending_playback_repairs', referenced_names)
+        self.assertNotIn('run_repair', referenced_names)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_repair_readcheck.py
+++ b/tests/test_repair_readcheck.py
@@ -132,6 +132,19 @@ class TestVerifyFileReadable(unittest.TestCase):
 
 
 class TestReplacementSubmission(unittest.TestCase):
+    def test_exact_active_repair_suppresses_duplicate_not_found(self):
+        original = re_mod.has_active_exact_repair
+        calls = []
+        re_mod.has_active_exact_repair = lambda item_id, old_uuid, filename: (
+            calls.append((item_id, old_uuid, filename)) or True
+        )
+        self.addCleanup(lambda: setattr(re_mod, 'has_active_exact_repair', original))
+
+        target = {'cli_debrid_id': 7, 'file_name': 'old.mkv'}
+        self.assertTrue(re_mod._has_pending_exact_playback_repair(target, 'old-uuid'))
+        self.assertEqual(calls, [(7, 'old-uuid', 'old.mkv')])
+        self.assertFalse(re_mod._has_pending_exact_playback_repair(None, 'old-uuid'))
+
     def test_explicit_failed_job_is_not_accepted(self):
         class Client:
             last_failed_job_id = ''

--- a/tests/test_repair_readcheck.py
+++ b/tests/test_repair_readcheck.py
@@ -145,6 +145,48 @@ class TestReplacementSubmission(unittest.TestCase):
         self.assertEqual(calls, [(7, 'old-uuid', 'old.mkv')])
         self.assertFalse(re_mod._has_pending_exact_playback_repair(None, 'old-uuid'))
 
+    def test_general_repair_skips_item_with_active_exact_repair(self):
+        """The general repair engine must not launch a second, competing
+        repair for an item the minimal exact-playback-repair system is
+        already actively working — even though the item still has a live,
+        matching DB row (not an orphan). Regression test for the race where
+        two independent candidates got submitted for the same broken file."""
+        original_reasons = re_mod.PLAYBACK_REPAIR_REASONS
+        re_mod.PLAYBACK_REPAIR_REASONS = {'usenet_segment_missing', 'media_probe_failed', 'media_no_playable_stream'}
+        self.addCleanup(lambda: setattr(re_mod, 'PLAYBACK_REPAIR_REASONS', original_reasons))
+
+        original_has_active = re_mod.has_active_exact_repair
+        re_mod.has_active_exact_repair = lambda item_id, old_uuid, filename: True
+        self.addCleanup(lambda: setattr(re_mod, 'has_active_exact_repair', original_has_active))
+
+        original_fetch = re_mod.fetch_broken_items
+        re_mod.fetch_broken_items = lambda *a, **k: [{
+            'entry_name': 'Old.Release', 'file_name': 'old.mkv', 'info_hash': 'old-uuid',
+            'cli_debrid_id': 42, 'reason': 'usenet_segment_missing',
+        }]
+        self.addCleanup(lambda: setattr(re_mod, 'fetch_broken_items', original_fetch))
+
+        original_find = re_mod._find_db_item_by_id
+        re_mod._find_db_item_by_id = lambda item_id: {
+            'id': 42, 'state': 'Collected', 'filled_by_torrent_id': 'nzb:old-uuid', 'title': 'Old Show',
+        }
+        self.addCleanup(lambda: setattr(re_mod, '_find_db_item_by_id', original_find))
+
+        activity_calls = []
+        original_log = re_mod.log_repair_activity
+        re_mod.log_repair_activity = lambda **kwargs: activity_calls.append(kwargs)
+        self.addCleanup(lambda: setattr(re_mod, 'log_repair_activity', original_log))
+
+        summary = re_mod._run_repair_inner(triggered_by='test')
+
+        # No repair activity logged, no replacement/not_found counted — the
+        # item was skipped entirely and left for the minimal repair to
+        # finish, not double-handled.
+        self.assertEqual(activity_calls, [])
+        self.assertEqual(summary.get('replaced', 0), 0)
+        self.assertEqual(summary.get('not_found', 0), 0)
+        self.assertEqual(summary.get('errors', 0), 0)
+
     def test_explicit_failed_job_is_not_accepted(self):
         class Client:
             last_failed_job_id = ''

--- a/tests/test_repair_readcheck.py
+++ b/tests/test_repair_readcheck.py
@@ -32,6 +32,7 @@ def _load():
     if 'requests' not in sys.modules:
         sys.modules['requests'] = _permissive_module('requests')
     for n in ['database', 'database.core', 'database.nzb_repair_activity',
+              'database.nzb_playback_repair',
               'database.not_wanted_magnets']:
         sys.modules[n] = _permissive_module(n)
     if 'utilities' not in sys.modules:
@@ -128,6 +129,35 @@ class TestVerifyFileReadable(unittest.TestCase):
         self._stub_probe([False])
         re_mod._verify_file_readable(self.tmp.name, attempts=1)
         self.assertEqual(self.offsets, [None])  # start-read (no offset)
+
+
+class TestReplacementSubmission(unittest.TestCase):
+    def test_explicit_failed_job_is_not_accepted(self):
+        class Client:
+            last_failed_job_id = ''
+
+            def add_nzb_content(self, **kwargs):
+                return 'failed-uuid'
+
+            def get_job_status(self, job_id):
+                return {'state': 'failed'}
+
+        client = Client()
+        usenet_mod = types.ModuleType('usenet')
+        usenet_mod.reset_usenet_client = lambda: None
+        usenet_mod.get_usenet_client = lambda: client
+        old = sys.modules.get('usenet')
+        sys.modules['usenet'] = usenet_mod
+        self.addCleanup(lambda: sys.modules.__setitem__('usenet', old) if old else sys.modules.pop('usenet', None))
+        import time
+        old_sleep = time.sleep
+        time.sleep = lambda *_: None
+        self.addCleanup(lambda: setattr(time, 'sleep', old_sleep))
+
+        job_id, title, disposition = re_mod._submit_and_confirm_replacement(
+            {'title': 'Bad.Release', '_prefetched_nzb': '<nzb />'}, 'Title')
+        self.assertEqual((job_id, title, disposition),
+                         ('failed-uuid', 'Bad.Release', 'failed'))
 
 
 if __name__ == '__main__':

--- a/usenet/climount_client.py
+++ b/usenet/climount_client.py
@@ -35,6 +35,7 @@ class CliMountClient:
         self.download_folder = cfg.get('download_folder', '')
         self.enabled = cfg.get('enabled', False)
         self.last_missing_segments = False  # set True by add_nzb_content on ARTICLE_NOT_FOUND
+        self.last_failed_job_id = ''
 
     def _headers(self) -> Dict[str, str]:
         h = {'Accept': 'application/json'}
@@ -60,6 +61,7 @@ class CliMountClient:
                         tags=None, tags_exclusive: bool = False) -> Optional[str]:
         """Submit NZB content directly as a file upload to avoid double-fetching."""
         self.last_missing_segments = False
+        self.last_failed_job_id = ''
         if not self.is_enabled():
             logging.warning('[cli_mount] Usenet provider is disabled or not configured')
             return None
@@ -83,6 +85,7 @@ class CliMountClient:
                     job = result[0]
                     job_id = job.get('id') or job.get('nzo_id') or job.get('hash', '')
                     if job.get('status') == 'error':
+                        self.last_failed_job_id = str(job_id or '')
                         err_msg = job.get('error', '')
                         logging.error(f'[cli_mount] add_nzb_content error: {err_msg}')
                         if 'ARTICLE_NOT_FOUND' in err_msg or 'article not found' in err_msg.lower():
@@ -109,6 +112,7 @@ class CliMountClient:
         content and uploads it directly instead of passing the URL.
         Returns the job ID string on success, None on failure.
         """
+        self.last_failed_job_id = ''
         if not self.is_enabled():
             logging.warning('[cli_mount] Usenet provider is disabled or not configured')
             return None
@@ -146,6 +150,7 @@ class CliMountClient:
                     job = result[0]
                     job_id = job.get('id') or job.get('nzo_id') or job.get('hash', '')
                     if job.get('status') == 'error':
+                        self.last_failed_job_id = str(job_id or '')
                         logging.error(f'[cli_mount] add_nzb error: {job.get("error")}')
                         return None
                     logging.info(f'[cli_mount] NZB submitted: id={job_id} title={title!r}')
@@ -372,6 +377,7 @@ class CliMountClient:
         """
         if not self.is_enabled() or not info_hash or not ids:
             return False
+
         try:
             import requests as _req_patch
             r = _req_patch.patch(
@@ -388,6 +394,22 @@ class CliMountClient:
         except Exception as e:
             logging.debug(f'[cli_mount] register_cli_ids error for {info_hash}: {e}')
             return False
+
+    def remove_nzb_exact(self, info_hash: str) -> bool:
+        """Remove one exact UUID; never fall back to a release-name match."""
+        if not self.is_enabled() or not info_hash:
+            return False
+        try:
+            r = api.delete(
+                f'{self.base_url}/api/browse/torrents/{info_hash}',
+                headers=self._headers(), timeout=15,
+            )
+            if r.status_code in (200, 204, 404):
+                return True
+            logging.warning('[cli_mount] Exact job delete %s returned HTTP %s', info_hash, r.status_code)
+        except Exception as exc:
+            logging.warning('[cli_mount] Exact job delete %s failed: %s', info_hash, exc)
+        return False
 
     def register_cli_ids_for_item(self, info_hash: str, item_id: int) -> bool:
         """
@@ -671,7 +693,26 @@ class CliMountClient:
                 logging.warning(f'[cli_mount] /api/repair/health HTTP {r.status_code}')
                 return []
             all_entries = self._parse_health_entries(r.json())
-            broken = [e for e in all_entries if (e.get('status') or '').lower() == 'broken']
+            broken = []
+            for health in all_entries:
+                if (health.get('status') or '').lower() != 'broken':
+                    continue
+                files = health.get('broken_files') or []
+                if not files:
+                    broken.append(health)
+                    continue
+                # cli_mount health is entry-oriented, but playback replacement is
+                # deliberately file-oriented.  Promote the exact file identity so
+                # repair_engine never has to guess which episode in a pack failed.
+                for broken_file in files:
+                    item = dict(health)
+                    item['entry_name'] = health.get('entry_name') or health.get('name') or ''
+                    item['file_name'] = broken_file.get('file_name') or ''
+                    item['info_hash'] = broken_file.get('info_hash') or health.get('info_hash') or ''
+                    item['cli_debrid_id'] = broken_file.get('cli_debrid_id')
+                    item['failure_reason'] = broken_file.get('reason') or health.get('failure_reason') or ''
+                    item['hash_is_authoritative'] = bool(item['info_hash'])
+                    broken.append(item)
             if self._debrid_naming_enabled():
                 before = len(broken)
                 broken = [e for e in broken if (e.get('protocol') or '').lower() != 'torrent']

--- a/usenet/climount_client.py
+++ b/usenet/climount_client.py
@@ -21,6 +21,25 @@ from utilities.settings import get_setting
 from routes.api_tracker import api
 
 
+def _delete_status(url, **kwargs):
+    """
+    DELETE via the shared api client and return (status_code, error).
+    api.delete() calls response.raise_for_status(), so an error response
+    (4xx/5xx) surfaces as a raised HTTPError rather than a returned Response
+    — without unwrapping it here, callers can never see e.g. a 404 and end
+    up treating "already gone" the same as a real failure.
+    status_code is None when the request never got a response at all
+    (timeout, connection error, etc).
+    """
+    try:
+        r = api.delete(url, **kwargs)
+        return r.status_code, None
+    except Exception as exc:
+        response = getattr(exc, 'response', None)
+        if response is not None:
+            return response.status_code, exc
+        return None, exc
+
 
 
 class CliMountClient:
@@ -311,37 +330,36 @@ class CliMountClient:
 
         # Primary: DELETE /api/browse/torrents/{hash} — removes from entries.db AND mount
         if info_hash:
-            try:
-                r = api.delete(
-                    f'{self.base_url}/api/browse/torrents/{info_hash}',
-                    headers=self._headers(), timeout=15,
-                )
-                if r.status_code in (200, 204):
-                    logging.info(f'[cli_mount] Removed NZB entry {info_hash} from storage and mount')
-                    return True
-                if r.status_code == 404:
-                    logging.info(f'[cli_mount] NZB entry {info_hash} already gone (404)')
-                    return True
-                logging.debug(f'[cli_mount] remove_nzb browse endpoint returned {r.status_code}')
-            except Exception as e:
-                logging.debug(f'[cli_mount] remove_nzb browse delete error: {e}')
+            status, exc = _delete_status(
+                f'{self.base_url}/api/browse/torrents/{info_hash}',
+                headers=self._headers(), timeout=15,
+            )
+            if status in (200, 204):
+                logging.info(f'[cli_mount] Removed NZB entry {info_hash} from storage and mount')
+                return True
+            if status == 404:
+                logging.info(f'[cli_mount] NZB entry {info_hash} already gone (404)')
+                return True
+            if status is not None:
+                logging.debug(f'[cli_mount] remove_nzb browse endpoint returned {status}')
+            else:
+                logging.debug(f'[cli_mount] remove_nzb browse delete error: {exc}')
 
         # Fallback: queue-only delete via hashes param
         if info_hash:
-            try:
-                r = api.delete(
-                    f'{self.base_url}/api/torrents',
-                    params={'hashes': info_hash},
-                    headers=self._headers(), timeout=15,
-                )
-                if r.status_code in (200, 204):
-                    logging.info(f'[cli_mount] Removed NZB job {info_hash} from queue')
-                    return True
-                if r.status_code == 404:
-                    logging.info(f'[cli_mount] NZB job {info_hash} already gone (404)')
-                    return True
-            except Exception as e:
-                logging.debug(f'[cli_mount] remove_nzb queue delete error: {e}')
+            status, exc = _delete_status(
+                f'{self.base_url}/api/torrents',
+                params={'hashes': info_hash},
+                headers=self._headers(), timeout=15,
+            )
+            if status in (200, 204):
+                logging.info(f'[cli_mount] Removed NZB job {info_hash} from queue')
+                return True
+            if status == 404:
+                logging.info(f'[cli_mount] NZB job {info_hash} already gone (404)')
+                return True
+            if status is None:
+                logging.debug(f'[cli_mount] remove_nzb queue delete error: {exc}')
 
         # Last resort: search by name and delete
         if entry_name:
@@ -355,11 +373,11 @@ class CliMountClient:
                     for t in r.json().get('torrents', []):
                         h = t.get('info_hash', '')
                         if h:
-                            d = api.delete(
+                            status, _exc = _delete_status(
                                 f'{self.base_url}/api/browse/torrents/{h}',
                                 headers=self._headers(), timeout=10,
                             )
-                            if d.status_code in (200, 204, 404):
+                            if status in (200, 204, 404):
                                 logging.info(f'[cli_mount] Removed NZB by name search: {entry_name!r}')
                                 return True
             except Exception as e:
@@ -399,15 +417,15 @@ class CliMountClient:
         """Remove one exact UUID; never fall back to a release-name match."""
         if not self.is_enabled() or not info_hash:
             return False
-        try:
-            r = api.delete(
-                f'{self.base_url}/api/browse/torrents/{info_hash}',
-                headers=self._headers(), timeout=15,
-            )
-            if r.status_code in (200, 204, 404):
-                return True
-            logging.warning('[cli_mount] Exact job delete %s returned HTTP %s', info_hash, r.status_code)
-        except Exception as exc:
+        status, exc = _delete_status(
+            f'{self.base_url}/api/browse/torrents/{info_hash}',
+            headers=self._headers(), timeout=15,
+        )
+        if status in (200, 204, 404):
+            return True
+        if status is not None:
+            logging.warning('[cli_mount] Exact job delete %s returned HTTP %s', info_hash, status)
+        else:
             logging.warning('[cli_mount] Exact job delete %s failed: %s', info_hash, exc)
         return False
 

--- a/usenet/climount_sync.py
+++ b/usenet/climount_sync.py
@@ -299,7 +299,7 @@ def sync_changes_from_climount(force_full: bool = False) -> dict:
 
             logger.info(f'[CMSync] Built maps — torrent: {len(torrent_map)}, nzb: {len(nzb_map)}, location: {len(location_map)}')
 
-            _BATCH_SIZE = 500
+            _BATCH_SIZE = 50
             _batch_count = 0
 
             for entry in changes:
@@ -341,6 +341,10 @@ def sync_changes_from_climount(force_full: bool = False) -> dict:
                     # Handle bad flag — trigger immediate re-insertion if cli_mount marked entry bad
                     if entry.get('bad'):
                         try:
+                            # Never hold a SQLite write transaction across provider HTTP.
+                            if _batch_count:
+                                conn.commit()
+                                _batch_count = 0
                             from usenet.debrid_repair_engine import reinsert_entry
                             folder_name = entry.get('folder_name', '')
                             info_hash = entry.get('info_hash', '')
@@ -415,6 +419,9 @@ def sync_changes_from_climount(force_full: bool = False) -> dict:
                     _info_hash = entry.get('info_hash') or ''
                     if _cli_ids_to_register and _info_hash:
                         try:
+                            if _batch_count:
+                                conn.commit()
+                                _batch_count = 0
                             from usenet.climount_client import get_climount_client as _get_dc_sync
                             _dc_sync = _get_dc_sync()
                             if _dc_sync and _dc_sync.is_enabled():
@@ -430,6 +437,9 @@ def sync_changes_from_climount(force_full: bool = False) -> dict:
                                 'SELECT tags FROM media_items WHERE id = ?', (item_ids[0],)
                             ).fetchone()
                             if _tags_row and _tags_row[0]:
+                                if _batch_count:
+                                    conn.commit()
+                                    _batch_count = 0
                                 from usenet.climount_client import get_climount_client as _get_dc_tags
                                 _dc_tags = _get_dc_tags()
                                 if _dc_tags and _dc_tags.is_enabled():
@@ -442,6 +452,7 @@ def sync_changes_from_climount(force_full: bool = False) -> dict:
                                             'UPDATE media_items SET tags_pushed_at = ? WHERE id = ?',
                                             (_dt_tags.now(), item_ids[0])
                                         )
+                                        _batch_count += 1
                                     else:
                                         logger.warning(f"[CMSync] Tag push returned false for {_info_hash} (tags='{_tags_row[0]}')")
                                 else:

--- a/usenet/repair_engine.py
+++ b/usenet/repair_engine.py
@@ -1402,6 +1402,26 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
                 summary['not_found'] += 1
                 continue
 
+            # An active exact-identity playback repair already owns this item —
+            # let it keep working the candidate it already submitted rather
+            # than launching a second, uncoordinated repair through this
+            # general pipeline. Without this, whichever candidate happens to
+            # collect first silently overwrites filled_by_torrent_id and
+            # orphans the other — leaving the minimal repair's own tracking
+            # row spinning on candidate_source_changed indefinitely, and
+            # wasting a full duplicate download in the meantime. Once the
+            # minimal repair finishes (success or eventual give-up), its row
+            # moves to status='complete' and has_active_exact_repair stops
+            # matching, so this falls through to the general pipeline again
+            # as a natural fallback.
+            if playback_target and _has_pending_exact_playback_repair(playback_target, info_hash):
+                logger.info(
+                    '[NZBPlayback] Item %s already has an active exact playback repair; '
+                    'skipping general repair to avoid a competing candidate (uuid=%s file=%s)',
+                    playback_target['cli_debrid_id'], info_hash, playback_target['file_name'],
+                )
+                continue
+
             # Skip if all items already in Adding (repair already in progress)
             if all(i.get('state') == 'Adding' for i in db_items):
                 logger.info(f'[NZBRepair] {entry_name!r} — all items already in Adding, skipping')

--- a/usenet/repair_engine.py
+++ b/usenet/repair_engine.py
@@ -1091,6 +1091,61 @@ def _update_db_for_repair(item: dict, new_job_id: str, replacement_result: dict,
         return False
 
 
+def find_and_submit_playback_candidate(repair_row: dict, item: dict) -> str:
+    """Re-run the same scrape/submit/exclude pipeline used for the initial
+    broken-entry repair, for a playback repair whose accepted candidate was
+    itself later found broken (status='awaiting_candidate'). Reuses
+    candidate_is_excluded/set_playback_candidate so a previously-failed
+    candidate (already recorded in excluded_keys_json by the caller) is
+    never re-tried. Returns an outcome string used only for retry
+    scheduling/logging by the completion worker — never raises.
+    """
+    item_id = item['id']
+    broken_nzb_title = (item.get('debrid_folder_name') or item.get('filled_by_file')
+                         or repair_row.get('old_entry_name') or item.get('title') or '')
+    candidates = _scrape_for_replacement(item, broken_nzb_title)
+    seen_keys = set()
+    unique_candidates = []
+    for candidate in candidates:
+        keys = candidate_keys(candidate)
+        if not keys or keys & seen_keys:
+            continue
+        seen_keys |= keys
+        if candidate_is_excluded(item_id, candidate):
+            continue
+        unique_candidates.append(candidate)
+    if not unique_candidates:
+        return 'no_replacement'
+
+    for candidate in unique_candidates:
+        job_id, submitted_title, disposition = _submit_and_confirm_replacement(
+            candidate, item.get('title', ''), item=item)
+        if disposition in ('failed', 'rejected'):
+            record_failed_candidate(item_id, candidate, job_id or '')
+            logger.warning(
+                '[NZBPlayback] Retry candidate rejected (%s); trying next distinct result: %r',
+                disposition, candidate.get('title'),
+            )
+            continue
+        best = dict(candidate)
+        best.setdefault('original_title', best.get('title', ''))
+        if submitted_title:
+            best['title'] = submitted_title
+        if not set_playback_candidate(item_id, best, job_id, submitted_title or best.get('title', '')):
+            record_failed_candidate(item_id, best, job_id)
+            logger.error('[NZBPlayback] Could not persist retry candidate %s for item %s', job_id, item_id)
+            return 'persist_failed'
+        if not _update_db_for_repair(item, job_id, best, unique_candidates, preserve_location=True):
+            logger.error('[NZBPlayback] Could not move retry candidate %s into Adding for item %s', job_id, item_id)
+            return 'db_update_failed'
+        logger.info(
+            '[NZBPlayback] Fresh candidate %s accepted for item %s after prior replacement also failed',
+            job_id, item_id,
+        )
+        return 'submitted'
+    return 'submission_failed'
+
+
 def _move_to_wanted(item: dict) -> None:
     """Move item back to Wanted without touching Plex or provider."""
     try:

--- a/usenet/repair_engine.py
+++ b/usenet/repair_engine.py
@@ -53,6 +53,14 @@ from database.not_wanted_magnets import (
     is_nzb_segment_not_wanted,
 )
 from utilities.settings import get_setting
+from database.nzb_playback_repair import (
+    ELIGIBLE_REASONS as PLAYBACK_REPAIR_REASONS,
+    begin_playback_repair,
+    candidate_is_excluded,
+    candidate_keys,
+    record_failed_candidate,
+    set_playback_candidate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +84,37 @@ def _client():
     """Active usenet client (climount or nzbdav) via the provider factory."""
     from usenet import get_usenet_client
     return get_usenet_client()
+
+
+def _find_db_item_by_id(item_id):
+    if not item_id:
+        return None
+    conn = get_db_connection()
+    try:
+        row = conn.execute('SELECT * FROM media_items WHERE id=?', (int(item_id),)).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _exact_playback_target(entry):
+    """Return the exact cli_mount file identity, or None for legacy repairs."""
+    reason = entry.get('failure_reason') or entry.get('reason') or ''
+    target = {
+        'entry_name': _entry_name(entry),
+        'file_name': entry.get('file_name') or '',
+        'info_hash': entry.get('info_hash') or entry.get('hash') or '',
+        'cli_debrid_id': entry.get('cli_debrid_id'),
+        'reason': reason,
+        'segment_id': entry.get('nzb_segment_id') or '',
+    }
+    if reason not in PLAYBACK_REPAIR_REASONS:
+        return None
+    if not all((target['entry_name'], target['file_name'], target['info_hash'],
+                target['cli_debrid_id'])):
+        logger.warning('[NZBPlayback] Ignoring incomplete exact target: %r', target)
+        return None
+    return target
 
 
 # ---------------------------------------------------------------------------
@@ -885,11 +924,14 @@ def _scrape_for_replacement(item: dict, broken_nzb_title: str, version_override:
 # Submit replacement and confirm in queue
 # ---------------------------------------------------------------------------
 
-def _submit_and_confirm_replacement(result: dict, title: str, item: dict = None) -> Tuple[Optional[str], str]:
+def _submit_and_confirm_replacement(result: dict, title: str, item: dict = None) -> Tuple[Optional[str], str, str]:
     """
     Submit replacement NZB to provider.
     Polls up to 30s to confirm it appears in the provider queue.
-    Returns (job_id, release_title) or (None, '') on failure.
+    Returns (job_id, release_title, disposition).  ``failed`` is reserved
+    for an explicit terminal provider response; callers may immediately try
+    the next distinct candidate.  ``provisional`` means the submission was
+    accepted but its status is inconclusive, so callers must not duplicate it.
     """
     try:
         from usenet import get_usenet_client, reset_usenet_client
@@ -937,14 +979,19 @@ def _submit_and_confirm_replacement(result: dict, title: str, item: dict = None)
                                     is_anime=_is_anime, media_type=_media_type,
                                     tags=_tags, tags_exclusive=False)
         else:
-            return None, ''
+            return None, '', 'rejected'
 
         if not job_id:
+            failed_job_id = getattr(client, 'last_failed_job_id', '') or ''
+            if failed_job_id:
+                logger.warning('[NZBRepair] Provider immediately failed job %s for %r', failed_job_id, release_title)
+                return failed_job_id, release_title, 'failed'
             logger.warning(f'[NZBRepair] Provider rejected submission for {release_title!r}')
-            return None, ''
+            return None, '', 'rejected'
 
         # Poll up to 30s to confirm job appears in provider queue
         confirmed = False
+        terminal_failure = False
         for attempt in range(6):
             time.sleep(5)
             try:
@@ -954,30 +1001,32 @@ def _submit_and_confirm_replacement(result: dict, title: str, item: dict = None)
                     break
                 if status and status.get('state') in ('failed', 'error'):
                     logger.warning(f'[NZBRepair] Replacement job {job_id} immediately failed: {status}')
+                    terminal_failure = True
                     break
             except Exception:
                 pass
 
         if confirmed:
             logger.info(f'[NZBRepair] Replacement confirmed in queue: job_id={job_id} title={release_title!r}')
-            return job_id, release_title
+            return job_id, release_title, 'accepted'
+        elif terminal_failure:
+            return job_id, release_title, 'failed'
         else:
-            # Job submitted but couldn't confirm — treat as submitted anyway
-            # (provider may have completed instantly if already cached)
-            logger.info(f'[NZBRepair] Replacement submitted (unconfirmed): job_id={job_id} title={release_title!r}')
-            return job_id, release_title
+            logger.info(f'[NZBRepair] Replacement submitted provisionally: job_id={job_id} title={release_title!r}')
+            return job_id, release_title, 'provisional'
 
     except Exception as e:
         logger.error(f'[NZBRepair] _submit_and_confirm_replacement error: {e}')
-        return None, ''
+        return None, '', 'rejected'
 
 
 # ---------------------------------------------------------------------------
 # DB update for repaired item
 # ---------------------------------------------------------------------------
 
-def _update_db_for_repair(item: dict, new_job_id: str, replacement_result: dict, all_results: list) -> bool:
-    """Update DB item in-place: state=Adding, new torrent_id, clear location.
+def _update_db_for_repair(item: dict, new_job_id: str, replacement_result: dict,
+                          all_results: list, preserve_location: bool = False) -> bool:
+    """Update DB item in-place for the accepted candidate.
     Also stores the replacement NZB segment ID so the next repair cycle can
     blacklist it without an extra HTTP fetch."""
     try:
@@ -992,7 +1041,12 @@ def _update_db_for_repair(item: dict, new_job_id: str, replacement_result: dict,
                 r = dict(r)
                 del r['_prefetched_nzb']
             return r
-        remaining = [_strip_prefetched(r) for r in all_results if r.get('title') != replacement_result.get('title')]
+        chosen_keys = candidate_keys(replacement_result)
+        remaining = [
+            _strip_prefetched(r) for r in all_results
+            if not (chosen_keys and candidate_keys(r) & chosen_keys)
+            and r.get('title') != replacement_result.get('title')
+        ]
 
         # Extract segment ID from the pre-fetched NZB XML (zero extra HTTP call)
         new_segment_id = ''
@@ -1015,7 +1069,10 @@ def _update_db_for_repair(item: dict, new_job_id: str, replacement_result: dict,
             scrape_results=remaining,
             **_seg_kwargs,
         )
-        update_media_item(item_id, location_on_disk=None, fall_back_to_single_scraper=False)
+        update_kwargs = {'fall_back_to_single_scraper': False}
+        if not preserve_location:
+            update_kwargs['location_on_disk'] = None
+        update_media_item(item_id, **update_kwargs)
         logger.info(f'[NZBRepair] DB updated item {item_id}: state=Adding torrent_id={new_torrent_id} segment={new_segment_id!r}')
         return True
     except Exception as e:
@@ -1178,6 +1235,7 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
         entry_name = _entry_name(entry)
         info_hash = entry.get('info_hash') or entry.get('hash') or ''
         nzb_url = entry.get('nzb_url') or entry.get('url') or ''
+        playback_target = _exact_playback_target(entry)
 
         # Resolve job UUID from provider if not in health response
         if not info_hash and entry_name:
@@ -1190,13 +1248,24 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
         try:
             # --- Step 1: Match to CLI DB ---
             db_items = []
-            if info_hash:
+            if playback_target:
+                exact_item = _find_db_item_by_id(playback_target['cli_debrid_id'])
+                if exact_item:
+                    current = str(exact_item.get('filled_by_torrent_id') or '')
+                    if current in (info_hash, f'nzb:{info_hash}'):
+                        db_items = [exact_item]
+                    else:
+                        logger.warning(
+                            '[NZBPlayback] Item %s no longer owns old UUID %s; refusing fuzzy repair',
+                            playback_target['cli_debrid_id'], info_hash,
+                        )
+            elif info_hash:
                 single = _find_db_item_by_info_hash(info_hash)
                 if single:
                     db_items = [single]
 
             # Fuzzy fallback only when hash is not authoritative (nzbdav sets hash_is_authoritative)
-            if not db_items and entry_name and not entry.get('hash_is_authoritative'):
+            if not playback_target and not db_items and entry_name and not entry.get('hash_is_authoritative'):
                 db_items = _find_db_items_by_entry_name(entry_name)
 
             if db_items is AMBIGUOUS:
@@ -1239,7 +1308,12 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
                 # Only attempt provider delete if we have a hash — name-search deletes
                 # are slow (one API call per orphan) and orphans with no hash are usually
                 # already gone from the provider queue.
-                if info_hash:
+                if playback_target:
+                    logger.warning(
+                        '[NZBPlayback] Exact item %s is unavailable or changed; leaving mounted file untouched',
+                        playback_target['cli_debrid_id'],
+                    )
+                elif info_hash:
                     logger.warning(f'[NZBRepair] No repairable DB items for {entry_name!r} — orphan, deleting from provider')
                     _delete_from_provider(info_hash, entry_name)
                 else:
@@ -1279,7 +1353,7 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
             _failure_reason = entry.get('failure_reason', '')
             # Skip readability check when cli_mount explicitly reports usenet_segment_missing
             # — that is a definitive diagnosis, not a transient server hiccup.
-            _skip_readability = _failure_reason == 'usenet_segment_missing'
+            _skip_readability = bool(playback_target) or _failure_reason == 'usenet_segment_missing'
             if not _skip_readability:
                 # Also skip when location_on_disk points to a different version.
                 # Compare the parent folder against entry_name — mismatch means
@@ -1309,10 +1383,11 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
                 )
 
             # --- Step 2: Check backoff/attempt limit ---
-            repair_state = get_repair_state(info_hash or entry_name)
+            repair_state = ({'attempts': 0, 'give_up': False}
+                            if playback_target else get_repair_state(info_hash or entry_name))
             attempts = repair_state['attempts']
 
-            if repair_state['give_up']:
+            if not playback_target and repair_state['give_up']:
                 logger.warning(
                     f'[NZBRepair] {entry_name!r} — reached max attempts ({MAX_REPAIR_ATTEMPTS}), '
                     f'requires manual intervention'
@@ -1333,7 +1408,7 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
                 summary['skipped_max_attempts'] += 1
                 continue
 
-            if is_in_backoff(info_hash or entry_name):
+            if not playback_target and is_in_backoff(info_hash or entry_name):
                 logger.info(f'[NZBRepair] {entry_name!r} — in backoff period, skipping this cycle')
                 summary['skipped_backoff'] += 1
                 continue
@@ -1350,6 +1425,25 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
             broken_nzb_title = rep.get('debrid_folder_name') or rep.get('filled_by_file') or entry_name
             candidates = _scrape_for_replacement(rep, broken_nzb_title, version_override=version_override)
 
+            if playback_target:
+                repair_id = begin_playback_repair(rep, playback_target, triggered_by=triggered_by)
+                if not repair_id:
+                    logger.error('[NZBPlayback] State persistence failed; submitting nothing for item %s', rep.get('id'))
+                    summary['errors'] += 1
+                    continue
+                unique_candidates = []
+                seen_keys = set()
+                for candidate in candidates:
+                    keys = candidate_keys(candidate)
+                    if not keys or keys & seen_keys:
+                        continue
+                    seen_keys |= keys
+                    if candidate_is_excluded(rep['id'], candidate):
+                        logger.info('[NZBPlayback] Excluding original/failed candidate %r', candidate.get('title'))
+                        continue
+                    unique_candidates.append(candidate)
+                candidates = unique_candidates
+
             if not candidates:
                 # No replacement found — leave Collected items in place (file may still be
                 # playable) and let the repair backoff handle retrying. Moving Collected items
@@ -1357,6 +1451,10 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
                 # doubling the spam. Non-Collected items (Checking/Adding) have no file on disk
                 # yet so they are moved to Wanted for a fresh scrape.
                 next_repair_at = calculate_next_repair_at(new_attempts)
+                if playback_target:
+                    logger.warning('[NZBPlayback] No distinct candidate for item %s; exact original remains mounted', rep['id'])
+                    summary['no_replacement'] += 1
+                    continue
                 for db_item in db_items:
                     if db_item.get('state') == 'Collected':
                         logger.warning(f'[NZBRepair] No replacement found for {entry_name!r} — keeping Collected, backoff until {next_repair_at}')
@@ -1380,14 +1478,39 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
                 continue
 
             # --- Step 5: Submit replacement and confirm in queue ---
-            best = candidates[0]
-            new_job_id, named_title = _submit_and_confirm_replacement(best, rep.get('title', ''), item=rep)
+            best = None
+            new_job_id = None
+            named_title = ''
+            candidates_to_try = candidates if playback_target else candidates[:1]
+            for candidate in candidates_to_try:
+                job_id, submitted_title, candidate_disposition = _submit_and_confirm_replacement(
+                    candidate, rep.get('title', ''), item=rep)
+                if playback_target and candidate_disposition in ('failed', 'rejected'):
+                    record_failed_candidate(rep['id'], candidate, job_id or '')
+                    logger.warning(
+                        '[NZBPlayback] Candidate rejected (%s); trying next distinct result: %r',
+                        candidate_disposition, candidate.get('title'),
+                    )
+                    continue
+                best = candidate
+                new_job_id = job_id
+                named_title = submitted_title
+                break
 
-            if named_title:
+            if best is not None and named_title:
                 best = dict(best)
+                # cli_mount may sanitize/rename the submitted release.  Keep
+                # the indexer's original title as the durable exclusion key so
+                # a later repair cycle cannot submit the same NZB again under
+                # its pre-submission name.
+                best.setdefault('original_title', best.get('title', ''))
                 best['title'] = named_title
 
             if not new_job_id:
+                if playback_target:
+                    logger.warning('[NZBPlayback] All distinct candidates failed submission for item %s', rep['id'])
+                    summary['submission_failed'] += 1
+                    continue
                 # Submission failed — keep item in Collected state (file still exists/plays).
                 # Moving to Wanted here causes re-scrape → re-submit → new cli_mount entry
                 # created each cycle, producing duplicate entries in the mount.
@@ -1409,6 +1532,27 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
                         next_repair_at=next_repair_at,
                     )
                 summary['submission_failed'] += 1
+                continue
+
+            if playback_target:
+                # Submission/collection is provisional.  Keep Plex, its symlink,
+                # and every broken mounted file until the completion worker proves
+                # this exact UUID healthy and finishes exact acknowledgements.
+                if not set_playback_candidate(rep['id'], best, new_job_id, named_title or best.get('title', '')):
+                    record_failed_candidate(rep['id'], best, new_job_id)
+                    logger.error('[NZBPlayback] Could not persist accepted candidate %s; DB item unchanged', new_job_id)
+                    summary['errors'] += 1
+                    continue
+                if not _update_db_for_repair(rep, new_job_id, best, candidates, preserve_location=True):
+                    logger.error('[NZBPlayback] Could not move accepted candidate %s into Adding', new_job_id)
+                    summary['errors'] += 1
+                    continue
+                summary.setdefault('pending_verification', 0)
+                summary['pending_verification'] += 1
+                logger.info(
+                    '[NZBPlayback] Candidate %s accepted provisionally for item %s; old file and Plex retained',
+                    new_job_id, rep['id'],
+                )
                 continue
 
             # --- REPLACEMENT CONFIRMED — now safe to delete broken ---

--- a/usenet/repair_engine.py
+++ b/usenet/repair_engine.py
@@ -58,6 +58,7 @@ from database.nzb_playback_repair import (
     begin_playback_repair,
     candidate_is_excluded,
     candidate_keys,
+    has_active_exact_repair,
     record_failed_candidate,
     set_playback_candidate,
 )
@@ -95,6 +96,16 @@ def _find_db_item_by_id(item_id):
         return dict(row) if row else None
     finally:
         conn.close()
+
+
+def _has_pending_exact_playback_repair(playback_target, info_hash):
+    """Whether a changed media row is already tracked by the exact repair lifecycle."""
+    if not playback_target:
+        return False
+    return has_active_exact_repair(
+        playback_target.get('cli_debrid_id'), info_hash,
+        playback_target.get('file_name'),
+    )
 
 
 def _exact_playback_target(entry):
@@ -1313,6 +1324,15 @@ def _run_repair_inner(triggered_by: str = 'scheduled', version_override: str = N
                         '[NZBPlayback] Exact item %s is unavailable or changed; leaving mounted file untouched',
                         playback_target['cli_debrid_id'],
                     )
+                    if _has_pending_exact_playback_repair(playback_target, info_hash):
+                        logger.info(
+                            '[NZBPlayback] Exact old file already belongs to an active repair; '
+                            'retaining its canonical activity and suppressing duplicate Not Found '
+                            '(item=%s uuid=%s file=%s)',
+                            playback_target['cli_debrid_id'], info_hash,
+                            playback_target['file_name'],
+                        )
+                        continue
                 elif info_hash:
                     logger.warning(f'[NZBRepair] No repairable DB items for {entry_name!r} — orphan, deleting from provider')
                     _delete_from_provider(info_hash, entry_name)


### PR DESCRIPTION
## Summary

Adds a minimal, exact-identity NZB playback-repair lifecycle in its own table (`nzb_playback_repairs`), deliberately independent of the older experimental replacement-saga tables. Pairs with [mash2k3/decypharr#2](https://github.com/mash2k3/decypharr/pull/2).

- When a mounted file is flagged unplayable, a candidate replacement is submitted and tracked provisionally — the old file and Plex entry are retained until the exact replacement is proven healthy.
- Once decypharr's `/api/repair/replacements/verify` confirms the replacement is healthy, the old file is cleaned up via `/api/repair/replacements/ack`, and the activity log is finalized as `replaced` — never delete-before-confirm.
- If an accepted candidate later verifies broken, `find_and_submit_playback_candidate` automatically resumes searching for a different one instead of stalling.

## ⚠️ Needs testing on Plex mode

Everything in this PR has only been exercised against a live instance running **Symlinked/Local** file management. The verification step (`_symlink_matches`) originally required `location_on_disk` to be a real OS symlink, which is only ever true in Symlinked/Local mode — in **Plex mode**, `location_on_disk` is the real mounted file path as reported by Plex's own API, never a symlink, so every repair would have looped forever on `replacement_symlink_not_ready` and never reached `replaced`. This has been fixed (see below) by tracing through the whole pipeline, but the fix itself has **not** been run against a real Plex-mode deployment — only unit-tested against a synthetic real-file-not-symlink case. Would appreciate someone on Plex mode confirming a repair actually completes end-to-end (reaches `replaced` in the activity log, old file gets cleaned up) before this is considered fully verified for both modes.

## Fixes included from testing against a real running instance

- **Retry-forever loops**: a persistent `stale_target` on the exact-cleanup ack (see decypharr PR for the underlying race) or an undeletable stale `failed_job_id` would retry every 15–30s indefinitely, leaving the repair stuck at "Pending verification" forever. Both now have a bounded attempt cap (`STALE_TARGET_MAX_ATTEMPTS`, `FAILED_JOB_MAX_ATTEMPTS`).
- **HTTP error handling**: the shared `api.delete()` wrapper calls `raise_for_status()`, which turns any non-2xx response (including a `404` meaning "already gone") into a raised exception — so `remove_nzb_exact`/`remove_nzb`'s own status-code checks for `404` were dead code and a clean "already deleted" response was being treated as a failure. Added `_delete_status()` to unwrap the real status code from the exception.
- **Plex-mode verification lockout**: `_symlink_matches()` now falls back to checking the real file directly when `location_on_disk` isn't a symlink, covering both Plex mode and Windows Symlinked/Local (which uses hardlinks, not symlinks). See the testing note above.
- **Old file abandoned instead of retried**: after exhausting the fast retry cap on `stale_target`, the repair was finalizing as `replaced` but permanently leaving the old file undeleted — in practice this often happens because decypharr's own multi-hour general health sweeps cause transient `stale_target` well past the old ~2.5 minute retry window, on cleanup that would have succeeded fine given more time. The repair still finalizes as `replaced` immediately once the new file is confirmed (that's never blocked further), but the old-file cleanup is now handed off to a new slow-cadence background task (`task_nzb_playback_cleanup_retry`, every 20 min) that keeps retrying the same safety-checked ack call with backoff for up to 48 hours before concluding it's genuinely unresolvable.
- **More retry-forever loops found under real load**: the verify-stage's `unknown`/`stale_target`/`repair_busy` branches and the candidate-search retry loop (`awaiting_candidate`) all rescheduled unconditionally with no attempt cap — one item (a Bar Rescue episode) sat retrying verification for 27+ hours with nothing surfaced anywhere. Verify `unknown` and `stale_target` now reject the candidate and resume searching after a bounded number of attempts; `repair_busy` gets a much longer leash since it just means decypharr's own sweep is running, not that the candidate is bad. The candidate-search loop never fully gives up on its own (usenet content can reappear days later), but now becomes visible after ~2h with no candidate found (`skipped_max_attempts` in the activity log) and actually stops scheduling after 7 days with nothing found (`abandoned_after_retries`).
- **Exact-cleanup's generic-failure branch had no cap**, unlike its `stale_target` sibling right next to it — any other persistent ack failure retried inline every 15s forever instead of ever finalizing. Now capped the same way: defer to the background retry and finalize as replaced, same as `stale_target` already does.
- **Two systems could race to fix the same broken item**: the general repair engine (`run_repair`) and this minimal exact-playback-repair system could both independently submit a candidate for the same broken file — whichever candidate collected first silently overwrote `filled_by_torrent_id`, orphaning the other and leaving its `nzb_playback_repairs` row spinning on `candidate_source_changed` forever, plus a wasted duplicate download. `has_active_exact_repair()` already existed to prevent this but was only checked in the orphan (no matching DB row) branch; extended to the matched-item branch too. Also capped `candidate_source_changed` itself as a backstop for if the race happens some other way.
- **The `candidate_source_changed` backstop's "superseded externally" branch left the original broken file's cleanup unreachable**: it correctly stopped touching the new candidate it no longer owned, but never set `cleanup_status='pending'` — so the background cleanup retry (which only picks up `status='complete' AND cleanup_status='pending'`) never picked up the still-known-exactly old file. Confirmed live on a real repair that hit this branch. Now hands the original file off to the same background retry a normal successful repair already uses.

## Test plan

- [x] `python3 -m pytest tests/` — full suite green, including coverage for the retry backstops, the 404 unwrap fix, the Plex-mode/Symlinked-mode verification fix, the deferred cleanup/background-retry flow, the verify-stage and candidate-search caps, the exact-cleanup generic-failure cap, the general-repair-engine race guard, and the superseded-externally cleanup handoff (`test_general_repair_skips_item_with_active_exact_repair`, `test_source_mismatch_rejects_candidate_after_max_attempts_when_reverted`, `test_source_mismatch_stops_without_cleanup_when_superseded_externally`, `test_superseded_externally_cleanup_is_picked_up_by_background_retry`)
- [x] Verified against a real cli_debrid + decypharr instance over an extended session (Symlinked/Local mode only): previously-stuck repairs (`stale_target` loops, undeletable failed jobs, verify-stage loops, the general-engine race, the superseded-externally cleanup gap) all now resolve
- [x] Live-verified the exact-cleanup orphaned-registration fix (decypharr-side) directly against a running instance: reproduced the failure, confirmed the fix clears it end-to-end
- [x] **End-of-session health check**: after deploying every fix in this PR, the running instance settled to zero stuck repairs — all `nzb_playback_repairs` rows were either `complete` or actively progressing (searching/downloading), none idle past 20 minutes, and decypharr's broken-file count dropped from dozens to only entries with active repairs already in flight
- [ ] **Plex mode**: not yet verified end-to-end on a real instance — see note above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
