### PR TITLE
Fix NZB season-pack misdetection using obfuscated filenames

### DIFF
--- a/queues/scraping_queue.py
+++ b/queues/scraping_queue.py
@@ -301,7 +301,16 @@ class ScrapingQueue:
                         finally:
                             _cconn.close()
                         import re as _re_coal
-                        if _sibling_nzb and not _re_coal.search(r'[Ss]\d{2}[Ee]\d{2}', _sibling_nzb[1] or ''):
+                        # Check the original scraped release title first — it reflects what was
+                        # actually searched/matched and isn't obfuscated. filled_by_file (the
+                        # downloaded filename) is only a fallback: it's frequently an obfuscated
+                        # hex string for single-episode NZBs, which was wrongly read as "not a
+                        # normal episode filename, must be an unresolved pack" and caused
+                        # coalescing to fire for genuinely single-episode releases.
+                        _coal_check_title = _sibling_nzb[4] if _sibling_nzb else None  # original_scraped_torrent_title
+                        if not _coal_check_title and _sibling_nzb:
+                            _coal_check_title = _sibling_nzb[1]  # fall back to filled_by_file
+                        if _sibling_nzb and not _re_coal.search(r'[Ss]\d{2}[Ee]\d{2}', _coal_check_title or ''):
                             _job_id = _sibling_nzb[0]
                             _job_url = _sibling_nzb[2] or ''
                             _job_title = _sibling_nzb[3] or ''

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -548,8 +548,12 @@ class TorrentProcessor:
                                 _mem_item.get('version', 'Default') != _item_version or
                                 not str(_mem_item.get('filled_by_torrent_id', '')).startswith('nzb:')):
                             continue
-                        _mem_file = _mem_item.get('filled_by_file') or ''
-                        _mem_is_pack = not _re_mem.search(r'[Ss]\d{2}[Ee]\d{2}', _mem_file)
+                        # Prefer the original scraped release title over filled_by_file, which
+                        # is frequently an obfuscated hex string for single-episode usenet
+                        # releases and was wrongly read as "not a normal episode filename,
+                        # must be an unresolved pack".
+                        _mem_check_title = _mem_item.get('original_scraped_torrent_title') or _mem_item.get('filled_by_file') or ''
+                        _mem_is_pack = not _re_mem.search(r'[Ss]\d{2}[Ee]\d{2}', _mem_check_title)
                         _mem_job = _mem_item.get('filled_by_torrent_id')
                         _mem_id = _mem_job[4:] if _mem_job and _mem_job.startswith('nzb:') else _mem_job
                         if _is_pack and _mem_is_pack:
@@ -577,7 +581,7 @@ class TorrentProcessor:
                     _sibling_ver = (item.get('version') or '').rstrip('*')
                     try:
                         _sibling = _conn.execute(
-                            "SELECT filled_by_torrent_id, filled_by_file FROM media_items "
+                            "SELECT filled_by_torrent_id, filled_by_file, original_scraped_torrent_title FROM media_items "
                             "WHERE imdb_id=? AND season_number=? AND type='episode' "
                             "AND id!=? AND filled_by_torrent_id LIKE 'nzb:%' "
                             "AND REPLACE(COALESCE(version,''),'*','')=? "
@@ -587,7 +591,12 @@ class TorrentProcessor:
                     finally:
                         _conn.close()
                     if _sibling:
-                        _sibling_is_pack = not _re_dedup.search(r'[Ss]\d{2}[Ee]\d{2}', _sibling[1] or '')
+                        # Prefer the original scraped release title (not obfuscated) over
+                        # filled_by_file, which is frequently an obfuscated hex string for
+                        # single-episode usenet releases and was wrongly read as "not a normal
+                        # episode filename, must be an unresolved pack".
+                        _sibling_check_title = _sibling[2] or _sibling[1] or ''
+                        _sibling_is_pack = not _re_dedup.search(r'[Ss]\d{2}[Ee]\d{2}', _sibling_check_title)
                         if _is_pack and _sibling_is_pack:
                             # New result is a pack, existing job is a pack — reuse existing
                             _existing_job = _sibling[0]


### PR DESCRIPTION
## Summary

Three separate call sites guessed whether a sibling episode's NZB job was a season pack by regex-matching `SxxEyy` against `filled_by_file` (the downloaded filename):
- `queues/scraping_queue.py`'s coalescing check
- `queues/torrent_processor.py`'s in-memory adding-queue sibling check
- `queues/torrent_processor.py`'s DB sibling check

For usenet releases this filename is frequently an obfuscated hex string even for genuine single-episode NZBs, so the `SxxEyy` match failed and the release was wrongly treated as an unresolved season pack — causing individual episodes to be silently coalesced/reused as if they were pack jobs.

`original_scraped_torrent_title` (the pre-download indexer release title) isn't obfuscated and is a reliable signal for this check. All three call sites now prefer it over `filled_by_file`, falling back to `filled_by_file` only when the original title is unavailable.

## Root cause

Confirmed via `git blame` that this bug predates any downstream changes (introduced in `89bcdca6`, 2026-08-10) — pre-existing in `dev`, unrelated to any other in-flight work.

## Test plan

- [x] `python3 -m py_compile` on both changed files
- [x] Live-verified against a running instance: reproduced the misdetection (Lioness, Breaking Bad episodes wrongly coalesced into "season pack already submitted" skips), applied the fix live, confirmed individual episodes are now submitted correctly instead of being skipped/reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)