### PR TITLE
fix: don't leak torrent entries into the Usenet repair tab

### DIFF
--- a/usenet/climount_client.py
+++ b/usenet/climount_client.py
@@ -743,9 +743,13 @@ class CliMountClient:
             return []
 
     def get_health_summary(self) -> dict:
-        """Counts by status from cli_mount /api/repair/health.
-        When debrid naming is enabled, excludes torrent protocol entries
-        to avoid showing false positives in the broken count.
+        """Counts by status from cli_mount /api/repair/health, usenet entries only.
+
+        /api/repair/health is protocol-agnostic (nzb + torrent together); this
+        is the usenet-only view, so torrent entries always need excluding
+        here regardless of any other setting — debrid_repair_engine's own
+        get_health_summary is the symmetric torrent-only counterpart. Mirrors
+        the same always-filter fix already applied to fetch_broken_items.
         """
         if not self.is_enabled():
             return {}
@@ -754,8 +758,7 @@ class CliMountClient:
             if r.status_code != 200:
                 return {}
             entries = self._parse_health_entries(r.json())
-            if self._debrid_naming_enabled():
-                entries = [e for e in entries if (e.get('protocol') or '').lower() != 'torrent']
+            entries = [e for e in entries if (e.get('protocol') or '').lower() != 'torrent']
             counts: Dict[str, int] = {}
             for e in entries:
                 s = (e.get('status') or 'unknown').lower()

--- a/usenet/repair_engine.py
+++ b/usenet/repair_engine.py
@@ -158,17 +158,18 @@ def fetch_broken_items(annotate_mount: bool = False) -> list:
         logger.error(f'[NZBRepair] fetch_broken_items error: {e}')
         return []
 
-    # Filter out debrid torrent entries when debrid naming is enabled,
-    # as renaming causes false positives in cli_mount health checks.
-    try:
-        from utilities.settings import get_setting as _gs
-        if _gs('Debrid Provider', 'enable_debrid_naming', False):
-            before = len(items)
-            items = [e for e in items if (e.get('protocol') or '').lower() != 'torrent']
-            if len(items) < before:
-                logger.info(f'[NZBRepair] Skipped {before - len(items)} debrid torrent entries (debrid naming enabled)')
-    except Exception:
-        pass
+    # cli_mount's /api/repair/health is protocol-agnostic (nzb + torrent
+    # entries together); this function is the usenet-only view, so torrent
+    # entries always need excluding here regardless of any other setting —
+    # debrid_repair_engine.fetch_broken_items() is the symmetric torrent-only
+    # counterpart. This used to only filter when enable_debrid_naming was on,
+    # which left torrent entries (and their broken files, since climount_client
+    # flattens one row per broken file) leaking into the Usenet tab whenever
+    # that unrelated setting was off.
+    before = len(items)
+    items = [e for e in items if (e.get('protocol') or '').lower() != 'torrent']
+    if len(items) < before:
+        logger.info(f'[NZBRepair] Skipped {before - len(items)} debrid torrent entries')
 
     if not annotate_mount or not items:
         return items


### PR DESCRIPTION
## Summary
- `usenet.repair_engine.fetch_broken_items()` only filtered out torrent-protocol entries when the unrelated `enable_debrid_naming` setting was on. With it off (the common case), every broken torrent entry leaked into the Usenet tab's broken-items list — and since the client flattens one row per broken file, a single multi-file torrent showed up as many duplicate rows. The filter is now unconditional.
- Same class of bug in the sibling `get_health_summary` method — the Usenet tab's health-count badge included torrent entries too, even after the list itself was correctly filtered. Fixed the same way.

## Test plan
- [x] Live-tested: torrent entries no longer appear in the Usenet tab's broken list or health-count badge
- [x] Debrid tab's own broken list/badge confirmed unaffected (still correctly torrent-only)