### PR TITLE
Also blacklist the raw indexer URL on a failed playability check

### DIFF
--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1144,12 +1144,26 @@ def _reject_unplayable_source(item: Dict[str, Any], is_nzb: bool) -> None:
             if nzb_url:
                 add_to_not_wanted_nzb_guid(nzb_url)
         else:
-            from database.not_wanted_magnets import add_to_not_wanted
+            from database.not_wanted_magnets import add_to_not_wanted, add_to_not_wanted_urls
             from debrid.common import extract_hash_from_magnet
             magnet = item.get('filled_by_magnet', '')
             hash_value = extract_hash_from_magnet(magnet) if magnet else None
             if hash_value:
                 add_to_not_wanted(hash_value)
+            # Also blacklist the raw URL itself (mirrors torrent_processor.py's
+            # add_to_not_wanted_urls alongside add_to_not_wanted). Needed because
+            # `magnet` here is frequently an unresolved Jackett indexer redirect
+            # link, not a real magnet: URI — is_magnet_not_wanted's hash-based
+            # comparison can never match that at scrape-filter time (it doesn't
+            # follow redirects), so a re-scrape can pick the exact same broken
+            # torrent again via a different indexer wrapping the same release.
+            # is_url_not_wanted is already checked everywhere is_magnet_not_wanted
+            # is, and both indexer links for the same release carry the same
+            # `file=` query param, so this closes the gap using the matching
+            # mechanism that already exists for it — no changes needed to the
+            # comparison logic itself.
+            if magnet and magnet.startswith('http'):
+                add_to_not_wanted_urls(magnet)
     except Exception as e:
         logging.warning(f"[ffprobe] Failed to add unplayable source to not-wanted: {e}")
 


### PR DESCRIPTION
## Summary

Follow-up to #465 (the ffprobe playability check). `_reject_unplayable_source` only called `add_to_not_wanted(hash_value)`, extracted via `extract_hash_from_magnet`. For a debrid item, `filled_by_magnet` is frequently still an unresolved Jackett indexer redirect link (e.g. `http://.../dl/limetorrents/?...&file=<title>`) at the point a release fails ffprobe, not a real `magnet:` URI.

`is_magnet_not_wanted`'s comparison never follows that redirect — it just extracts a hash from real `magnet:` URIs and falls through to the URL's `file=` query param (a release-title string) as a weaker fallback for anything else. Since the blacklist entry itself was the properly-resolved real info-hash, the two representations could never match: a re-scrape carrying the same still-unresolved indexer URL sailed straight past the check.

**Confirmed live:** the same broken release (Supernatural S13, RD torrent ID `J23NGIGGFXLZK`) got re-picked ~1h50m after being rejected and blacklisted, this time via a different Jackett indexer wrapping the identical release.

## Fix

Mirrors an existing, already-wired precedent one call away — `torrent_processor.py`'s `add_to_not_wanted(definitive_hash)` alongside `add_to_not_wanted_urls(original_link)` — rather than reworking the hash-comparison logic itself: also add the raw URL to the separate `not_wanted_urls` list when it's still in http(s) form. `is_url_not_wanted` is already checked everywhere `is_magnet_not_wanted` is (6 call sites in `scraping_queue.py`), and both indexer links for the same release carry the same `file=` value, so this closes the gap using the matching mechanism the codebase already has for it. Skipped for genuine `magnet:` URIs, which the hash-based check already handles correctly on its own.

## Test plan

- [x] Confirmed empirically that the two real indexer URLs from the incident (`limetorrents` vs `torrentdownloads`, both wrapping the same release) normalize to the same `get_base_filename()` value, and that the previously-stored resolved hash never matched a raw unresolved URL — reproducing the exact gap
- [x] Verified inside the running container against a throwaway test DB (not the real one): `_reject_unplayable_source` now correctly calls `add_to_not_wanted_urls` with the raw URL for the http case, and skips it for a real `magnet:` URI (the hash-based path already covers that case, so a duplicate entry would be redundant)
- [x] Confirmed the fix is robust even when hash resolution itself fails (e.g. indexer unreachable) — the URL blacklist entry is recorded independently of whether `extract_hash_from_magnet` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)