### PR TITLE
Add Clear Log buttons for the NZB and debrid repair activity logs

### DIFF
--- a/database/nzb_repair_activity.py
+++ b/database/nzb_repair_activity.py
@@ -162,6 +162,32 @@ def is_in_backoff(broken_nzb_id: str) -> bool:
         return False
 
 
+def clear_repair_activity(source: str = None) -> int:
+    """
+    Delete repair activity log entries.
+    source='usenet'  → only NZB entries (broken_nzb_id NOT LIKE 'debrid:%')
+    source='debrid'  → only debrid entries (broken_nzb_id LIKE 'debrid:%')
+    source=None      → all entries
+    Returns the number of rows deleted.
+    """
+    conn = get_db_connection()
+    try:
+        if source == 'usenet':
+            where = "WHERE (broken_nzb_id NOT LIKE 'debrid:%' OR broken_nzb_id IS NULL OR broken_nzb_id = '')"
+        elif source == 'debrid':
+            where = "WHERE broken_nzb_id LIKE 'debrid:%'"
+        else:
+            where = ""
+        cur = conn.execute(f"DELETE FROM nzb_repair_activity {where}")
+        conn.commit()
+        return cur.rowcount
+    except Exception as e:
+        logger.error(f"[NZBRepair] clear_repair_activity error: {e}")
+        return 0
+    finally:
+        conn.close()
+
+
 def get_repair_activity(limit: int = 100, offset: int = 0, outcome: str = None, source: str = None):
     """
     Get repair activity log entries.

--- a/routes/debrid_manager_routes.py
+++ b/routes/debrid_manager_routes.py
@@ -5574,6 +5574,20 @@ def debrid_repair_activity():
         return jsonify(success=False, error=str(e))
 
 
+@debrid_manager_bp.route('/api/debrid/repair/activity/clear', methods=['POST'])
+def debrid_repair_activity_clear():
+    """Clear the debrid repair activity log. Shares the nzb_repair_activity
+    table with the NZB log, scoped by the same broken_nzb_id prefix the
+    debrid engine's own reads use."""
+    try:
+        from database.nzb_repair_activity import clear_repair_activity
+        deleted = clear_repair_activity(source='debrid')
+        return jsonify(success=True, deleted=deleted)
+    except Exception as e:
+        logging.error(f'[DebridRepair] activity clear error: {e}')
+        return jsonify(success=False, error=str(e))
+
+
 @debrid_manager_bp.route('/api/debrid/repair/scan_status')
 def debrid_scan_status():
     """Check if cli_mount is currently running a health sweep."""

--- a/routes/debrid_manager_routes.py
+++ b/routes/debrid_manager_routes.py
@@ -5319,6 +5319,18 @@ def usenet_repair_activity():
         return jsonify(success=False, error=str(e))
 
 
+@debrid_manager_bp.route('/api/usenet/repair/activity/clear', methods=['POST'])
+def usenet_repair_activity_clear():
+    """Clear the NZB repair activity log."""
+    try:
+        from database.nzb_repair_activity import clear_repair_activity
+        deleted = clear_repair_activity(source='usenet')
+        return jsonify(success=True, deleted=deleted)
+    except Exception as e:
+        logging.error(f'[UsenetRepair] activity clear error: {e}')
+        return jsonify(success=False, error=str(e))
+
+
 @debrid_manager_bp.route('/api/usenet/repair/scan_status')
 def usenet_scan_status():
     """Check if cli_mount is currently running a health sweep (active_run != null and running)."""

--- a/templates/debrid_manager.html
+++ b/templates/debrid_manager.html
@@ -901,6 +901,7 @@
                         <option value="error">Error</option>
                     </select>
                     <button onclick="debridLoadActivity(document.getElementById('dr-filter-select').value||null)" class="un-btn"><i class="fa-solid fa-rotate" style="color:#CE93D8"></i> Refresh</button>
+                    <button onclick="debridClearActivity()" class="un-btn"><i class="fa-solid fa-trash" style="color:#ff4444"></i> Clear Log</button>
                 </div>
             </div>
             <div id="dr-activity-container">
