### PR TITLE
Fix Overseerr deletion sync: delete the media record, and scope it correctly

### DIFF
--- a/content_checkers/overseerr.py
+++ b/content_checkers/overseerr.py
@@ -506,36 +506,74 @@ def remove_from_overseerr_by_tmdb_id(tmdb_id: int, media_type: str, imdb_id: str
                 'request_id': None
             }
 
-        # Step 1: Lookup request ID
+        # Step 1: Look up the media record and any request on it. The media record's
+        # id (mediaInfo.id) is distinct from the request id, and is what actually
+        # drives Overseerr/Jellyseerr's "Available"/"Partially Available" status and
+        # blocks re-requesting — deleting only the request leaves that status intact.
+        details = get_overseerr_details(overseerr_url, api_key, tmdb_id, media_type)
+        media_info = (details or {}).get('mediaInfo') or {}
+        media_id = media_info.get('id')
         request_id = get_overseerr_request_id(overseerr_url, api_key, tmdb_id, media_type)
 
-        if not request_id:
+        if not request_id and not media_id:
             return {
                 'success': False,
-                'message': f'No request found for TMDB ID {tmdb_id}',
+                'message': f'No request or media record found for TMDB ID {tmdb_id}',
                 'request_id': None,
                 'not_found': True  # Flag to indicate item wasn't in Overseerr
             }
 
-        # Step 2: Delete the request
-        url = f"{overseerr_url}/api/v1/request/{request_id}"
         headers = get_overseerr_headers(api_key)
+        request_deleted = False
+        request_error = None
 
