### PR TITLE
Merge duplicate Symlink Settings / Symlink & Naming sections

### DIFF
--- a/templates/settings_tabs/additional_tangerine.html
+++ b/templates/settings_tabs/additional_tangerine.html
@@ -1006,6 +1006,22 @@ document.addEventListener('DOMContentLoaded', function() {
             <p class="settings-description">Name of the documentary TV shows folder</p>
         </div>
 
+        <div class="settings-form-group">
+            <label for="additional-anime_renaming_using_anidb" class="settings-title">Use AniDB for Anime Renaming:</label>
+            <input type="checkbox" id="additional-anime_renaming_using_anidb" name="Debug.anime_renaming_using_anidb"
+                   data-section="Debug" data-key="anime_renaming_using_anidb"
+                   {% if settings.get('Debug', {}).get('anime_renaming_using_anidb') %}checked{% endif %}>
+            <p class="settings-description">Use AniDB to rename anime episodes instead of Trakt metadata (symlinking only)</p>
+        </div>
+
+        <div class="settings-form-group">
+            <label for="additional-use_symlinks_on_windows" class="settings-title">Use Symlinks on Windows:</label>
+            <input type="checkbox" id="additional-use_symlinks_on_windows" name="Debug.use_symlinks_on_windows"
+                   data-section="Debug" data-key="use_symlinks_on_windows"
+                   {% if settings.get('Debug', {}).get('use_symlinks_on_windows') %}checked{% endif %}>
+            <p class="settings-description">Allow the use of symlinks on Windows. WARNING: Creating symlinks on Windows requires administrator privileges or Developer Mode to be enabled.</p>
+        </div>
+
         <div class="settings-form-group example-paths-container" style="margin-top: 20px; padding-top: 15px; border-top: 1px solid #444;">
             <h5 class="settings-title" style="margin-bottom: 10px;">Example Symlink Paths (Based on Current Settings):</h5>
             

--- a/templates/settings_tabs/debug_tangerine.html
+++ b/templates/settings_tabs/debug_tangerine.html
@@ -547,66 +547,6 @@
     </div>
 </div>
 
-<!-- Symlink & Naming Section -->
-<div class="settings-section settings-card">
-    <div class="settings-section-header">
-        <svg class="expand-icon settings-toggle-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-        </svg>
-        <div class="settings-header-left">
-            <h4>Symlink & Naming</h4>
-        </div>
-    </div>
-    <div class="settings-section-content">
-        {% for key in ['symlink_movie_template', 'symlink_episode_template', 'anime_renaming_using_anidb', 'enable_separate_anime_folders', 'enable_separate_documentary_folders', 'movies_folder_name', 'tv_shows_folder_name', 'anime_movies_folder_name', 'anime_tv_shows_folder_name', 'documentary_movies_folder_name', 'documentary_tv_shows_folder_name', 'apply_to_anime_tv_shows', 'apply_to_documentary_movies', 'apply_to_documentary_tv_shows', 'use_symlinks_on_windows'] %}
-            {% set value = settings_schema.Debug.get(key) %}
-            {% if value %}
-            <div class="settings-form-group">
-                <label for="debug-{{ key }}" class="settings-title">{{ key|replace('_', ' ')|title }}:</label>
-                {% if value.type == 'boolean' %}
-                    <input type="checkbox" id="debug-{{ key }}" name="Debug.{{ key }}"
-                           data-section="Debug" data-key="{{ key }}"
-                           {% if settings.get('Debug', {}).get(key, value.default) == True %}checked{% endif %}>
-                {% elif value.type == 'string' and value.choices %}
-                    <select id="debug-{{ key }}" name="Debug.{{ key }}" class="settings-input"
-                            data-section="Debug" data-key="{{ key }}">
-                        {% for option in value.choices %}
-                            <option value="{{ option }}" {% if (settings.get('Debug', {}).get(key, value.default) | string) == (option | string) %}selected{% endif %}>{{ option }}</option>
-                        {% endfor %}
-                    </select>
-                {% else %}
-                    <input type="{{ value.type if value.type != 'string' else 'text' }}" id="debug-{{ key }}" name="Debug.{{ key }}"
-                           value="{% set val = settings.get('Debug', {}).get(key, value.default) %}{{ val if val != None else '' }}" class="settings-input"
-                           data-section="Debug" data-key="{{ key }}"
-                           {% if value.sensitive %}type="password"{% endif %}
-                           {% if value.min is defined %}min="{{ value.min }}"{% endif %}
-                           {% if value.max is defined %}max="{{ value.max }}"{% endif %}>
-                {% endif %}
-                {% if value.description %}
-                    {% if value.description is string %}
-                        <p class="settings-description">{{ value.description }}</p>
-                    {% else %}
-                        <div class="settings-description">
-                            {% for item in value.description %}
-                                {% if loop.first %}
-                                    <p>{{ item }}</p>
-                                    <ul>
-                                {% elif loop.last %}
-                                    <li>{{ item }}</li>
-                                    </ul>
-                                {% else %}
-                                    <li>{{ item }}</li>
-                                {% endif %}
-                            {% endfor %}
-                        </div>
-                    {% endif %}
-                {% endif %}
-            </div>
-            {% endif %}
-        {% endfor %}
-    </div>
-</div>
-
 <!-- Scraping & Scoring Section -->
 <div class="settings-section settings-card">
     <div class="settings-section-header">


### PR DESCRIPTION
## Summary

The tangerine theme's Advanced Settings tab has a "Symlink & Naming" card that duplicates 10 of its 13 fields with Additional Settings' "Symlink Settings" card — same underlying `Debug.*` config keys, just rendered twice in two different tabs. This was introduced when the tangerine theme was built (`4a42d53b`) without carrying over an exclusion list the classic theme's `debug.html` already uses specifically to prevent this duplication.

## Real bug this duplication caused

Settings tabs are hidden `<div>`s, not removed from the DOM. Normally hidden inputs are skipped when the form serializes on save, but both duplicate copies of these fields carry a `data-section` attribute, which is explicitly exempted from that skip logic (intended for legitimate collapsed-but-visible sections). So both duplicate copies get submitted on every save regardless of which tab is open — and since Advanced Settings comes later in the DOM than Additional Settings, its (possibly stale) copy always won.

**Practical impact:** editing the movie/episode naming template (or any of the other 8 duplicated fields) in Additional Settings → Symlink Settings and clicking Save without also having opened Advanced Settings that page load would silently discard the edit — the stale value sitting in the hidden Advanced Settings copy would overwrite it.

## Fix

Removed the "Symlink & Naming" card entirely and folded its two fields that weren't already present elsewhere (`anime_renaming_using_anidb`, `use_symlinks_on_windows`) into the Symlink Settings card, using the identical `name`/`data-key` attributes so they map to the exact same config keys as before.

**No data migration needed** — both panels already read/write the identical `(Debug, key)` config entries; removing one of the two duplicate UI panels doesn't change anything in `config.json` for existing users.

**Left out of scope:**
- The removed card's `apply_to_anime_tv_shows`/`apply_to_documentary_movies`/`apply_to_documentary_tv_shows` toggles were already dead before this change (they saved to `Debug.apply_to_*`, but the only real consumer reads `Subtitle Settings.apply_to_*` instead — a separate, pre-existing, unrelated bug). Not carried forward, not otherwise touched.
- **Follow-up needed:** `use_symlinks_on_windows` has a *third* copy, in the separate "True Debug" tab (`true_debug_tangerine.html` / `true_debug.html`, "System & Integration" section) that still duplicates the one merged here — same clobbering risk remains for just this one field between Symlink Settings and True Debug. Deliberately left alone in this PR to keep scope to the two sections this issue was actually about; worth a small follow-up PR.

## Test plan

- [x] Verified via `git show --stat` that only the two template files changed — no Python touched, so the actual symlink-naming logic (`utilities/local_library_scan.py`, `utilities/path_utils.py`) and the settings schema/defaults are completely unaffected
- [x] Confirmed the two relocated fields use identical `name="Debug.<key>"` / `data-key="<key>"` attributes to their removed originals, so existing users' saved values are read from the exact same config location, unchanged
- [x] Validated both edited templates with `jinja2.Environment.parse()` — no syntax errors
- [x] Grepped for leftover references to the removed "Symlink & Naming" heading/section — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)