### PR TITLE
Fix episode/season delete UI refresh race + season-tab reset

### DIFF
--- a/static/js/library_show.js
+++ b/static/js/library_show.js
@@ -2103,22 +2103,22 @@ async function handleDeleteShow(event) {
                 showPopup({
                     type: POPUP_TYPES.SUCCESS,
                     message: reportMessage,
-                    autoClose: false,  // Require user to close manually
-                    onConfirm: () => {
-                        // Redirect to library page after user closes notification
-                        window.location.href = '/library';
-                    }
+                    autoClose: false  // Require user to close manually
                 });
 
-                // Add close button callback for redirect
-                setTimeout(() => {
-                    const closeButton = document.querySelector('.universal-popup #popupClose');
-                    if (closeButton) {
-                        closeButton.onclick = () => {
-                            window.location.href = '/library';
-                        };
-                    }
-                }, 100);
+                // Redirect once the user closes the report. showPopup's onConfirm
+                // isn't invoked for SUCCESS-type popups (only CONFIRM/PROMPT), so
+                // wire the close button directly - synchronously, right here, since
+                // the popup and its default close handler already exist in the DOM
+                // by the time showPopup() returns (no setTimeout delay needed, and
+                // a delay here previously raced the default handler: closing fast
+                // enough left the user stranded on the now-deleted show's page).
+                const closeButton = document.querySelector('.universal-popup #popupClose');
+                if (closeButton) {
+                    closeButton.onclick = () => {
+                        window.location.href = '/library';
+                    };
+                }
             } else {
                 throw new Error(result.error || 'Failed to delete show');
             }