-        response = api.delete(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        # Step 2: Delete the request, if one exists
+        if request_id:
+            url = f"{overseerr_url}/api/v1/request/{request_id}"
+            response = api.delete(url, headers=headers, timeout=REQUEST_TIMEOUT)
 
-        if response.status_code == 204:
-            logging.info(f"Successfully deleted Overseerr request {request_id} for TMDB {tmdb_id}")
+            if response.status_code == 204:
+                logging.info(f"Successfully deleted Overseerr request {request_id} for TMDB {tmdb_id}")
+                request_deleted = True
+            else:
+                error_text = response.text if hasattr(response, 'text') else 'Unknown error'
+                logging.error(f"Failed to delete Overseerr request {request_id}: HTTP {response.status_code} - {error_text}")
+                request_error = f'HTTP {response.status_code}: {error_text}'
+
+        # Step 3: Delete the media record itself so availability status actually
+        # clears (this is the same call Overseerr's own "Remove from Overseerr"
+        # button makes). Do this even if there was no request to delete, and even
+        # if the request delete above failed — the media record is independent.
+        media_deleted = False
+        media_error = None
+
+        if media_id:
+            media_url = f"{overseerr_url}/api/v1/media/{media_id}"
+            media_response = api.delete(media_url, headers=headers, timeout=REQUEST_TIMEOUT)
+
+            if media_response.status_code in (200, 204):
+                logging.info(f"Successfully deleted Overseerr media record {media_id} for TMDB {tmdb_id}")
+                media_deleted = True
+            else:
+                error_text = media_response.text if hasattr(media_response, 'text') else 'Unknown error'
+                logging.error(f"Failed to delete Overseerr media record {media_id}: HTTP {media_response.status_code} - {error_text}")
+                media_error = f'HTTP {media_response.status_code}: {error_text}'
+
+        if request_deleted or media_deleted:
+            message_parts = []
+            if request_deleted:
+                message_parts.append(f'request {request_id}')
+            if media_deleted:
+                message_parts.append(f'media record {media_id}')
             return {
                 'success': True,
-                'message': f'Removed request {request_id}',
+                'message': f"Removed {' and '.join(message_parts)}",
                 'request_id': request_id
             }
         else:
-            error_text = response.text if hasattr(response, 'text') else 'Unknown error'
-            logging.error(f"Failed to delete Overseerr request {request_id}: HTTP {response.status_code} - {error_text}")
             return {
                 'success': False,
-                'message': f'HTTP {response.status_code}: {error_text}',
+                'message': request_error or media_error or 'Unknown error',
                 'request_id': request_id
             }
 

--- a/tests/test_overseerr_removal.py
+++ b/tests/test_overseerr_removal.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Unit tests for remove_from_overseerr_by_tmdb_id's request+media deletion logic.
+
+Overseerr/Jellyseerr track a "request" and a "media" record separately — the
+media record is what actually drives the "Available"/"Partially Available"
+status, so deleting only the request (the old behavior) left items still
+showing as available. These tests exercise the real function with the HTTP
+layer stubbed, verifying both the request and the media record get deleted,
+and that either one succeeding is enough to report overall success.
+"""
+
+import unittest
+import sys
+import os
+import types
+
+
+def _load(get_responses, delete_responses):
+    """Load content_checkers/overseerr.py fresh with a stubbed `api` module.
+
+    get_responses: dict endpoint-suffix -> response dict (for api.get(...).json())
+    delete_responses: dict url -> (status_code, text)
+    """
+    if 'utilities' not in sys.modules:
+        sys.modules['utilities'] = types.ModuleType('utilities')
+    uss = types.ModuleType('utilities.settings')
+    uss.get_setting = lambda *a, **k: None
+    uss.get_all_settings = lambda *a, **k: {}
+    sys.modules['utilities.settings'] = uss
+
+    if 'routes' not in sys.modules:
+        sys.modules['routes'] = types.ModuleType('routes')
+
+    class FakeResponse:
+        def __init__(self, status_code, payload=None, text=''):
+            self.status_code = status_code
+            self._payload = payload or {}
+            self.text = text
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise Exception(f'HTTP {self.status_code}')
+
+        def json(self):
+            return self._payload
+
+    class FakeRequestException(Exception):
+        pass
+
+    def fake_get(url, headers=None, timeout=None):
+        for suffix, payload in get_responses.items():
+            if url.endswith(suffix):
+                return FakeResponse(200, payload)
+        return FakeResponse(404, {})
+
+    def fake_delete(url, headers=None, timeout=None):
+        status, text = delete_responses.get(url, (404, 'not found'))
+        return FakeResponse(status, text=text)
+
+    rta = types.ModuleType('routes.api_tracker')
+    rta.api = types.SimpleNamespace(
+        get=fake_get,
+        delete=fake_delete,
+        exceptions=types.SimpleNamespace(RequestException=FakeRequestException),
+    )
+    sys.modules['routes.api_tracker'] = rta
+
+    import importlib.util
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                         'content_checkers', 'overseerr.py')
+    spec = importlib.util.spec_from_file_location('overseerr_removal_test', path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+MEDIA_WITH_APPROVED_REQUEST = {
+    'mediaInfo': {
+        'id': 555,
+        'requests': [{'id': 999, 'status': 2, 'requestedBy': {'displayName': 'x'}}],
+    }
+}
+
+MEDIA_NO_REQUESTS = {
+    'mediaInfo': {
+        'id': 555,
+        'requests': [],
+    }
+}
+
+MEDIA_NOT_FOUND = {}
+
+
+class TestOverseerrRemoval(unittest.TestCase):
+
+    def test_removes_both_request_and_media(self):
+        m = _load(
+            get_responses={'/tv/123': MEDIA_WITH_APPROVED_REQUEST},
+            delete_responses={
+                'http://ov/api/v1/request/999': (204, ''),
+                'http://ov/api/v1/media/555': (204, ''),
+            },
+        )
+        result = m.remove_from_overseerr_by_tmdb_id(
+            tmdb_id=123, media_type='show', overseerr_url='http://ov', api_key='k')
+        self.assertTrue(result['success'])
+        self.assertEqual(result['request_id'], 999)
+        self.assertIn('request 999', result['message'])
+        self.assertIn('media record 555', result['message'])
+
+    def test_removes_media_only_when_no_request(self):
+        m = _load(
+            get_responses={'/tv/123': MEDIA_NO_REQUESTS},
+            delete_responses={
+                'http://ov/api/v1/media/555': (204, ''),
+            },
+        )
+        result = m.remove_from_overseerr_by_tmdb_id(
+            tmdb_id=123, media_type='show', overseerr_url='http://ov', api_key='k')
+        self.assertTrue(result['success'])
+        self.assertIsNone(result['request_id'])
+        self.assertIn('media record 555', result['message'])
+
+    def test_not_found_when_neither_exists(self):
+        m = _load(
+            get_responses={'/tv/123': MEDIA_NOT_FOUND},
+            delete_responses={},
+        )
+        result = m.remove_from_overseerr_by_tmdb_id(
+            tmdb_id=123, media_type='show', overseerr_url='http://ov', api_key='k')
+        self.assertFalse(result['success'])
+        self.assertTrue(result.get('not_found'))
+
+    def test_media_delete_still_succeeds_when_request_delete_fails(self):
+        # The request delete fails (e.g. request already gone), but the media
+        # record still gets deleted — availability status still clears, which
+        # is the actual user-visible fix, so this must still report success.
+        m = _load(
+            get_responses={'/tv/123': MEDIA_WITH_APPROVED_REQUEST},
+            delete_responses={
+                'http://ov/api/v1/request/999': (404, 'gone'),
+                'http://ov/api/v1/media/555': (204, ''),
+            },
+        )
+        result = m.remove_from_overseerr_by_tmdb_id(
+            tmdb_id=123, media_type='show', overseerr_url='http://ov', api_key='k')
+        self.assertTrue(result['success'])
+        self.assertIn('media record 555', result['message'])
+
+    def test_total_failure_when_both_deletes_fail(self):
+        m = _load(
+            get_responses={'/tv/123': MEDIA_WITH_APPROVED_REQUEST},
+            delete_responses={
+                'http://ov/api/v1/request/999': (500, 'boom'),
+                'http://ov/api/v1/media/555': (500, 'boom'),
+            },
+        )
+        result = m.remove_from_overseerr_by_tmdb_id(
+            tmdb_id=123, media_type='show', overseerr_url='http://ov', api_key='k')
+        self.assertFalse(result['success'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utilities/deletion_manager.py
+++ b/utilities/deletion_manager.py
@@ -2725,6 +2725,73 @@ class DeletionManager:
             else:
                 logging.info(f"[DELETE_MULTIPLE] Phase 0: No torrent/NZB IDs found for removal")
 
+        # PHASE 0.3: Content source removal (Trakt/Overseerr/etc.) - grouped, not per-item.
+        # For TV, a request/media record in a content source is tracked per SHOW, not per
+        # episode — so this must only fire when this batch covers every remaining kept
+        # episode of the show (no sibling outside the batch). Without this guard, deleting
+        # even a single episode or season through the generic multi-select path would
+        # remove the content source's request/media record for the ENTIRE show, wiping its
+        # availability status even though most of it is still collected. Movies don't have
+        # this ambiguity (one item = one removal target) and are handled per-item as before.
+        # Mirrors the existing show-level call already used by the dedicated /delete_show
+        # route, generalized here so every caller gets the same safety automatically.
+        if remove_from_content_source:
+            from database.database_reading import get_items_by_ids as _get_items_for_cs
+
+            content_source_results = {}
+            items_for_cs = _get_items_for_cs(item_ids)
+            _batch_id_set_cs = set(item_ids)
+
+            for movie_item in (it for it in items_for_cs if it.get('type') == 'movie'):
+                try:
+                    r = self.remove_from_content_source(movie_item)
+                    content_source_results[f"movie_{movie_item['id']}"] = r
+                except Exception as e:
+                    logging.error(f"[DELETE_MULTIPLE] Content source removal failed for movie {movie_item.get('id')}: {e}")
+
+            # Group episode items by show (imdb_id) - one removal attempt per show, not per episode
+            shows_seen = {}
+            for ep in (it for it in items_for_cs if it.get('type') == 'episode'):
+                imdb_id = ep.get('imdb_id')
+                if imdb_id and imdb_id not in shows_seen:
+                    shows_seen[imdb_id] = ep
+
+            for imdb_id, rep_episode in shows_seen.items():
+                try:
+                    from database import get_db_connection as _gdb_cs
+                    _conn_cs = _gdb_cs()
+                    try:
+                        _rows = _conn_cs.execute(
+                            "SELECT id FROM media_items WHERE imdb_id = ? AND type = 'episode' "
+                            "AND state IN ('Collected','Upgrading','Checking')",
+                            (imdb_id,)
+                        ).fetchall()
+                    finally:
+                        _conn_cs.close()
+                    has_external_sibling = any(r[0] not in _batch_id_set_cs for r in _rows)
+                except Exception as e:
+                    logging.warning(f"[DELETE_MULTIPLE] Sibling check failed for content source removal of show {imdb_id}, skipping to be safe: {e}")
+                    has_external_sibling = True
+
+                if has_external_sibling:
+                    logging.info(f"[DELETE_MULTIPLE] Skipping content source removal for show {imdb_id} — other episodes remain outside this batch (partial deletion)")
+                    continue
+
+                show_item = rep_episode.copy()
+                show_item['type'] = 'show'
+                try:
+                    r = self.remove_from_content_source(show_item)
+                    content_source_results[f"show_{imdb_id}"] = r
+                    logging.info(f"[DELETE_MULTIPLE] Removed show {imdb_id} from content sources (batch covers every remaining episode): {r.get('message')}")
+                except Exception as e:
+                    logging.error(f"[DELETE_MULTIPLE] Content source removal failed for show {imdb_id}: {e}")
+
+            aggregate_result['content_source_removal'] = content_source_results
+
+            # Already handled above, centrally and per-show/per-movie - never let the
+            # per-item loop below redundantly (and unsafely, for episodes) repeat this.
+            remove_from_content_source = False
+
         # PHASE 0.5: Batch cache clearing (if enabled) - BEFORE per-item loop
         # Opens each cache file once instead of once per item
         batch_cache_cleared = False


### PR DESCRIPTION
## Summary

Two related fixes to how cli_debrid removes items from Overseerr on deletion.

### 1. Delete the media record, not just the request

`remove_from_overseerr_by_tmdb_id` only called `DELETE /api/v1/request/{id}` — which deletes the *request* object but not the underlying *media* record. Overseerr/Jellyseerr track those separately: the media record is what actually drives the "Available"/"Partially Available" status shown on the details page. So deletion reported success, but the item kept showing as available in Overseerr/Jellyseerr — and could get re-added the next time the content source was pulled, since Overseerr still considered it requested/available.

Now also calls `DELETE /api/v1/media/{mediaId}` — the same call Overseerr's own "Remove from Overseerr" button makes — using the media id already available from the existing details lookup (`mediaInfo.id`). Either delete succeeding is enough to report overall success.

### 2. Scope that removal to full shows/movies only, never partial deletions

The media-record delete from fix #1 is a show-wide action — but `delete_multiple_items` called content-source removal per individual item with no awareness of whether a deletion batch covered a whole show or just some of its episodes. Deleting a single episode or season through the generic multi-select endpoint (`remove_from_content_sources` defaults to on) would have wiped Overseerr's status for the *entire* show, not just the part being deleted.

Checked Overseerr's real API spec directly: there's no season- or episode-level status endpoint, only whole-media delete and whole-media status update. So there's no correct partial action available — the only safe behavior is to skip content-source removal entirely for partial deletions and let Overseerr's own next Plex scan pick up the season/episode disappearing on its own.

`delete_multiple_items` now groups episode items by show and only fires removal when the batch covers every remaining kept episode of that show (no sibling outside the batch — same guard pattern already used for debrid removal in this function), doing it once per show rather than once per episode. Movies are unaffected (one item already maps 1:1 to one removal target). The dedicated `/delete_show` and `/delete_episode` routes already had their own correct scoping for this; this generalizes the same safety to the shared batch orchestrator so every caller gets it, including the generic multi-select `/delete_items` endpoint that previously had no guard at all.

## Test plan

- [x] `python3 -m pytest tests/test_overseerr_removal.py` — 5 tests covering request+media deletion, media-only, request-fails-but-media-succeeds, total failure, not-found
- [x] Verified the scope guard against a throwaway test DB inside the running container (not the real database): a full-show batch triggers exactly one show-level removal, a partial episode/season batch triggers none, movie deletion is unaffected
- [x] Live-verified fix #1 against a real cli_debrid + Overseerr/Jellyseerr instance: deleted a show, confirmed it now correctly clears to "not requested" instead of staying "Partially Available"
- [x] Live-patched fix #2 into the same running instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)