### PR TITLE
Lock the ffprobe playability checkboxes when in Plex mode

### DIFF
--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -41,6 +41,17 @@
     border-radius: 4px;
 }
 
+/* ffprobe playability checks only run in Symlinked/Local mode — locked and
+   dimmed in Plex mode since toggling them there would be a silent no-op. */
+.settings-form-group.settings-disabled-plex-mode {
+    opacity: 0.5;
+}
+
+.settings-form-group.settings-disabled-plex-mode .settings-title,
+.settings-form-group.settings-disabled-plex-mode .settings-description {
+    cursor: not-allowed;
+}
+
 /* Checkbox specific styles */
 .settings-form-group:has(input[type="checkbox"]) {
     margin-bottom: 0;

--- a/static/css/tangerine/tangerine_settings.css
+++ b/static/css/tangerine/tangerine_settings.css
@@ -630,6 +630,17 @@
     border-color: rgba(255, 255, 255, 0.08);
 }
 
+/* ffprobe playability checks only run in Symlinked/Local mode — locked and
+   dimmed in Plex mode since toggling them there would be a silent no-op. */
+.settings-form-group.settings-disabled-plex-mode {
+    opacity: 0.5;
+}
+
+.settings-form-group.settings-disabled-plex-mode:hover {
+    background-color: transparent;
+    border-color: rgba(255, 255, 255, 0.05);
+}
+
 /* Checkbox specific styles */
 .settings-form-group:has(input[type="checkbox"]) {
     margin-bottom: 0;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -115,6 +115,28 @@ function togglePlexSection() {
                 element.style.display = 'none';
             });
         }
+
+        // The ffprobe playability checks (NZB/debrid additions) only ever run in
+        // Symlinked/Local mode server-side — Plex mode never reaches a resolvable
+        // local file path for them, so they're a silent no-op there regardless of
+        // this setting's stored value. Lock the controls in Plex mode so that's
+        // obvious in the UI too, instead of letting someone toggle a checkbox that
+        // does nothing. This only affects interactivity, not the saved setting —
+        // switching back to Symlinked/Local re-enables the control showing
+        // whatever value was already stored.
+        // IDs vary by theme (tangerine uses underscores, default theme uses a
+        // literal space), so check both.
+        const ffprobeCheckboxIds = [
+            'usenet_provider-ffprobe_all_nzbs', 'usenet provider-ffprobe_all_nzbs',
+            'debrid_provider-ffprobe_all_debrid_additions', 'debrid provider-ffprobe_all_debrid_additions',
+        ];
+        ffprobeCheckboxIds.forEach(id => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.disabled = !isSymlinked;
+            const group = el.closest('.settings-form-group');
+            if (group) group.classList.toggle('settings-disabled-plex-mode', !isSymlinked);
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

**Purely visual — no functional/behavior change.** `ffprobe_all_nzbs` and `ffprobe_all_debrid_additions` (added in #465) already only run server-side in `Symlinked/Local` mode — Plex mode never reaches a resolvable local file path for them, so the check hard-skips itself regardless of what these settings say. Toggling either one on while in Plex mode was already a silent no-op before this PR; this just makes that visible in the UI instead of leaving a checkbox that looks live but does nothing.

Disables and dims both controls whenever the file collection management mode isn't `Symlinked/Local`, re-enabling them (showing whatever value was already stored) when switching back to Symlinked/Local. Handles both theme's element ID conventions (tangerine uses underscores, the default theme uses a literal space).

## Test plan
- [x] `node --check` on the changed JS file
- [x] Confirmed the settings-save logic reads `.checked`/`.value` directly via JS rather than relying on native HTML form submission, so disabling the control doesn't affect what actually gets persisted — the real stored setting is untouched by this change either way, in both directions of the mode switch
- [x] Live-patched the static JS/CSS into a running instance and confirmed no console errors on the settings page