### PR TITLE
Add optional ffprobe playability check for NZB/debrid additions

### DIFF
--- a/queues/checking_queue.py
+++ b/queues/checking_queue.py
@@ -1283,7 +1283,28 @@ class CheckingQueue:
                                             if directory:
                                                 # Store item type with directory for proper section matching
                                                 item_type = updated_item_data.get('type', 'episode')  # Default to episode for shows
-                                                directories_to_scan[directory] = item_type
+
+                                                # If this item was ffprobe-verified (playability check enabled
+                                                # for its protocol), scan its directory immediately instead of
+                                                # waiting for the batched scan at the end of this torrent
+                                                # group - a confirmed-playable file should show up in Plex
+                                                # right away. Leaves the batched path below completely
+                                                # untouched for every item where the setting is off.
+                                                _torrent_id_for_scan = str(updated_item_data.get('filled_by_torrent_id', '') or '')
+                                                _is_nzb_for_scan = _torrent_id_for_scan.startswith('nzb:')
+                                                _ffprobe_scan_section = 'Usenet Provider' if _is_nzb_for_scan else 'Debrid Provider'
+                                                _ffprobe_scan_key = 'ffprobe_all_nzbs' if _is_nzb_for_scan else 'ffprobe_all_debrid_additions'
+                                                if get_setting(_ffprobe_scan_section, _ffprobe_scan_key, False):
+                                                    try:
+                                                        if use_jellyfin:
+                                                            emby_update_item({'full_path': directory, 'location_on_disk': directory, 'type': item_type})
+                                                        elif use_plex:
+                                                            plex_update_item({'full_path': directory, 'location_on_disk': directory, 'type': item_type})
+                                                        logging.info(f"[ffprobe] Triggered immediate media server scan for verified directory: {directory}")
+                                                    except Exception as _ffprobe_scan_err:
+                                                        logging.warning(f"[ffprobe] Immediate scan failed for {directory}: {_ffprobe_scan_err}")
+                                                else:
+                                                    directories_to_scan[directory] = item_type
 
                                 conn = get_db_connection()
                                 cursor = conn.execute('SELECT state FROM media_items WHERE id = ?', (item_in_torrent_group['id'],))

--- a/templates/settings_tabs/required_tangerine.html
+++ b/templates/settings_tabs/required_tangerine.html
@@ -208,6 +208,13 @@
                    data-section="Usenet Provider" data-key="enabled"
                    {% if settings.get('Usenet Provider', {}).get('enabled') %}checked{% endif %}>
         </div>
+        <div class="settings-form-group">
+            <label for="usenet_provider-ffprobe_all_nzbs" class="settings-title">Ffprobe All NZBs:</label>
+            <input type="checkbox" id="usenet_provider-ffprobe_all_nzbs" name="Usenet Provider.ffprobe_all_nzbs"
+                   data-section="Usenet Provider" data-key="ffprobe_all_nzbs"
+                   {% if settings.get('Usenet Provider', {}).get('ffprobe_all_nzbs') %}checked{% endif %}>
+            <p class="settings-description">Before collecting an NZB file, probe it with ffprobe to confirm it's actually playable, on top of the existing missing-article/segment health check. Symlinked/Local mode only. Requires ffprobe to be installed. This will slow down how long it takes NZB items to reach Collected.</p>
+        </div>
         {% set _provider = settings.get('Usenet Provider', {}).get('provider', 'climount') %}
         <div class="settings-form-group">
             <label for="usenet_provider-provider" class="settings-title">Provider:</label>

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1133,6 +1133,32 @@ def _apply_nzb_naming(source_file: str, item: Dict[str, Any]) -> str:
         return source_file
 
 