@@ -2318,28 +2318,18 @@ async function handleDeleteSeason(event) {
         hideDeletionLoading();
 
         if (result && result.success) {
+            // Refresh immediately - see comment on the single-episode delete path
+            // for why this doesn't wait on the popup being closed.
+            loadShowData();
+
             // Build deletion report using shared utility
             const reportMessage = buildDeletionReport(result, seasonTitle);
 
             showPopup({
                 type: POPUP_TYPES.SUCCESS,
                 message: reportMessage,
-                autoClose: false,  // Require user to close manually
-                onConfirm: () => {
-                    // Reload show data after user closes notification
-                    loadShowData();
-                }
+                autoClose: false  // Require user to close manually
             });
-
-            // Add close button callback for reload
-            setTimeout(() => {
-                const closeButton = document.querySelector('.universal-popup #popupClose');
-                if (closeButton) {
-                    closeButton.onclick = () => {
-                        loadShowData();
-                    };
-                }
-            }, 100);
         } else {
             throw new Error(result.error || 'Failed to delete season');
         }
@@ -2578,19 +2568,15 @@ async function handleBulkDeleteEpisodes(checkboxes, seasonNumber) {
         failed.forEach(f => reportLines.push(`✗ ${f.label}: ${escapeHtml(f.error)}`));
     }
 
+    // Refresh immediately - see comment on the single-episode delete path for why
+    // this doesn't wait on the popup being closed.
+    loadShowData();
+
     showPopup({
         type: failed.length === 0 ? POPUP_TYPES.SUCCESS : POPUP_TYPES.WARNING,
         message: reportLines.join('\n'),
-        autoClose: false,
-        onConfirm: () => loadShowData()
+        autoClose: false
     });
-
-    setTimeout(() => {
-        const closeButton = document.querySelector('.universal-popup #popupClose');
-        if (closeButton) {
-            closeButton.onclick = () => loadShowData();
-        }
-    }, 100);
 }
 
 async function handleDeleteEpisode(event) {
@@ -2799,23 +2785,21 @@ async function handleDeleteEpisode(event) {
         hideDeletionLoading();
 
         if (result && result.success) {
+            // Refresh immediately so the deleted episode's row updates (e.g. to a
+            // "Missing" phantom row) right away, instead of depending on how the
+            // user happens to dismiss the popup below (which was racy: onclick set
+            // after the popup exists could lose to an already-attached default
+            // close handler if the user closed it fast enough).
+            loadShowData();
+
             // Build detailed deletion report
             const reportMessage = buildDeletionReport(result, episodeTitle);
 
             showPopup({
                 type: POPUP_TYPES.SUCCESS,
                 message: reportMessage,
-                autoClose: false,
-                onConfirm: () => loadShowData()
+                autoClose: false
             });
-
-            // Add close button callback
-            setTimeout(() => {
-                const closeButton = document.querySelector('.universal-popup #popupClose');
-                if (closeButton) {
-                    closeButton.onclick = () => loadShowData();
-                }
-            }, 100);
         } else {
             throw new Error(result.error || 'Failed to delete episode');
         }

--- a/static/js/library_show.js
+++ b/static/js/library_show.js
@@ -2320,7 +2320,10 @@ async function handleDeleteSeason(event) {
         if (result && result.success) {
             // Refresh immediately - see comment on the single-episode delete path
             // for why this doesn't wait on the popup being closed.
-            loadShowData();
+            await loadShowData();
+            // Re-render defaults back to season 1 - switch back to the season that
+            // was just deleted so its now-missing state is visible.
+            switchTab(seasonNumber);
 
             // Build deletion report using shared utility
             const reportMessage = buildDeletionReport(result, seasonTitle);
@@ -2570,7 +2573,10 @@ async function handleBulkDeleteEpisodes(checkboxes, seasonNumber) {
 
     // Refresh immediately - see comment on the single-episode delete path for why
     // this doesn't wait on the popup being closed.
-    loadShowData();
+    await loadShowData();
+    // Re-render defaults back to season 1 - switch back to the season these
+    // episodes were actually deleted from.
+    switchTab(seasonNumber);
 
     showPopup({
         type: failed.length === 0 ? POPUP_TYPES.SUCCESS : POPUP_TYPES.WARNING,
@@ -2790,7 +2796,10 @@ async function handleDeleteEpisode(event) {
             // user happens to dismiss the popup below (which was racy: onclick set
             // after the popup exists could lose to an already-attached default
             // close handler if the user closed it fast enough).
-            loadShowData();
+            await loadShowData();
+            // Re-render defaults back to season 1 - switch back to the season the
+            // deleted episode was actually in.
+            switchTab(seasonNumber);
 
             // Build detailed deletion report
             const reportMessage = buildDeletionReport(result, episodeTitle);


### PR DESCRIPTION
## Summary

Two related fixes to the Library show-detail page's delete flows (episode, bulk-episode, season, and show).

### 1. Refresh race condition — episode sometimes just vanishes instead of showing "Missing"

After a delete, the page refresh (`loadShowData()`, which re-renders episode rows including "Missing" phantom rows for gaps) was gated on how the user dismissed the success popup. `showPopup`'s `onConfirm` option is only actually invoked for `CONFIRM`/`PROMPT` popup types (see `notifications.js`) — never for `SUCCESS` — so every caller here worked around that by grabbing the `#popupClose` button after a `setTimeout(..., 100)` and manually setting its `.onclick`. But `.onclick` doesn't replace the button's existing `addEventListener('click', closePopup)` handler from `showPopup` itself — both fire independently. If the user closed the popup within that 100ms window (easy to do, since the popup often renders already-complete), only the default `closePopup` ran and the refresh never fired at all.

**Practical effect:** deleting an episode would sometimes correctly show it as a "Missing" phantom row (if the timing happened to line up) and sometimes just silently vanish with no refresh, forcing a trip to Discover to re-request it.

**Fix:** decoupled the refresh from the popup lifecycle for episode/season/bulk-episode delete — `loadShowData()` now runs immediately on a successful response, before the popup is even shown, so it no longer depends on any user interaction with the popup at all.

Show delete is different (it redirects to `/library`, which would hide the deletion report if done immediately) — kept that gated on closing the popup, but fixed the actual race by wiring the close button synchronously right after `showPopup()` returns instead of after an arbitrary delay (the popup and its default close handler already exist in the DOM synchronously by then).

### 2. Deleting from a later season kicked you back to Season 1

`loadShowData()`'s re-render defaults back to Season 1, so deleting an episode or season from e.g. Season 8 would silently jump the user back to Season 1 right when the success popup appears — annoying when deleting multiple episodes from the same season in a row.

**Fix:** mirrors an existing pattern already used elsewhere in this file (`handleRefreshClick`'s restore-active-tab logic) — each delete handler already knows the season number the deletion happened in, so it just calls `switchTab(seasonNumber)` after `loadShowData()` resolves.

## Test plan

- [x] `node --check static/js/library_show.js` — syntax valid
- [x] Live-verified against a real running instance: deleted an episode from a season other than 1, confirmed it now shows a correct "Missing" status row immediately and reliably (not intermittently), and the page stays on the season the deletion happened in instead of resetting to Season 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)