### PR TITLE
skip ffprobe_all_nzbs for active playback-repair replacement candidates

### DIFF
--- a/database/nzb_playback_repair.py
+++ b/database/nzb_playback_repair.py
@@ -264,6 +264,26 @@ def candidate_is_excluded(item_id, result):
         conn.close()
 
 
+def has_pending_playback_repair(item_id):
+    """Return whether this item currently has an active (non-complete)
+    playback repair in progress — i.e. it's a replacement candidate whose
+    playability decypharr's own VerifyReplacement already ffprobes before
+    accepting it. Used to skip the redundant ffprobe_all_nzbs check on the
+    same file during Adding/Checking, instead of running two independent,
+    uncoordinated ffprobe checks on the same replacement candidate."""
+    if not item_id:
+        return False
+    conn = get_db_connection()
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM nzb_playback_repairs WHERE cli_debrid_id=? AND status!='complete' LIMIT 1",
+            (int(item_id),),
+        ).fetchone()
+        return bool(row)
+    finally:
+        conn.close()
+
+
 def has_active_exact_repair(item_id, old_info_hash, old_file_name):
     """Return whether the exact old mounted file already has an active repair."""
     if not item_id or not old_info_hash or not old_file_name:

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1448,7 +1448,27 @@ def check_local_file_for_item(item: Dict[str, Any], is_webhook: bool = False, ex
             _is_nzb_for_probe = _torrent_id_for_probe.startswith('nzb:')
             _probe_section = 'Usenet Provider' if _is_nzb_for_probe else 'Debrid Provider'
             _probe_key = 'ffprobe_all_nzbs' if _is_nzb_for_probe else 'ffprobe_all_debrid_additions'
-            if get_setting(_probe_section, _probe_key, False):
+            # An item that's an active playback-repair replacement candidate
+            # (NZB-only — there's no debrid equivalent of VerifyReplacement)
+            # already gets ffprobed by cli_mount's own VerifyReplacement
+            # before it's accepted, on a code path that's synchronized with
+            # when the old file's cleanup can proceed. Running ffprobe_all_nzbs
+            # here too would be a second, independent, uncoordinated check on
+            # the exact same file — skip it and let VerifyReplacement be the
+            # sole authority for replacement candidates specifically.
+            _skip_probe_for_replacement = False
+            if _is_nzb_for_probe:
+                try:
+                    from database.nzb_playback_repair import has_pending_playback_repair
+                    if has_pending_playback_repair(item.get('id')):
+                        _skip_probe_for_replacement = True
+                        logging.info(
+                            f"[ffprobe] Skipping {_probe_key} for '{source_file}' — active playback-repair "
+                            f"replacement candidate, already verified by cli_mount's own check"
+                        )
+                except Exception:
+                    pass
+            if get_setting(_probe_section, _probe_key, False) and not _skip_probe_for_replacement:
                 logging.info(f"[ffprobe] Running playability check ({_probe_key}) on '{source_file}'")
                 from usenet.repair_engine import _verify_file_readable
                 if _verify_file_readable(source_file):


### PR DESCRIPTION
## Summary
A replacement candidate for an active exact playback repair already gets ffprobed by cli_mount's own `VerifyReplacement` before it's accepted — that check is synchronized with when the old file's cleanup can proceed (it's the gate that keeps the old file around until the replacement is confirmed playable). Running `ffprobe_all_nzbs` on the same file too was a second, independent, uncoordinated check with no relationship to that cleanup timing.

Added `has_pending_playback_repair(item_id)` and use it to skip `ffprobe_all_nzbs` specifically when the item currently has an active row in `nzb_playback_repairs`. NZB-only — there's no debrid equivalent of `VerifyReplacement`, so `ffprobe_all_debrid_additions` is untouched.

Depends on the corresponding decypharr PR (mash2k3/decypharr#5) for `VerifyReplacement` to remain the sole ffprobe authority for replacement candidates.

## Test plan
- [x] Live-tested end to end: broken NZB entry → repair → replacement scraped → cli_debrid's own ffprobe skipped (confirmed via log line) → decypharr's `VerifyReplacement` ffprobed and confirmed healthy → old file cleaned up → repair finalized
- [x] Confirmed regular (non-repair) additions still run `ffprobe_all_nzbs` normally, unaffected