+def _reject_unplayable_source(item: Dict[str, Any], is_nzb: bool) -> None:
+    """Mark a confirmed-unplayable file's source as not-wanted and revert the item
+    to Wanted so it gets rescraped, mirroring the existing missing-segments/
+    checking-timeout rejection pattern used elsewhere in the queue processing."""
+    try:
+        if is_nzb:
+            from database.not_wanted_magnets import add_to_not_wanted_nzb_guid
+            nzb_url = item.get('filled_by_magnet', '')
+            if nzb_url:
+                add_to_not_wanted_nzb_guid(nzb_url)
+        else:
+            from database.not_wanted_magnets import add_to_not_wanted
+            from debrid.common import extract_hash_from_magnet
+            magnet = item.get('filled_by_magnet', '')
+            hash_value = extract_hash_from_magnet(magnet) if magnet else None
+            if hash_value:
+                add_to_not_wanted(hash_value)
+    except Exception as e:
+        logging.warning(f"[ffprobe] Failed to add unplayable source to not-wanted: {e}")
+
+    try:
+        update_media_item_state(item.get('id'), 'Wanted')
+    except Exception as e:
+        logging.error(f"[ffprobe] Failed to revert item {item.get('id')} to Wanted after failed playability check: {e}")
+
+
 def _cleanup_old_symlink(item: Dict[str, Any], item_identifier: str, source_file: str, old_filename: str) -> None:
     """Remove the old symlink (and notify the media server) after a successful upgrade.
 
@@ -1400,6 +1426,20 @@ def check_local_file_for_item(item: Dict[str, Any], is_webhook: bool = False, ex
             
             # For NZB items in Plex mode with NZB naming enabled: move file to organised structure
             source_file = _apply_nzb_naming(source_file, item)
+
+            # Optional playability verification, gated by protocol-specific toggles
+            # (off by default). Only meaningful here in Symlinked/Local mode, which
+            # is the only mode that reaches this function with a real source_file.
+            _torrent_id_for_probe = str(item.get('filled_by_torrent_id', '') or '')
+            _is_nzb_for_probe = _torrent_id_for_probe.startswith('nzb:')
+            _probe_section = 'Usenet Provider' if _is_nzb_for_probe else 'Debrid Provider'
+            _probe_key = 'ffprobe_all_nzbs' if _is_nzb_for_probe else 'ffprobe_all_debrid_additions'
+            if get_setting(_probe_section, _probe_key, False):
+                from usenet.repair_engine import _verify_file_readable
+                if not _verify_file_readable(source_file):
+                    logging.warning(f"Ffprobe playability check failed for '{source_file}' — rejecting and reverting to Wanted")
+                    _reject_unplayable_source(item, _is_nzb_for_probe)
+                    return False
 
             # Get destination path based on settings (using the found source_file)
             dest_file = get_symlink_path(item, source_file, skip_jikan_lookup=False)

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1435,9 +1435,12 @@ def check_local_file_for_item(item: Dict[str, Any], is_webhook: bool = False, ex
             _probe_section = 'Usenet Provider' if _is_nzb_for_probe else 'Debrid Provider'
             _probe_key = 'ffprobe_all_nzbs' if _is_nzb_for_probe else 'ffprobe_all_debrid_additions'
             if get_setting(_probe_section, _probe_key, False):
+                logging.info(f"[ffprobe] Running playability check ({_probe_key}) on '{source_file}'")
                 from usenet.repair_engine import _verify_file_readable
-                if not _verify_file_readable(source_file):
-                    logging.warning(f"Ffprobe playability check failed for '{source_file}' — rejecting and reverting to Wanted")
+                if _verify_file_readable(source_file):
+                    logging.info(f"[ffprobe] Playability check passed for '{source_file}'")
+                else:
+                    logging.warning(f"[ffprobe] Playability check FAILED for '{source_file}' — rejecting and reverting to Wanted")
                     _reject_unplayable_source(item, _is_nzb_for_probe)
                     return False
 

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -303,6 +303,11 @@ SETTINGS_SCHEMA = {
             "type": "boolean",
             "description": "Include the content source display name in the debrid folder name when Debrid File Naming is enabled.",
             "default": False
+        },
+        "ffprobe_all_debrid_additions": {
+            "type": "boolean",
+            "description": "Before collecting a debrid (Real-Debrid/etc.) file, probe it with ffprobe to confirm it's actually playable, on top of the normal checks. Symlinked/Local mode only. Requires ffprobe to be installed. This will slow down how long it takes items to reach Collected.",
+            "default": False
         }
     },
     "Usenet Provider": {
@@ -310,6 +315,11 @@ SETTINGS_SCHEMA = {
         "enabled": {
             "type": "boolean",
             "description": "Enable usenet as a download source via cli_mount",
+            "default": False
+        },
+        "ffprobe_all_nzbs": {
+            "type": "boolean",
+            "description": "Before collecting an NZB file, probe it with ffprobe to confirm it's actually playable, on top of the existing missing-article/segment health check. Symlinked/Local mode only. Requires ffprobe to be installed. This will slow down how long it takes NZB items to reach Collected.",
             "default": False
         },
         "url": {


### PR DESCRIPTION
## Summary

Similar in spirit to the existing "Probe for Embedded Subtitles" ffprobe toggle, this adds an optional playability check before an NZB or debrid file is collected — on top of the existing missing-article/segment health check, not instead of it.

Two new toggles, both **off by default**:
- **Usenet Provider → Ffprobe All NZBs** (`ffprobe_all_nzbs`)
- **Debrid Provider → Ffprobe All Debrid Additions** (`ffprobe_all_debrid_additions`)

Both are clearly labeled that enabling them will slow down how long it takes items to reach Collected.

## How it works

The check runs during the Checking stage, right where `check_local_file_for_item` resolves the file to a real path on the mount and is about to symlink it — reusing `_verify_file_readable` from `usenet/repair_engine.py` rather than inventing a new probe, since it already does exactly what's needed here: a deep-offset packet read with conservative retry/timeout handling that treats an inconclusive result (e.g. a momentarily busy mount) as playable rather than risking a false-positive rejection.

**Symlinked/Local mode only** — Plex mode never reaches this function with a resolvable local file path, the same limitation the existing subtitle-probe toggle already has (it hard-skips itself in Plex mode too).

On a confirmed-unplayable file, this mirrors the existing missing-segments/checking-timeout rejection pattern already used elsewhere in this queue: the source gets added to not-wanted and the item is reverted to `Wanted` so it gets rescraped — not just returning `False`, which would have looped forever re-probing the same dead file every tick.

**Bonus fix, same PR:** when either toggle is on, a file that passes now triggers an immediate Plex/Jellyfin scan of its directory instead of waiting for the batched scan that normally happens once per torrent group (season packs can hold up notifying Plex about an already-verified file until every sibling episode finishes its own check too). Items where the setting is off take the exact same batched code path as before — unchanged.

## Test plan

- [x] Verified inside the running container against a throwaway test DB (not the real one): schema defaults correct (both off by default), and the rejection helper correctly calls the right not-wanted function and reverts state to `Wanted` for both the NZB and debrid cases
- [x] Verified `_verify_file_readable` itself correctly returns `False` against a deliberately-corrupt test file (1KB of random bytes named `.mkv`), confirming the actual detection logic - not just the plumbing around it - works
- [x] **Extensively live-verified against a real running instance**: enabled both toggles, added several hundred real NZB and debrid episodes/season packs (including a ~300-episode Supernatural mass-add spanning multiple seasons) - every single check logged clearly (`[ffprobe] Running playability check...` / `Playability check passed`) and all real files passed cleanly with zero false positives
- [x] Live-verified the immediate-scan addition: `[ffprobe] Triggered immediate media server scan for verified directory: ...` fires right after each pass, confirmed via logs that Plex is notified per-item instead of waiting for the whole batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)