### PR TITLE
Add Scrob to the Connections page

### DIFF
--- a/routes/connections_routes.py
+++ b/routes/connections_routes.py
@@ -560,6 +560,23 @@ def check_tmdb_connection():
         return {'name': 'TMDB', 'connected': False, 'error': str(e), 'details': {}}
 
 
+def check_scrob_connection():
+    """Check Scrob connection if URL and API key are configured."""
+    from content_checkers.scrob import get_scrob_config, _scrob_get
+    config = get_scrob_config()
+    if not config:
+        return None
+    try:
+        data = _scrob_get('/lists')
+        if data is not None:
+            return {'name': 'Scrob', 'connected': True, 'error': None,
+                    'details': {'url': config['base_url']}}
+        return {'name': 'Scrob', 'connected': False,
+                'error': 'Failed to connect to Scrob API', 'details': {}}
+    except Exception as e:
+        return {'name': 'Scrob', 'connected': False, 'error': str(e), 'details': {}}
+
+
 def check_climount_connection():
     """Check usenet provider connection if usenet is enabled and URL is set.
 
@@ -1415,6 +1432,7 @@ def api_check_system():
     tasks['tvdb_status'] = check_tvdb_connection
     tasks['tmdb_status'] = check_tmdb_connection
     tasks['climount_status'] = check_climount_connection
+    tasks['scrob_status'] = check_scrob_connection
     results = {}
     with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
         future_to_task = {executor.submit(func): name for name, func in tasks.items()}
@@ -1435,6 +1453,7 @@ def api_check_system():
     results.setdefault('tvdb_status', None)
     results.setdefault('tmdb_status', None)
     results.setdefault('climount_status', None)
+    results.setdefault('scrob_status', None)
     return jsonify(results)
 
 
@@ -1662,6 +1681,7 @@ def index():
         'jellyfin_status': None, 'mounted_files_status': None,
         'phalanx_db_status': None,
         'tvdb_status': None, 'tmdb_status': None, 'climount_status': None,
+        'scrob_status': None,
         'scraper_statuses': skeleton_scrapers,
         'content_source_statuses': skeleton_sources,
     }
@@ -1686,6 +1706,7 @@ def index():
                          tvdb_status=results['tvdb_status'],
                          tmdb_status=results['tmdb_status'],
                          climount_status=results['climount_status'],
+                         scrob_status=results['scrob_status'],
                          scraper_statuses=results['scraper_statuses'],
                          content_source_statuses=results['content_source_statuses'],
                          failing_connections=failing_connections,

--- a/templates/connections.html
+++ b/templates/connections.html
@@ -296,6 +296,18 @@ body.tangerine-theme #tng-connections .tng-empty{text-align:center;padding:3rem;
                 <span class="conn-card-spinner"></span><span>Checking…</span>
             </div>
         </div>
+
+        <!-- Scrob -->
+        <div class="connection-card" data-service="scrob" {% if not scrob_status %}style="display:none"{% endif %}>
+            <div class="connection-header">
+                <i class="fas fa-list"></i>
+                <span class="connection-title">Scrob</span>
+                <div class="status-indicator {% if scrob_status %}{{ 'connected' if scrob_status.connected else 'disconnected' }}{% else %}checking{% endif %}"></div>
+            </div>
+            <div class="conn-card-footer" data-ts="">
+                <span class="conn-card-spinner"></span><span>Checking…</span>
+            </div>
+        </div>
     </div>
 
     <!-- Scraper Cards -->
@@ -498,6 +510,7 @@ body.tangerine-theme #tng-connections .tng-empty{text-align:center;padding:3rem;
                 'tvdb_status': 'tvdb',
                 'tmdb_status': 'tmdb',
                 'climount_status': 'climount',
+                'scrob_status': 'scrob',
             };
             for (const [key, service] of Object.entries(map)) {
                 if (data[key]) {


### PR DESCRIPTION
## Summary

Scrob already has content-source integration (`content_checkers/scrob.py`), but wasn't showing up on the Connections page as its own tracked service like TVDB/TMDB/the usenet provider do. Adds a `check_scrob_connection()` following the exact same pattern as those:

- Returns `None` when Scrob's URL/API key aren't configured under Additional Settings — card stays hidden, matching every other optional-service card on this page.
- Reuses the existing `get_scrob_config()`/`_scrob_get()` helpers already proven by the Scrob content-source connection check, rather than adding a new HTTP call path.
- Registered in `api_check_system()` and wired into the `connections.html` card grid + JS status map, plus the initial-render skeleton in `index()` for consistency with the sibling cards (not strictly required — Jinja's default undefined-is-falsy would hide the card either way — but keeps this card explicit like every other one instead of relying on that implicit behavior).

## Test plan
- [x] `python3 -m py_compile` on the changed Python file
- [x] Live-verified against a real running Scrob instance: called `check_scrob_connection()` directly through the live app process (with `setup_api_logging()` initialized, to avoid a test-harness-only `NameError` false negative) — confirmed `connected: True` while Scrob was running
- [x] Stopped the real Scrob instance and re-ran the same check — confirmed `connected: False` with a genuine "Failed to connect to Scrob API" error, not the earlier false negative
- [x] Confirmed visually in the browser: the Scrob card appears on the Connections page once configured, and reflects both states correctly