### PR TITLE
Fix non-Latin anime/show titles breaking scraping, symlinks, and alias detection

### DIFF
--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -703,6 +703,113 @@ def get_show_data(imdb_id: str) -> Optional[dict]:
     return show_data
 
 
+def _extract_tmdb_id_from_remote_ids(raw: dict) -> Optional[int]:
+    """Pull the TMDB ID out of a TVDB series/movie response's own remoteIds,
+    when present - more reliable than re-resolving it independently via
+    TMDB's /find endpoint (which can fail to link an IMDb ID that TVDB's own
+    cross-reference already has)."""
+    remote_ids = raw.get('remoteIds', []) or raw.get('remote_ids', [])
+    if not isinstance(remote_ids, list):
+        return None
+    for rid in remote_ids:
+        if isinstance(rid, dict):
+            source = (rid.get('sourceName', '') or '').lower()
+            if 'tmdb' in source or 'themoviedb' in source:
+                try:
+                    return int(rid.get('id', ''))
+                except (ValueError, TypeError):
+                    return None
+    return None
+
+
+def _fetch_tmdb_title_only(tmdb_id: Optional[int], imdb_id: str, api_key: str, media_type: str) -> Optional[str]:
+    """Minimal TMDB lookup for just a title - avoids the overhead of the full
+    _fetch_tmdb_show_data / _fetch_tmdb_movie_data fallback fetchers below,
+    which build out seasons/episodes/genres/etc. that aren't needed here.
+    Falls back to resolving the TMDB ID from the IMDb ID only if the caller
+    doesn't already have one from TVDB's own remoteIds."""
+    if not tmdb_id:
+        tmdb_id = _resolve_tmdb_id_from_imdb(imdb_id, api_key, media_type=media_type)
+    if not tmdb_id:
+        return None
+    endpoint = 'tv' if media_type == 'show' else 'movie'
+    try:
+        resp = requests.get(
+            f"https://api.themoviedb.org/3/{endpoint}/{tmdb_id}",
+            params={'api_key': api_key},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            return None
+        raw = resp.json()
+        return raw.get('name') if media_type == 'show' else raw.get('title')
+    except Exception as e:
+        logger.debug(f"TMDB title-only lookup failed for {imdb_id}: {e}")
+        return None
+
+
+def _resolve_display_title(title: str, raw: dict, imdb_id: str, media_type: str) -> str:
+    """When `title` (TVDB's primary name) contains non-Latin script, try to find
+    a usable Latin-script title instead, in order:
+      1. A TVDB nameTranslations 'eng' entry that's itself actually Latin-clean -
+         not just the first 'eng' entry array-order, since TVDB's community data
+         sometimes has the non-Latin name copied verbatim into the eng slot, or a
+         mixed-script entry (e.g. a stray non-Latin word left in an otherwise
+         English translation), ahead of a genuinely clean one further down.
+      2. TMDB's own title for the same item, when TVDB has no clean translation -
+         TMDB's editorial title is often present even when TVDB's
+         community-contributed translations are missing or unusable.
+
+    Detected via the presence of any non-Latin *letter*, not "lacks a Latin
+    letter" — a title can contain both, e.g. Naruto's TVDB primary name is
+    'NARUTO－ナルト－' (has plenty of Latin letters, but still half Japanese
+    katakana); requiring the *absence* of Latin letters missed this case
+    entirely. Also not just "any ASCII survives encoding" — a title like
+    '怪獣8号' has a literal ASCII digit in it, so that check would call it
+    "representable" too. Script-agnostic (Japanese, Korean, Chinese, Hindi,
+    Cyrillic, Arabic, etc.) rather than enumerating specific scripts one at a
+    time - see utilities.text_utils.has_non_latin_letter.
+
+    Falls through to the original non-Latin title if nothing usable is found
+    anywhere - the symlink-path layer (utilities/local_library_scan.py) has its
+    own independent ID-based fallback for that case, so this never risks a
+    folder collision either way, only display/scraping accuracy.
+    """
+    from utilities.text_utils import has_non_latin_letter
+    if not title or not has_non_latin_letter(title):
+        return title
+
+    for t in (raw.get('translations', {}).get('nameTranslations') or []):
+        candidate = t.get('name')
+        if t.get('language') == 'eng' and candidate and not has_non_latin_letter(candidate):
+            logger.info(
+                f"TVDB primary name {title!r} is non-Latin — using clean TVDB "
+                f"English translation {candidate!r} instead"
+            )
+            return candidate
+
+    try:
+        tmdb_api_key = _get_tmdb_api_key()
+        if tmdb_api_key:
+            tmdb_id = _extract_tmdb_id_from_remote_ids(raw)
+            tmdb_title = _fetch_tmdb_title_only(tmdb_id, imdb_id, tmdb_api_key, media_type)
+            if tmdb_title and not has_non_latin_letter(tmdb_title):
+                logger.info(
+                    f"TVDB primary name {title!r} is non-Latin with no clean TVDB "
+                    f"translation — using TMDB title {tmdb_title!r} instead"
+                )
+                return tmdb_title
+    except Exception as e:
+        logger.debug(f"TMDB title fallback failed for {imdb_id}: {e}")
+
+    logger.warning(
+        f"TVDB primary name {title!r} is non-Latin and no clean English title "
+        f"found via TVDB or TMDB — leaving as-is (symlink layer will use its "
+        f"own ID-based fallback)"
+    )
+    return title
+
+
 def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
     """Build a Trakt-compatible show metadata dict from TVDB series data."""
     ids = {
@@ -751,27 +858,9 @@ def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
     # romanized or English form at all. Storing that as the canonical title breaks
     # every ASCII-dependent downstream consumer — scraper query normalization strips
     # it to an empty (or badly mangled) string, and symlink path generation strips it
-    # down too. Fall back to the English nameTranslations entry instead, when the
-    # primary name actually contains non-Latin script.
-    #
-    # Detected via the presence of any non-Latin letter, not "lacks a Latin
-    # letter" — a title can contain both, e.g. Naruto's TVDB primary name is
-    # 'NARUTO－ナルト－' (has plenty of Latin letters, but still half Japanese
-    # katakana); requiring the *absence* of Latin letters missed this case entirely.
-    # Also not just "any ASCII survives encoding" — a title like '怪獣8号' has a
-    # literal ASCII digit in it, so that check would call it "representable" too.
-    # Script-agnostic (Japanese, Korean, Chinese, Hindi, Cyrillic, Arabic, etc.)
-    # rather than enumerating specific scripts one at a time.
-    from utilities.text_utils import has_non_latin_letter
-    if title and has_non_latin_letter(title):
-        for t in (raw.get('translations', {}).get('nameTranslations') or []):
-            if t.get('language') == 'eng' and t.get('name'):
-                logger.info(
-                    f"TVDB primary name {title!r} has no Latin-representable content — "
-                    f"using English translation {t['name']!r} instead"
-                )
-                title = t['name']
-                break
+    # down too. Fall back to a usable Latin-script title instead, when the primary
+    # name actually contains non-Latin script.
+    title = _resolve_display_title(title, raw, imdb_id, media_type='show')
 
     # Airs info
     airs = {}
@@ -1140,13 +1229,17 @@ def _build_movie_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
             except ValueError:
                 pass
 
-    # Find English overview/title
+    # Find title/overview. Unlike overview (always fine to prefer the English
+    # translation when present), the primary name must NOT be unconditionally
+    # replaced — a TVDB 'eng' nameTranslations entry is sometimes a wrong
+    # marketing AKA rather than a true localization (e.g. "Gangs of Manila" for
+    # "Batang Quiapo"), so only fall back to it when the primary name actually
+    # contains non-Latin script and can't be used as-is. See
+    # _resolve_display_title's docstring for the full detection/fallback chain
+    # (TVDB clean translation, then TMDB, then leave as-is).
     title = raw.get('name', '')
     overview = raw.get('overview', '')
-    for t in raw.get('translations', {}).get('nameTranslations', []) or []:
-        if t.get('language') == 'eng' and t.get('name'):
-            title = t['name']
-            break
+    title = _resolve_display_title(title, raw, imdb_id, media_type='movie')
     for t in raw.get('translations', {}).get('overviewTranslations', []) or []:
         if t.get('language') == 'eng':
             overview = t.get('overview', overview)

--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -8,7 +8,6 @@ Rate limiting: No preemptive tracking; 429s handled with exponential backoff.
 """
 
 import json
-import re
 import time
 import logging
 import threading
@@ -755,19 +754,16 @@ def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
     # down too. Fall back to the English nameTranslations entry instead, when the
     # primary name actually contains non-Latin script.
     #
-    # Detected via the presence of CJK/Kana/Hangul characters, not "lacks a Latin
+    # Detected via the presence of any non-Latin letter, not "lacks a Latin
     # letter" — a title can contain both, e.g. Naruto's TVDB primary name is
     # 'NARUTO－ナルト－' (has plenty of Latin letters, but still half Japanese
     # katakana); requiring the *absence* of Latin letters missed this case entirely.
     # Also not just "any ASCII survives encoding" — a title like '怪獣8号' has a
     # literal ASCII digit in it, so that check would call it "representable" too.
-    _non_latin_script = re.compile(
-        r'[぀-ヿ'   # Hiragana + Katakana
-        r'㐀-䶿'    # CJK Extension A
-        r'一-鿿'    # CJK Unified Ideographs
-        r'가-힣]'   # Hangul syllables
-    )
-    if title and _non_latin_script.search(title):
+    # Script-agnostic (Japanese, Korean, Chinese, Hindi, Cyrillic, Arabic, etc.)
+    # rather than enumerating specific scripts one at a time.
+    from utilities.text_utils import has_non_latin_letter
+    if title and has_non_latin_letter(title):
         for t in (raw.get('translations', {}).get('nameTranslations') or []):
             if t.get('language') == 'eng' and t.get('name'):
                 logger.info(

--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -8,6 +8,7 @@ Rate limiting: No preemptive tracking; 429s handled with exponential backoff.
 """
 
 import json
+import re
 import time
 import logging
 import threading
@@ -745,6 +746,36 @@ def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
     # rather than a true localization, so it must not override the primary name here —
     # it's still captured separately via _extract_aliases() for search matching.
     title = raw.get('name', '')
+
+    # Exception: some series (commonly anime) have their primary TVDB name stored
+    # partly or entirely in non-Latin script (e.g. Japanese/Chinese/Korean), with no
+    # romanized or English form at all. Storing that as the canonical title breaks
+    # every ASCII-dependent downstream consumer — scraper query normalization strips
+    # it to an empty (or badly mangled) string, and symlink path generation strips it
+    # down too. Fall back to the English nameTranslations entry instead, when the
+    # primary name actually contains non-Latin script.
+    #
+    # Detected via the presence of CJK/Kana/Hangul characters, not "lacks a Latin
+    # letter" — a title can contain both, e.g. Naruto's TVDB primary name is
+    # 'NARUTO－ナルト－' (has plenty of Latin letters, but still half Japanese
+    # katakana); requiring the *absence* of Latin letters missed this case entirely.
+    # Also not just "any ASCII survives encoding" — a title like '怪獣8号' has a
+    # literal ASCII digit in it, so that check would call it "representable" too.
+    _non_latin_script = re.compile(
+        r'[぀-ヿ'   # Hiragana + Katakana
+        r'㐀-䶿'    # CJK Extension A
+        r'一-鿿'    # CJK Unified Ideographs
+        r'가-힣]'   # Hangul syllables
+    )
+    if title and _non_latin_script.search(title):
+        for t in (raw.get('translations', {}).get('nameTranslations') or []):
+            if t.get('language') == 'eng' and t.get('name'):
+                logger.info(
+                    f"TVDB primary name {title!r} has no Latin-representable content — "
+                    f"using English translation {t['name']!r} instead"
+                )
+                title = t['name']
+                break
 
     # Airs info
     airs = {}

--- a/queues/adding_queue.py
+++ b/queues/adding_queue.py
@@ -93,6 +93,35 @@ class AddingQueue:
         else:
             logging.error("Attempted to remove item without ID from queue")
         
+    def _torrent_has_other_active_owner(self, torrent_id: str, exclude_item_id) -> bool:
+        """True if another media_items row still actively depends on this torrent_id.
+
+        Debrid season-pack sibling reuse (torrent_processor.py's _check_sibling_debrid_pack)
+        means multiple episodes can now legitimately share the same torrent_id — something
+        that never happened before that fix, since every debrid torrent used to belong to
+        exactly one item. Callers that remove a torrent from the debrid service in response
+        to *this* item's own failure (no matching files, filter match, etc.) must check this
+        first: removing a still-needed shared pack breaks every sibling relying on it, even
+        though only one of them actually failed.
+        """
+        if not torrent_id or str(torrent_id).startswith('nzb:'):
+            return False
+        try:
+            from database import get_db_connection
+            conn = get_db_connection()
+            try:
+                row = conn.execute(
+                    "SELECT 1 FROM media_items WHERE filled_by_torrent_id=? AND id!=? "
+                    "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 1",
+                    (torrent_id, exclude_item_id)
+                ).fetchone()
+            finally:
+                conn.close()
+            return row is not None
+        except Exception as e:
+            logging.warning(f"Could not check for other owners of torrent {torrent_id}: {e} — assuming shared, skipping removal to be safe")
+            return True
+
     def remove_unwanted_torrent(self, torrent_id: str, is_nzb: bool = False):
         """
         Remove an unwanted torrent from the debrid service and track the removal
@@ -866,8 +895,10 @@ class AddingQueue:
                 # --- START EDIT: Check if failure was due to filter and remove torrent ---
                 if "matched filter-out list" in error:
                     logging.info(f"Upgrade for {item_identifier} failed due to filename filter. Attempting to remove torrent.")
-                    if item.get('torrent_id'):
+                    if item.get('torrent_id') and not self._torrent_has_other_active_owner(item['torrent_id'], item.get('id')):
                         self.remove_unwanted_torrent(item['torrent_id'], is_nzb=is_nzb)
+                    elif item.get('torrent_id'):
+                        logging.info(f"Torrent {item['torrent_id']} still needed by other episode(s) sharing this pack — not removing")
                 # --- END EDIT ---
 
                 # Remove from Adding queue memory regardless of restore success for upgrades
@@ -881,9 +912,12 @@ class AddingQueue:
                "No matching files found in parsed files" in error or \
                "No valid video files found in torrent" in error:
                 logging.info(f"Media matching failed for {item_identifier}, moving back to Wanted queue. Error: {error}")
-                # Remove torrent if ID is present
-                if item.get('torrent_id'):
+                # Remove torrent if ID is present — but only if no sibling episode sharing this
+                # (season-pack-reused) torrent still actively needs it.
+                if item.get('torrent_id') and not self._torrent_has_other_active_owner(item['torrent_id'], item.get('id')):
                     self.remove_unwanted_torrent(item['torrent_id'])
+                elif item.get('torrent_id'):
+                    logging.info(f"Torrent {item['torrent_id']} still needed by other episode(s) sharing this pack — not removing")
                 queue_manager.move_to_wanted(item, "Adding")
                 # move_to_wanted handles removing from self.items
                 return
@@ -891,8 +925,10 @@ class AddingQueue:
             # --- NEW: Handle filename/title filter match ---
             elif "matched filter-out list" in error:
                 logging.info(f"Item {item_identifier} matched filename/title filter, moving back to Wanted queue. Error: {error}")
-                if item.get('torrent_id'):
+                if item.get('torrent_id') and not self._torrent_has_other_active_owner(item['torrent_id'], item.get('id')):
                     self.remove_unwanted_torrent(item['torrent_id'], is_nzb=is_nzb)
+                elif item.get('torrent_id'):
+                    logging.info(f"Torrent {item['torrent_id']} still needed by other episode(s) sharing this pack — not removing")
                 queue_manager.move_to_wanted(item, "Adding")
                 # move_to_wanted handles removing from self.items
                 return

--- a/queues/checking_queue.py
+++ b/queues/checking_queue.py
@@ -1657,6 +1657,35 @@ class CheckingQueue:
         # Iterate over a copy of self.items for safety if handlers modify it.
         items_for_stalled_torrent = [item for item in list(self.items) if item.get('filled_by_torrent_id') == torrent_id]
 
+        # Debrid season-pack sibling reuse means a sibling episode can already be Collected
+        # on this same torrent_id while another sibling is still stuck stalling in this
+        # queue - such a sibling has left self.items entirely, so it's invisible to the
+        # in-memory check above. Removing the torrent here would silently break that
+        # already-Collected episode's playback. Check the DB for any such episode first.
+        if not str(torrent_id).startswith('nzb:'):
+            try:
+                from database import get_db_connection as _gdb_stall
+                _known_ids = {i['id'] for i in items_for_stalled_torrent}
+                _conn = _gdb_stall()
+                try:
+                    _placeholders = ','.join('?' * len(_known_ids)) if _known_ids else 'NULL'
+                    _other = _conn.execute(
+                        f"SELECT 1 FROM media_items WHERE filled_by_torrent_id=? "
+                        f"AND state IN ('Collected','Upgrading') "
+                        f"AND id NOT IN ({_placeholders}) LIMIT 1",
+                        (torrent_id, *_known_ids)
+                    ).fetchone()
+                finally:
+                    _conn.close()
+                if _other:
+                    logging.info(f"Torrent {torrent_id} has a Collected/Upgrading sibling outside this queue's stalled check — not removing, only handling the items stalled here")
+                    for item_to_move in items_for_stalled_torrent:
+                        if self.contains_item_id(item_to_move['id']):
+                            queue_manager.move_to_wanted(item_to_move, "Checking")
+                    return
+            except Exception as e:
+                logging.warning(f"Could not check for Collected siblings of torrent {torrent_id}: {e} — proceeding with normal stalled handling")
+
         if not items_for_stalled_torrent:
             logging.warning(f"No items found for stalled torrent {torrent_id} at the moment of handling.")
             # Clean up strike counter if it exists, as there are no items to process

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -579,7 +579,19 @@ class TorrentProcessor:
                 info['original_scraped_torrent_title'] = check_title
                 logging.info(f"[{item.get('title', 'Unknown')}] Season pack already submitted for "
                              f"S{_season:02d} (torrent_id={torrent_id}) — reusing instead of duplicate submission")
-                return info, magnet, None
+                # chosen_result_info must reflect THIS reused torrent's own title, not None -
+                # adding_queue.py falls back to results[0] (the fresh scrape's top candidate,
+                # unrelated to what we're actually reusing) whenever this is falsy, which writes
+                # a mismatched title into original_scraped_torrent_title. That's usually masked by
+                # debrid_folder_name (set separately from this torrent's own info) still letting
+                # check_local_file_for_item resolve the file via a different fallback attempt, but
+                # not always - live-reproduced as "not found in any checked location" recurring
+                # once something else also disrupted that fallback.
+                chosen_result_info = {
+                    'title': check_title,
+                    'original_scraped_torrent_title': check_title,
+                }
+                return info, magnet, chosen_result_info
             return None
 
         # In-memory check first: catches a sibling submitted this same tick, before it's

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -577,6 +577,15 @@ class TorrentProcessor:
                 self.debrid_provider = provider
                 info = dict(info)
                 info['original_scraped_torrent_title'] = check_title
+                # debrid_folder_name must reflect the provider's OWN real mount folder name
+                # (info['filename']/'original_filename'), not the indexer's cosmetic display
+                # title (check_title) - those two frequently differ (e.g. a release named
+                # "[Fuchs] Mushoku Tensei - S02 (BD 1080p HEVC Opus 2.0)..." by the indexer but
+                # actually stored on the mount as "Mushoku.Tensei.S02.1080p.BluRay...-Fuchs" by
+                # whoever uploaded it). check_local_file_for_item's first folder-name guess
+                # (debrid_folder_name) needs the real one to succeed without depending on the
+                # other, title-based fallback guesses also happening to match by luck.
+                info['debrid_folder_name'] = info.get('filename') or info.get('original_filename') or check_title
                 logging.info(f"[{item.get('title', 'Unknown')}] Season pack already submitted for "
                              f"S{_season:02d} (torrent_id={torrent_id}) — reusing instead of duplicate submission")
                 # chosen_result_info must reflect THIS reused torrent's own title, not None -
@@ -721,7 +730,12 @@ class TorrentProcessor:
         from database import get_media_item_by_id as _gmi_con
         from utilities.local_library_scan import check_local_file_for_item as _clffi_con
 
-        new_debrid_folder_name = torrent_info.get('debrid_folder_name') or torrent_info.get('title')
+        new_debrid_folder_name = (
+            torrent_info.get('debrid_folder_name')
+            or torrent_info.get('filename')
+            or torrent_info.get('original_filename')
+            or torrent_info.get('title')
+        )
         old_torrent_ids_touched = set()
 
         for sib in siblings:

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -616,13 +616,26 @@ class TorrentProcessor:
             from database import get_db_connection as _gdb
             _conn = _gdb()
             try:
+                # Dedup by filled_by_torrent_id via a MIN(id)-per-group subquery, not a bare
+                # GROUP BY on the outer SELECT - SQLite does not guarantee that non-aggregated
+                # ("bare") columns in a GROUP BY come from the same physical row as the grouped
+                # column, so filled_by_file/original_scraped_torrent_title/filled_by_magnet could
+                # end up mismatched against a *different* row's torrent_id than the one actually
+                # being reused. Confirmed live: this silently wrote a completely different
+                # release's title onto the correct, already-working torrent_id, breaking the
+                # downstream folder-name guess in check_local_file_for_item for every episode
+                # that inherited the wrong title.
                 _siblings = _conn.execute(
                     "SELECT filled_by_torrent_id, filled_by_file, original_scraped_torrent_title, filled_by_magnet "
                     "FROM media_items "
-                    "WHERE imdb_id=? AND season_number=? AND type='episode' "
-                    "AND id!=? AND filled_by_torrent_id IS NOT NULL AND filled_by_torrent_id NOT LIKE 'nzb:%' "
-                    "AND REPLACE(COALESCE(version,''),'*','')=? "
-                    "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 5",
+                    "WHERE id IN ("
+                    "  SELECT MIN(id) FROM media_items "
+                    "  WHERE imdb_id=? AND season_number=? AND type='episode' "
+                    "  AND id!=? AND filled_by_torrent_id IS NOT NULL AND filled_by_torrent_id NOT LIKE 'nzb:%' "
+                    "  AND REPLACE(COALESCE(version,''),'*','')=? "
+                    "  AND state IN ('Adding','Checking','Collected','Upgrading') "
+                    "  GROUP BY filled_by_torrent_id"
+                    ") LIMIT 5",
                     (_imdb, _season, item.get('id', -1), _item_version)
                 ).fetchall()
             finally:
@@ -631,13 +644,139 @@ class TorrentProcessor:
             logging.debug(f"Sibling debrid-pack DB check failed: {e}")
             return None
 
+        # Evaluate all distinct candidates rather than stopping at the first that contains the
+        # target episode - prefer the most complete pack (most files) when more than one
+        # legitimately covers this episode, so a still-pending episode lands on the bigger of two
+        # known sibling packs instead of whichever was found first.
+        best, best_file_count = None, -1
         for _sib in _siblings:
             _sib_check_title = _sib[2] or _sib[1] or ''
             reused = _try_reuse(_sib[0], _sib_check_title, _sib[3])
             if reused:
-                return reused
+                file_count = len(reused[0].get('files', []))
+                if file_count > best_file_count:
+                    best, best_file_count = reused, file_count
 
-        return None
+        return best
+
+    def _consolidate_covered_siblings(self, item: Optional[Dict], torrent_info: Dict) -> None:
+        """If the torrent just finalized for `item` also fully covers other episodes that are
+        already Collected on a smaller/different torrent (e.g. a wide pack scraped after those
+        episodes already landed on single-episode releases), repoint those episodes' symlinks
+        onto this torrent live, in this same tick, and remove the old torrent once nothing else
+        references it.
+
+        Deliberately reuses check_local_file_for_item for the actual file-resolution + symlink
+        swap (it already does source_file resolution and create_symlink's own safe "existing
+        symlink pointing elsewhere -> unlink and recreate" handling, unconditionally, regardless
+        of upgrade status) rather than any new path logic. `upgrading_from` is deliberately left
+        unset on the synthetic item so check_local_file_for_item's upgrade-cleanup block (which
+        removes the old torrent unconditionally, no sibling-owner check) never runs - old-torrent
+        removal here is instead done explicitly, once, after every covered sibling is swapped.
+        """
+        if not item or item.get('type') != 'episode':
+            return
+        if get_setting('File Management', 'file_collection_management') != 'Symlinked/Local':
+            return
+        _imdb = item.get('imdb_id')
+        _season = item.get('season_number')
+        _new_torrent_id = torrent_info.get('id')
+        if not _imdb or _season is None or not _new_torrent_id:
+            return
+        _item_version = (item.get('version') or '').rstrip('*')
+        _files = torrent_info.get('files', [])
+        if not _files:
+            return
+
+        import re as _re_con
+
+        def _filename_for_episode(episode_number: int) -> Optional[str]:
+            pattern = _re_con.compile(rf'[Ss]{_season:02d}[Ee]{episode_number:02d}(?!\d)')
+            for f in _files:
+                path = f.get('path') or f.get('filename') or ''
+                if pattern.search(path):
+                    return os.path.basename(path)
+            return None
+
+        try:
+            from database import get_db_connection as _gdb_con
+            conn = _gdb_con()
+            try:
+                siblings = conn.execute(
+                    "SELECT id, episode_number, filled_by_torrent_id FROM media_items "
+                    "WHERE imdb_id=? AND season_number=? AND type='episode' "
+                    "AND id!=? AND state='Collected' AND filled_by_torrent_id IS NOT NULL "
+                    "AND filled_by_torrent_id NOT LIKE 'nzb:%' AND filled_by_torrent_id!=? "
+                    "AND REPLACE(COALESCE(version,''),'*','')=?",
+                    (_imdb, _season, item.get('id', -1), _new_torrent_id, _item_version)
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception as e:
+            logging.debug(f"Sibling consolidation DB lookup failed: {e}")
+            return
+        if not siblings:
+            return
+
+        from database import get_media_item_by_id as _gmi_con
+        from utilities.local_library_scan import check_local_file_for_item as _clffi_con
+
+        new_debrid_folder_name = torrent_info.get('debrid_folder_name') or torrent_info.get('title')
+        old_torrent_ids_touched = set()
+
+        for sib in siblings:
+            sib_filename = _filename_for_episode(sib['episode_number'])
+            if not sib_filename:
+                continue
+            sib_item = _gmi_con(sib['id'])
+            if not sib_item or sib_item.get('state') != 'Collected':
+                continue  # re-check live state; skip if it moved (e.g. into Upgrading) since the query ran
+            old_torrent_id = sib_item.get('filled_by_torrent_id')
+            synthetic_item = dict(sib_item)
+            synthetic_item['filled_by_torrent_id'] = _new_torrent_id
+            synthetic_item['filled_by_file'] = sib_filename
+            synthetic_item['filled_by_magnet'] = torrent_info.get('magnet') or synthetic_item.get('filled_by_magnet')
+            synthetic_item['original_scraped_torrent_title'] = new_debrid_folder_name
+            synthetic_item['debrid_folder_name'] = new_debrid_folder_name
+            synthetic_item.pop('upgrading_from', None)
+            synthetic_item.pop('upgrading_from_torrent_id', None)
+            try:
+                swapped = _clffi_con(synthetic_item, skip_multifile_scan=True)
+            except Exception as e:
+                logging.warning(f"Consolidation swap failed for sibling {sib['id']} (S{_season:02d}E{sib['episode_number']:02d}): {e}")
+                continue
+            if swapped:
+                logging.info(f"[{item.get('title', 'Unknown')}] Consolidated S{_season:02d}E{sib['episode_number']:02d} "
+                             f"onto torrent {_new_torrent_id} (was {old_torrent_id})")
+                if old_torrent_id:
+                    old_torrent_ids_touched.add(old_torrent_id)
+            else:
+                logging.debug(f"Consolidation swap did not confirm success for sibling {sib['id']}; leaving as-is")
+
+        for old_torrent_id in old_torrent_ids_touched:
+            try:
+                from database import get_db_connection as _gdb_con2
+                conn2 = _gdb_con2()
+                try:
+                    still_used = conn2.execute(
+                        "SELECT 1 FROM media_items WHERE filled_by_torrent_id=? "
+                        "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 1",
+                        (old_torrent_id,)
+                    ).fetchone()
+                finally:
+                    conn2.close()
+                if still_used:
+                    logging.debug(f"Old torrent {old_torrent_id} still referenced after consolidation — not removing")
+                    continue
+                for provider in self._providers:
+                    try:
+                        provider.remove_torrent(old_torrent_id, removal_reason="Consolidated onto a wider sibling pack")
+                        logging.info(f"Removed consolidated-away torrent {old_torrent_id} (superseded by {_new_torrent_id})")
+                        break
+                    except Exception as e:
+                        logging.debug(f"[{provider.PROVIDER_NAME}] remove_torrent failed for {old_torrent_id}: {e}")
+            except Exception as e:
+                logging.warning(f"Error removing consolidated-away torrent {old_torrent_id}: {e}")
 
     def _process_nzb_result(self, result: Dict, item: Optional[Dict] = None, adding_queue_items: Optional[list] = None) -> Optional[Tuple]:
         """Submit an NZB result to cli_mount and return a synthetic torrent_info tuple."""
@@ -1038,14 +1177,34 @@ class TorrentProcessor:
         item: Optional[Dict] = None,
         adding_queue_items: Optional[list] = None,
     ) -> Tuple[Optional[Dict], Optional[str], Optional[Dict]]:
+        """Thin wrapper around _process_results_inner that also consolidates any already-Collected
+        siblings the finalized torrent happens to cover onto it, live, in the same tick - see
+        _consolidate_covered_siblings for details."""
+        torrent_info, magnet, chosen_result = self._process_results_inner(
+            results, accept_uncached=accept_uncached, item=item, adding_queue_items=adding_queue_items,
+        )
+        if torrent_info:
+            try:
+                self._consolidate_covered_siblings(item, torrent_info)
+            except Exception as e:
+                logging.warning(f"Sibling pack consolidation failed (non-fatal): {e}", exc_info=True)
+        return torrent_info, magnet, chosen_result
+
+    def _process_results_inner(
+        self,
+        results: list[Dict],
+        accept_uncached: bool = False,
+        item: Optional[Dict] = None,
+        adding_queue_items: Optional[list] = None,
+    ) -> Tuple[Optional[Dict], Optional[str], Optional[Dict]]:
         """
         Process a list of results to find the best match
-        
+
         Args:
             results: List of results to process
             accept_uncached: Whether to accept uncached results
             item: Optional media item for tracking successful results
-            
+
         Returns:
             Tuple of (torrent_info, magnet_link, chosen_result) if successful, (None, None, None) otherwise
         """

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -509,6 +509,124 @@ class TorrentProcessor:
                 except Exception as e:
                     logging.error(f"Error cleaning up temp file {temp_file}: {e}")
                     
+    def _check_sibling_debrid_pack(self, item: Optional[Dict] = None, adding_queue_items: Optional[list] = None) -> Optional[Tuple]:
+        """If another episode of the same show/season/version already has a debrid season-pack
+        job, reuse it instead of independently scraping and adding a duplicate pack.
+
+        Mirrors _process_nzb_result's sibling-reuse logic, adapted for the debrid path, which
+        previously had no equivalent check at all - every episode of a whole-show/whole-season
+        request scraped and submitted completely independently, and since a successful add
+        immediately blacklists that release's hash via add_to_not_wanted(), each subsequent
+        sibling's scrape fell through to the next-best *distinct* pack (often a different
+        release group) instead of reusing the one already grabbed. Confirmed live: this
+        downloaded ~12 different season-pack torrents for one anime show before this fix.
+
+        Unlike NZB reuse (which returns an empty files list and defers resolution to a separate
+        reconciliation task), debrid's get_torrent_info() is synchronous and already returns the
+        full file listing - so this returns a real, populated torrent_info dict and rides the
+        existing _parse_file_info -> find_best_match_from_parsed -> find_related_items pipeline
+        in adding_queue.py completely unmodified to resolve this episode's own file.
+        """
+        if not item or item.get('type') != 'episode':
+            return None
+        _imdb = item.get('imdb_id')
+        _season = item.get('season_number')
+        if not _imdb or _season is None:
+            return None
+
+        import re as _re_sib
+        _item_version = (item.get('version') or '').rstrip('*')
+
+        def _is_pack_title(title: str) -> bool:
+            return bool(title) and not _re_sib.search(r'[Ss]\d{2}[Ee]\d{2}', title)
+
+        _episode = item.get('episode_number')
+        _ep_pattern = (
+            _re_sib.compile(rf'[Ss]{_season:02d}[Ee]{_episode:02d}(?!\d)')
+            if _episode is not None else None
+        )
+
+        def _try_reuse(torrent_id: str, check_title: str, magnet: Optional[str]) -> Optional[Tuple]:
+            if not _is_pack_title(check_title):
+                return None
+            for provider in self._providers:
+                try:
+                    info = provider.get_torrent_info(torrent_id)
+                except Exception as e:
+                    logging.debug(f"[{provider.PROVIDER_NAME}] get_torrent_info failed for sibling reuse {torrent_id}: {e}")
+                    continue
+                if not (info and info.get('files')):
+                    continue
+                # Verify this specific episode is actually present in the candidate pack before
+                # reusing it - some season "packs" only cover part of the season (e.g. a
+                # "Part 1"/"Part 2" split, common for long anime seasons). Blindly reusing a
+                # pack that doesn't contain this episode stuck it in a permanent loop: every
+                # retry re-hit this same sibling check, got pointed at the same non-containing
+                # pack again, failed to match, and never got a chance to scrape fresh for the
+                # pack that actually has it.
+                if _ep_pattern is not None:
+                    _files = info.get('files', [])
+                    _has_episode = any(
+                        _ep_pattern.search(f.get('path') or f.get('filename') or '')
+                        for f in _files
+                    )
+                    if not _has_episode:
+                        logging.info(f"[{item.get('title', 'Unknown')}] Sibling pack {torrent_id} does not "
+                                     f"contain S{_season:02d}E{_episode:02d} — not reusing, trying next candidate")
+                        return None
+                self.debrid_provider = provider
+                info = dict(info)
+                info['original_scraped_torrent_title'] = check_title
+                logging.info(f"[{item.get('title', 'Unknown')}] Season pack already submitted for "
+                             f"S{_season:02d} (torrent_id={torrent_id}) — reusing instead of duplicate submission")
+                return info, magnet, None
+            return None
+
+        # In-memory check first: catches a sibling submitted this same tick, before it's
+        # written back to the DB.
+        if adding_queue_items:
+            for _mem_item in adding_queue_items:
+                if (_mem_item.get('id') == item.get('id') or
+                        _mem_item.get('imdb_id') != _imdb or
+                        _mem_item.get('season_number') != _season or
+                        (_mem_item.get('version') or '').rstrip('*') != _item_version):
+                    continue
+                _mem_torrent_id = _mem_item.get('filled_by_torrent_id')
+                if not _mem_torrent_id or str(_mem_torrent_id).startswith('nzb:'):
+                    continue
+                _mem_check_title = _mem_item.get('original_scraped_torrent_title') or _mem_item.get('filled_by_file') or ''
+                reused = _try_reuse(_mem_torrent_id, _mem_check_title, _mem_item.get('filled_by_magnet'))
+                if reused:
+                    return reused
+
+        # DB check second - covers siblings resolved on a prior tick.
+        try:
+            from database import get_db_connection as _gdb
+            _conn = _gdb()
+            try:
+                _siblings = _conn.execute(
+                    "SELECT filled_by_torrent_id, filled_by_file, original_scraped_torrent_title, filled_by_magnet "
+                    "FROM media_items "
+                    "WHERE imdb_id=? AND season_number=? AND type='episode' "
+                    "AND id!=? AND filled_by_torrent_id IS NOT NULL AND filled_by_torrent_id NOT LIKE 'nzb:%' "
+                    "AND REPLACE(COALESCE(version,''),'*','')=? "
+                    "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 5",
+                    (_imdb, _season, item.get('id', -1), _item_version)
+                ).fetchall()
+            finally:
+                _conn.close()
+        except Exception as e:
+            logging.debug(f"Sibling debrid-pack DB check failed: {e}")
+            return None
+
+        for _sib in _siblings:
+            _sib_check_title = _sib[2] or _sib[1] or ''
+            reused = _try_reuse(_sib[0], _sib_check_title, _sib[3])
+            if reused:
+                return reused
+
+        return None
+
     def _process_nzb_result(self, result: Dict, item: Optional[Dict] = None, adding_queue_items: Optional[list] = None) -> Optional[Tuple]:
         """Submit an NZB result to cli_mount and return a synthetic torrent_info tuple."""
         from usenet.climount_client import get_climount_client, reset_climount_client
@@ -921,7 +1039,11 @@ class TorrentProcessor:
         """
         item_identifier = item.get('title', 'Unknown') if item else 'Unknown'
         logging.info(f"[{item_identifier}] Starting to process {len(results)} results (accept_uncached={accept_uncached})")
