### PR TITLE
Show a styled horizontal scrollbar on the Discover page category rows

### DIFF
--- a/static/css/discover.css
+++ b/static/css/discover.css
@@ -582,19 +582,33 @@ input, textarea, [contenteditable="true"] {
     gap: 1rem;
     overflow-x: auto;
     overflow-y: hidden;
-    padding-bottom: 0.5rem;
+    padding-bottom: 0.75rem;
     scroll-behavior: smooth;
     -webkit-overflow-scrolling: touch;
 }
 
-/* Hide scrollbar but keep functionality */
+/* Visible horizontal scrollbar, styled to match the site's scrollbar theme */
 .category-grid {
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE/Edge */
+    scrollbar-width: thin; /* Firefox */
+    scrollbar-color: #5a5a5a #2c2c2c; /* Firefox: thumb track */
 }
 
 .category-grid::-webkit-scrollbar {
-    display: none; /* Chrome, Safari, Opera */
+    height: 8px;
+}
+
+.category-grid::-webkit-scrollbar-track {
+    background: #2c2c2c;
+    border-radius: 4px;
+}
+
+.category-grid::-webkit-scrollbar-thumb {
+    background: #5a5a5a;
+    border-radius: 4px;
+}
+
+.category-grid::-webkit-scrollbar-thumb:hover {
+    background: #707070;
 }
 
 /* Fixed width for items in horizontal scroll */

--- a/static/css/tangerine/tangerine_discover.css
+++ b/static/css/tangerine/tangerine_discover.css
@@ -364,19 +364,32 @@ body[data-theme="tangerine"] .discover-subtitle {
     gap: 1rem;
     overflow-x: auto;
     overflow-y: hidden;
-    padding-bottom: 0.5rem;
+    padding-bottom: 0.75rem;
     scroll-behavior: smooth;
     -webkit-overflow-scrolling: touch;
 }
 
-/* Hide scrollbar but keep functionality */
+/* Visible horizontal scrollbar - matches filter-drawer/filter-content styling */
 .category-grid {
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE/Edge */
+    scrollbar-width: thin; /* Firefox */
+    scrollbar-color: rgba(255, 255, 255, 0.1) rgba(255, 255, 255, 0.02);
 }
 
 .category-grid::-webkit-scrollbar {
-    display: none; /* Chrome, Safari, Opera */
+    height: 6px;
+}
+
+.category-grid::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.category-grid::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+}
+
+.category-grid::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 107, 53, 0.3);
 }
 
 /* Fixed width for items in horizontal scroll */


### PR DESCRIPTION
## Summary

The Discover page's category-row scroll containers hide their horizontal scrollbar entirely (`scrollbar-width: none` / `-webkit-scrollbar { display: none }`), so there's no visual affordance that a row scrolls sideways — you only find out by dragging or scrolling into it.

This gives the scroll container a thin, theme-matched scrollbar instead, for both the default and tangerine themes.

## Changes

- `static/css/discover.css` — visible thin scrollbar for the default theme
- `static/css/tangerine/tangerine_discover.css` — matching styling for the tangerine theme

CSS-only change, no HTML/JS/behavior changes — purely a visual affordance fix.

## Test plan

- [x] Verified against a running instance in the browser: category rows now show a subtle horizontal scrollbar on hover/scroll, in both the default and tangerine themes
- [x] Confirmed no layout shift — only `padding-bottom` on the scroll container adjusted slightly to make room for the scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)