@@ -5151,6 +5152,23 @@ async function debridLoadActivity(filter) {
     const sel = document.getElementById('dr-filter-select');
     if (sel) sel.value = filter || '';
     await _debridFetchActivity();
+}
+
+async function debridClearActivity() {
+    if (!confirm('Clear the entire debrid repair activity log?\n\nThis only deletes the log history — it does not touch any media, Plex entries, or provider jobs.\n\nContinue?')) return;
+    try {
+        const r = await fetch('/debrid_manager/api/debrid/repair/activity/clear', {method: 'POST'});
+        const d = await r.json();
+        if (d.success) {
+            _debridActivityOffset = 0;
+            await _debridFetchActivity();
+        } else {
+            alert('Failed to clear activity log: ' + (d.error || 'unknown error'));
+        }
+    } catch(e) {
+        console.error('[Debrid] activity clear error', e);
+        alert('Failed to clear activity log');
+    }
 }
 
 async function _debridFetchActivity() {

--- a/templates/debrid_manager.html
+++ b/templates/debrid_manager.html
@@ -788,6 +788,7 @@
                         <option value="error">Error</option>
                     </select>
                     <button onclick="usenetLoadActivity(document.getElementById('usenet-filter-select').value||null)" class="un-btn"><i class="fa-solid fa-rotate" style="color:#e8601c"></i> Refresh</button>
+                    <button onclick="usenetClearActivity()" class="un-btn"><i class="fa-solid fa-trash" style="color:#ff4444"></i> Clear Log</button>
                 </div>
             </div>
             <div id="usenet-activity-container">
@@ -4421,6 +4422,23 @@ async function usenetLoadActivity(filter) {
     const sel = document.getElementById('usenet-filter-select');
     if (sel) sel.value = filter || '';
     await _usenetFetchActivity();
+}
+
+async function usenetClearActivity() {
+    if (!confirm('Clear the entire NZB repair activity log?\n\nThis only deletes the log history — it does not touch any media, Plex entries, or provider jobs.\n\nContinue?')) return;
+    try {
+        const r = await fetch('/debrid_manager/api/usenet/repair/activity/clear', {method: 'POST'});
+        const d = await r.json();
+        if (d.success) {
+            _usenetActivityOffset = 0;
+            await _usenetFetchActivity();
+        } else {
+            alert('Failed to clear activity log: ' + (d.error || 'unknown error'));
+        }
+    } catch(e) {
+        console.error('[Usenet] activity clear error', e);
+        alert('Failed to clear activity log');
+    }
 }
 
 async function _usenetFetchActivity() {


### PR DESCRIPTION
## Summary

The repair activity log (`nzb_repair_activity` table, shared between the NZB and debrid repair UIs) has no cap besides a 90-day auto-prune, and can grow into the tens of thousands of rows on an active instance. Adds a "Clear Log" button next to Refresh on both the NZB and debrid Repair Activity Log sections in Debrid Manager.

- `clear_repair_activity(source=None)` in `database/nzb_repair_activity.py` — a single `DELETE FROM nzb_repair_activity` scoped the same way the existing read path already splits NZB vs debrid entries (`broken_nzb_id LIKE 'debrid:%'`).
- Two new routes, `POST /api/usenet/repair/activity/clear` and `POST /api/debrid/repair/activity/clear`, each scoped to their own log.
- Confirmation dialog before clearing, matching the existing destructive-action pattern used elsewhere in this page (e.g. "Delete broken NZBs").

This only ever deletes rows from the log table itself — confirmed no foreign keys or triggers exist on `nzb_repair_activity`, and neither route touches media, Plex, or any provider API.

## Test plan
- [x] `python3 -m py_compile` on the changed Python files
- [x] Live-verified against a running instance: cleared the NZB log (91k+ rows), confirmed only that table's NZB-scoped rows were removed, debrid-scoped rows and all other tables (`media_items`, etc.) unaffected
- [x] Same for the debrid log's Clear button, scoped to the opposite filter