-        
+
+        sibling_pack = self._check_sibling_debrid_pack(item, adding_queue_items=adding_queue_items)
+        if sibling_pack:
+            return sibling_pack
+
         for idx, result in enumerate(results, 1):
             chosen_result_for_return = None # Initialize variable to hold the chosen result
             try:

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1214,35 +1214,31 @@ def scrape(imdb_id: str, tmdb_id: str, title: str, year: int, content_type: str,
                     aliases = metadata.get('aliases', {})
                     romanized_found = False
                     
-                    # Look for romanized titles in aliases (prioritize Japanese romanization patterns)
+                    # Look for a romanized title specifically among Japan-sourced aliases.
+                    # Previously this scanned every country's aliases and guessed "is this
+                    # Japanese?" from short substring patterns (e.g. 'ta', 'na', 'ri') — far
+                    # too permissive to be reliable, since those substrings show up
+                    # constantly in other languages too. Confirmed live: "Angriff auf Titan"
+                    # (German for "Attack on Titan") matched the pattern for 'ri' (in
+                    # "Angriff") and 'ta' (in "Titan") and got misfiled as a "Japanese
+                    # romanized alias," triggering a second, pointless scrape. The alias
+                    # dict is already keyed by the country/language it actually came from —
+                    # use that directly instead of guessing from the text.
                     for country_code, alias_list in aliases.items():
+                        if country_code.lower() != 'jp':
+                            continue
                         if isinstance(alias_list, list):
                             for alias in alias_list:
-                                # Check if this alias looks like a romanized Japanese title
+                                # Only the Latin-script form of a Japan-sourced alias is a
+                                # useful search query — the native kanji/kana form isn't.
                                 if alias and re.match(r'^[a-zA-Z\s\-]+$', alias) and alias.lower() not in tried_titles_lower:
                                     # Skip if it's just the English title again
                                     if alias.lower() != title.lower():
-                                        # Check for Japanese romanization patterns (common Japanese words/patterns)
-                                        japanese_patterns = [
-                                            r'\bno\b',  # "no" particle is very common in Japanese titles
-                                            r'(yama|kawa|saki|mura|hara|da|ta|ka|na|ma|sa|ra|wa|ga|zu|ji|chi|shi|ki|mi|ni|hi|ri|ai|ei|ou|uu)',  # Common Japanese syllable patterns
-                                            r'\w+(?:gami|kami|sama|chan|kun|san)\b',  # Japanese honorifics
-                                            r'\w+(?:ya|ko|ro|to|go|bo|po|zo|do|ba|pa)\b'  # Common Japanese ending patterns
-                                        ]
-                                        
-                                        # Check if it matches Japanese romanization patterns
-                                        is_likely_japanese = any(re.search(pattern, alias.lower()) for pattern in japanese_patterns)
-                                        
-                                        # Also check if it's NOT common English words
-                                        common_english_words = ['drugstore', 'soliloquy', 'pharmacy', 'apothecary', 'diary', 'diaries', 'story', 'tale', 'chronicles']
-                                        has_english_words = any(word in alias.lower() for word in common_english_words)
-                                        
-                                        if is_likely_japanese and not has_english_words:
-                                            logging.info(f"Adding Japanese romanized alias for anime: {alias}")
-                                            titles_to_try.append(('romanized_alias', alias))
-                                            tried_titles_lower.add(alias.lower())
-                                            romanized_found = True
-                                            break
+                                        logging.info(f"Adding Japanese romanized alias for anime: {alias}")
+                                        titles_to_try.append(('romanized_alias', alias))
+                                        tried_titles_lower.add(alias.lower())
+                                        romanized_found = True
+                                        break
                         if romanized_found:
                             break
                     

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1299,11 +1299,9 @@ def scrape(imdb_id: str, tmdb_id: str, title: str, year: int, content_type: str,
                     titles_to_try.append(('country_alias', alias))
                     tried_titles_lower.add(alias.lower())
 
-        # Execute scraping based on the determined titles with threading and deduplication protection
+        # Execute scraping based on the determined titles with threading
         logging.info(f"Will search with {len(titles_to_try)} titles: {[source for source, _ in titles_to_try]}")
-        
-        # Track already scraped episode formats to avoid duplicates
-        scraped_episode_formats = set()
+
         all_results_lock = threading.Lock()
         
         # Aggregate per-segment timings across all title searches
@@ -1311,19 +1309,11 @@ def scrape(imdb_id: str, tmdb_id: str, title: str, year: int, content_type: str,
         timing_reports_count = 0
         
         def scrape_single_title(args):
-            """Helper function to scrape a single title with deduplication protection"""
+            """Helper function to scrape a single title. titles_to_try is already
+            deduplicated by tried_titles_lower at build time, so every call here
+            is for a genuinely distinct title — no further dedup needed."""
             source, search_title = args
-            
-            # For anime, check if we've already scraped this episode format
-            if is_anime and episode_formats:
-                # Create a key based on the episode formats to avoid duplicate scraping
-                format_key = tuple(sorted(episode_formats.values()))
-                with all_results_lock:
-                    if format_key in scraped_episode_formats:
-                        logging.info(f"Skipping duplicate episode format scrape for {source}: {search_title}")
-                        return [], [], {}
-                    scraped_episode_formats.add(format_key)
-            
+
             logging.info(f"Scraping with {source}: {search_title}")
             logging.debug(f"[scrape_main] Calling _do_scrape for '{search_title}' (source: {source}).")
 

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -796,16 +796,12 @@ def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup
         # titled shows released the same year landing in the same directory and silently
         # interleaving episode files. Fall back to a stable, unique identifier whenever
         # the title contains any non-Latin script at all, rather than only when nothing
-        # survives — checked via presence of CJK/Kana/Hangul characters, matching the
+        # survives — checked via presence of any non-Latin letter (script-agnostic:
+        # Japanese, Korean, Chinese, Hindi, Cyrillic, Arabic, etc. all match), the
         # same detection used for the TVDB-side fix for this same underlying issue.
-        _non_latin_script = re.compile(
-            r'[぀-ヿ'   # Hiragana + Katakana
-            r'㐀-䶿'    # CJK Extension A
-            r'一-鿿'    # CJK Unified Ideographs
-            r'가-힣]'   # Hangul syllables
-        )
+        from utilities.text_utils import has_non_latin_letter
         effective_title = raw_title
-        if raw_title and raw_title.strip() and _non_latin_script.search(raw_title):
+        if raw_title and raw_title.strip() and has_non_latin_letter(raw_title):
             effective_title = imdb_id or item.get('tmdb_id', '') or 'unknown'
             logging.warning(
                 f"[SymlinkPath] Title {raw_title!r} has no ASCII-safe representation — "

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -784,9 +784,37 @@ def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup
         imdb_id = item.get('imdb_id', '')
         if imdb_id == 'tt0000000':
             imdb_id = ''
-            
+
+        raw_title = item.get('title', 'Unknown')
+        # sanitize_filename ASCII-encodes and drops anything it can't represent — for a
+        # title that's partly or entirely non-Latin script, that can strip it down to
+        # nothing (or to a short, non-distinguishing fragment — e.g. '怪獣8号' survives
+        # as just "8", 'NARUTO－ナルト－' survives as "NARUTO", which happens to be fine
+        # here but isn't guaranteed to be unique for some other mixed-script title). The
+        # show-level folder template ('{title} ({year})') has no other uniqueness anchor,
+        # so a collapsed or barely-distinguishing title risks two different non-Latin
+        # titled shows released the same year landing in the same directory and silently
+        # interleaving episode files. Fall back to a stable, unique identifier whenever
+        # the title contains any non-Latin script at all, rather than only when nothing
+        # survives — checked via presence of CJK/Kana/Hangul characters, matching the
+        # same detection used for the TVDB-side fix for this same underlying issue.
+        _non_latin_script = re.compile(
+            r'[぀-ヿ'   # Hiragana + Katakana
+            r'㐀-䶿'    # CJK Extension A
+            r'一-鿿'    # CJK Unified Ideographs
+            r'가-힣]'   # Hangul syllables
+        )
+        effective_title = raw_title
+        if raw_title and raw_title.strip() and _non_latin_script.search(raw_title):
+            effective_title = imdb_id or item.get('tmdb_id', '') or 'unknown'
+            logging.warning(
+                f"[SymlinkPath] Title {raw_title!r} has no ASCII-safe representation — "
+                f"falling back to {effective_title!r} to avoid colliding with other "
+                f"items released in {item.get('year', '')!r}"
+            )
+
         template_vars = {
-            'title': item.get('title', 'Unknown'),
+            'title': effective_title,
             'year': item.get('year', ''),
             'imdb_id': imdb_id,
             'tmdb_id': item.get('tmdb_id', ''),

--- a/utilities/text_utils.py
+++ b/utilities/text_utils.py
@@ -1,0 +1,35 @@
+import unicodedata
+
+# Unicode code point ranges covering Latin-script letters (base Latin plus the
+# extended blocks used by accented/diacritic Latin text, e.g. Vietnamese).
+# Anything else letter-like (CJK, Hangul, Devanagari, Cyrillic, Arabic, Thai,
+# etc.) falls outside these ranges.
+_LATIN_LETTER_RANGES = (
+    (0x0041, 0x005A), (0x0061, 0x007A),  # Basic Latin A-Z a-z
+    (0x00C0, 0x00FF),  # Latin-1 Supplement letters
+    (0x0100, 0x017F),  # Latin Extended-A
+    (0x0180, 0x024F),  # Latin Extended-B
+    (0x1E00, 0x1EFF),  # Latin Extended Additional (Vietnamese etc.)
+    (0x2C60, 0x2C7F),  # Latin Extended-C
+    (0xA720, 0xA7FF),  # Latin Extended-D
+)
+
+
+def has_non_latin_letter(text: str) -> bool:
+    """Return True if `text` contains any Unicode *letter* character outside
+    the Latin script ranges above - script-agnostic (Japanese, Chinese,
+    Korean, Hindi, Cyrillic, Arabic, Thai, etc. all match), unlike checking
+    for specific script blocks one at a time.
+
+    Only flags actual letters (Unicode category starting with 'L') - digits,
+    punctuation, and spaces never trigger this, so e.g. a title with a stray
+    ASCII digit alongside non-Latin letters is still correctly flagged.
+    """
+    if not text:
+        return False
+    for ch in text:
+        if unicodedata.category(ch).startswith('L') and not any(
+            lo <= ord(ch) <= hi for lo, hi in _LATIN_LETTER_RANGES
+        ):
+            return True
+    return False


### PR DESCRIPTION
## Summary

Reported in the wild: certain anime (Demon Slayer, Attack on Titan, Jujutsu Kaisen) found zero scrape results and got blacklisted, and a batch of non-English anime symlink folders got renamed down to bare `(Year)` after a symlink resync — silently risking two different shows released the same year colliding into one folder. Root cause traced to TVDB, with two further downstream issues found along the way. Four fixes, three files:

### 1. Root cause — `cli_battery/app/tvdb_client.py`
`_build_show_dict` deliberately always used TVDB's primary series name as the canonical title, never the "eng" `nameTranslations` entry, specifically to avoid a prior bug where that translation was sometimes a wrong marketing AKA (e.g. "Gangs of Manila" incorrectly overriding "Batang Quiapo"). That fix over-corrected: many series — commonly anime — have their TVDB primary name stored partly or entirely in non-Latin script (Japanese, Chinese, Korean), with no romanized or English form at all. Always preferring the primary name meant those shows got an unusable title with no way to recover.

Now falls back to the English translation whenever the primary name contains any CJK/Kana/Hangul script — not only when the primary name is *entirely* non-Latin, since a mixed title like Naruto's actual TVDB primary name (`NARUTO－ナルト－`) still has Latin letters in it but is still half Japanese. A genuinely Latin-script primary name (including one with a bad "marketing AKA" translation available) is still always preferred exactly as before, so the original bug this guarded against stays fixed.

### 2. Defense-in-depth — `utilities/local_library_scan.py`
`sanitize_filename`'s Unicode-to-ASCII conversion drops any character it can't represent — for a title that's partly or entirely non-Latin script, that can strip it down to nothing, or to a short, non-distinguishing fragment. The show-level folder template (`{title} ({year})`) has no other uniqueness anchor, so two different non-Latin-titled shows released the same year could land in the exact same directory and silently interleave each other's episode files.

Falls back to the item's IMDB ID (or TMDB ID) whenever the title contains any CJK/Kana/Hangul script — always unique per show, so a stable, collision-proof folder instead of a collapsed or coincidentally-colliding one. Independent safety net for any title that reaches this point non-Latin from a source other than TVDB.

### 3. Scraper dedup guard — `scraper/scraper.py`
Anime scraping builds multiple title variants to search with (original, translated, romanized alias, etc.) specifically to handle non-English content — but a dedup guard meant to prevent redundant scrapes was keyed *only* on episode format, which is identical across every title variant for the same episode. So whichever title's thread won a race to grab a lock first was the *only* one ever actually scraped, for any anime item with episode formats set. The CJK original title reliably wins that race (submitted first), so the working romanized alternative never got a chance to run at all. A comment a few lines later in the same function already documented the intended behavior this guard was silently violating ("Always continue searching all titles... to ensure comprehensive results from both original and romanized titles"). Every title in the search list is already deduplicated by exact string at build time, so this guard had no legitimate purpose left — removed.

### 4. Japanese-alias false positives — `scraper/scraper.py`
Separately found via a real scrape log: the heuristic that decides "is this alias a Japanese romanization" scanned every country's aliases for short substrings like `ta`, `na`, `ri`, `ka` — far too permissive, since those show up constantly in other languages too. Confirmed live: "Angriff auf Titan" (German for "Attack on Titan") matched on `ri` (in "Angriff") and `ta` (in "Titan") and got misfiled as a "Japanese romanized alias," triggering a second, entirely pointless scrape for a German phrase no indexer will ever match — doubling indexer load for every affected title, including doubling exposure to any slow/hanging indexer in that round. The alias dict is already keyed by the country/language each alias actually came from (both TVDB and Trakt use 2-letter codes, `jp` for Japan) — now uses that directly instead of guessing from text.

## Test plan
- [x] Live-verified fix #1 against 27 real anime shows via TVDB's actual API (not synthetic data) — every one now resolves to its correct English title, including mixed-script titles (Naruto) and titles with a stray ASCII digit in an otherwise non-Latin name (Kaiju No. 8's primary name is `怪獣8号`)
- [x] Live-verified fix #2 by calling `get_symlink_path` directly against a real running instance with a synthetic non-Latin title — confirmed it produces an ID-based, collision-proof folder instead of collapsing to bare `(Year)`; cleaned up the test directory afterward
- [x] Live-verified fix #3 and #4 together end-to-end against a real production scrape of Attack on Titan: confirms only two legitimate titles are searched (`Attack on Titan`, `Shingeki no Kyojin`) — the previous run had misfired on `Angriff auf Titan` (German) instead
- [x] Broad follow-up test: verified the fixed Japanese-alias detection against 20 more real anime shows via live metadata calls — every result is either a correct romanization or a safe `None` (no clean alias available), zero false positives on any other language

## Follow-up: generalized beyond CJK/Kana/Hangul + fixed a real translation-selection bug

Real-world testing (external user report) confirmed the original fix works for Japanese/Korean, but found it didn't help Hindi content at all. Root cause: the detection regex only matched CJK Unified/Extension-A, Hiragana/Katakana, and Hangul syllable ranges — Devanagari, Cyrillic, Arabic, etc. were invisible to it.

### Generalized detection (`utilities/text_utils.py`, new)
`has_non_latin_letter()` flags any Unicode *letter* outside the Latin script ranges, instead of enumerating specific scripts one at a time — one check instead of a growing per-language allowlist. Verified against every case from the original test plan (Naruto, Kaiju No. 8, Batang Quiapo) plus newly added Hindi/Cyrillic/Arabic cases, live against real TVDB data (88 items across all 4 language groups, 100% pass, no regressions).

### Second-pass testing against obscure/low-score titles surfaced two more real gaps:

1. **`_build_show_dict` took the first `eng` translation candidate unconditionally.** TVDB's community-contributed data sometimes has the non-Latin name copied verbatim into the `eng` slot (or a mixed-script entry) *ahead of* a genuinely usable translation further down the list — e.g. Russian show "Вольная грамота" has a garbage `eng` entry equal to its own Cyrillic name, followed by the real "Life of a Mistress" translation; the old code took the first one and stopped. Fixed: now only accepts a candidate that's itself Latin-clean, and keeps scanning if not.
2. **`_build_movie_dict` never got the original fix at all** — it unconditionally overwrote a movie's title with the first `eng` translation regardless of whether the primary name needed it, which is literally the original marketing-AKA bug this whole feature exists to prevent. Now shares the same validated resolution logic as shows.
3. **Added a TMDB cross-check as a further fallback**, since TVDB's own translations are sometimes missing or unusable entirely (e.g. "Пётр I" has zero `eng` translations on TVDB, but TMDB has "Peter I"). Only used when TVDB has nothing clean; falls through to the original title if neither source has anything usable, same as before — the symlink-path layer's independent ID-based fallback already covers that case safely regardless.

Verified against all 4 real broken cases the second pass found (Пётр I, Вольная грамота, Щит и меч, and an Arabic-mixed movie title) — all now resolve to clean Latin titles — plus a regression spot-check confirming no change to previously-correct cases.


### Third-pass: regression check + movie marketing-AKA verification

Re-ran the full obscure-title batch (240 items, 60/group across CJK/Hindi/Cyrillic/Arabic) against the fixed code: zero exceptions, zero regressions — all 4 previously-broken cases stay fixed, everything that passed before still passes.

Also specifically tested the movie-side fix (never exercised before, since `_build_movie_dict` had no protection at all until this branch): 30 real movies with an already-correct Latin primary title *and* a differing `eng` translation available (e.g. `Il buono, il brutto, il cattivo` / `The Good, the Bad and the Ugly`) — **30/30 correctly kept the real primary title** instead of getting overridden by the alternate. Confirms the marketing-AKA protection now works for movies the same way it always has for shows.

**Known, deliberately unfixed limitation:** one obscure Arabic show picked a broadcaster name (`MBC`) over a better, correctly-romanized candidate (`Majmo'at Insan`) sitting later in TVDB's translation list — `has_non_latin_letter` only screens for script contamination, not "is this plausibly a title vs. a channel/network name." Affects 1 of 240 obscure test items; not a crash or a broken symlink path, just a wrong-but-plausible title in a narrow case. Left as a known follow-up rather than fixed now — a title-plausibility heuristic (e.g. deprioritizing short all-caps single-token candidates) would need its own verification to avoid over-filtering genuinely short titles.


## Additional fix (2026-08-19): debrid path downloading a duplicate season pack per episode

Reported via Discord: requesting Mushoku Tensei (2 seasons + 1 running) caused cli_debrid to request 12 duplicate season packs, exhausting the user's debrid limit, reproducing every time. Root cause: the debrid/torrent add path (`torrent_processor.py`) had no sibling-awareness at all — unlike the pre-existing NZB path, which already reused a sibling episode's in-flight pack instead of grabbing a duplicate. Every episode independently scraped and added its own pack, and a successful add immediately blacklists that release's hash (`add_to_not_wanted`), pushing each subsequent episode onto a *different* release-group's pack instead of reusing what was already grabbed. Anime is hit hardest since it commonly has 5-10+ interchangeable fansub packs per season.

### Fix (4 commits, `queues/torrent_processor.py` + `queues/adding_queue.py` + `queues/checking_queue.py`)

1. **Sibling-pack reuse for the debrid path** — new `_check_sibling_debrid_pack`, mirroring the NZB path's existing logic: checks in-memory and DB for a sibling episode (same show/season/version) that already has a debrid job, and reuses it instead of submitting a duplicate. Includes a file-membership check (does the candidate pack actually contain this episode?) to avoid an infinite retry loop against a partial "Part 1"/"Part 2" split pack. Since multiple episodes can now legitimately share one torrent_id, added `_torrent_has_other_active_owner` — a guard in `adding_queue.py` and `checking_queue.py` that checks the DB before letting a single episode's own failure delete a torrent other episodes still depend on.
2. **Title-mismatch fix** — the reuse path was returning an empty `chosen_result_info`, which made the caller fall back to an unrelated fresh-scrape candidate's title instead of the reused torrent's own title, corrupting `original_scraped_torrent_title` and breaking file-location resolution for affected episodes (surfaced as episodes permanently stuck in "Checking").
3. **Candidate dedup + prefer-largest** — the sibling candidate query now dedups by torrent_id (via a `MIN(id)` subquery — a bare `GROUP BY` isn't safe here, SQLite doesn't guarantee non-aggregated columns come from the same row as the grouped one) and picks the most complete pack when more than one legitimately covers the needed episode.
4. **Live consolidation of already-Collected siblings** — when a wider pack gets chosen for the episode currently being processed, and that pack also covers other episodes that already landed on a smaller/different torrent earlier, their symlinks get repointed onto the wider pack live, in the same tick (reuses the existing file-resolution/symlink-creation code, no new path logic), with the old torrent removed only once nothing else references it. Symlink-mode only (Plex mode has no symlink layer to safely repoint). Also fixed a related bug where the reused torrent's *real* mount folder name (from the provider) wasn't being used, falling back to the indexer's cosmetic display title instead — the two frequently differ and only the real one reliably resolves on disk.

### Real-world testing
Live-verified against 3 real shows on a production instance, with both a debrid provider and a usenet provider (cli_mount) enabled simultaneously to confirm no cross-protocol duplication:
- **Mushoku Tensei** (anime, the original bug report): Seasons 1-2 (47 episodes, both fully aired) converged from 12+ duplicate packs down to **3 distinct torrents**. Season 3 is currently airing with no season pack released yet by any group, so its episodes correctly fell to individual per-episode grabs (8 distinct torrents for 8 episodes so far) — expected behavior, not a regression, since sibling-reuse can only reuse a pack that actually exists to be found.
- **Prison Break S02** (non-anime): 22 episodes → **1 torrent**, S03-S05 each fully converged onto their own single shared pack
- **Reacher**: full-season packs correctly reused across all episodes; also the only show where a usenet grab won the race for a few episodes, confirmed via direct DB query afterward that none of those episodes were *also* independently grabbed via debrid — no cross-protocol duplication
- Confirmed via direct diff that the pre-existing NZB sibling-reuse path (`_process_nzb_result`) is untouched by any of this work
