### PR TITLE
Add duplicate-symlink audit tool; fix non-Latin anime titles, debrid duplicate season-pack downloads, and 8 other bugs (NZB coalescing, ffprobe parity, symlink audit data loss, request-version handling, Plex box sets)

### DIFF
--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -703,6 +703,113 @@ def get_show_data(imdb_id: str) -> Optional[dict]:
     return show_data
 
 
+def _extract_tmdb_id_from_remote_ids(raw: dict) -> Optional[int]:
+    """Pull the TMDB ID out of a TVDB series/movie response's own remoteIds,
+    when present - more reliable than re-resolving it independently via
+    TMDB's /find endpoint (which can fail to link an IMDb ID that TVDB's own
+    cross-reference already has)."""
+    remote_ids = raw.get('remoteIds', []) or raw.get('remote_ids', [])
+    if not isinstance(remote_ids, list):
+        return None
+    for rid in remote_ids:
+        if isinstance(rid, dict):
+            source = (rid.get('sourceName', '') or '').lower()
+            if 'tmdb' in source or 'themoviedb' in source:
+                try:
+                    return int(rid.get('id', ''))
+                except (ValueError, TypeError):
+                    return None
+    return None
+
+
+def _fetch_tmdb_title_only(tmdb_id: Optional[int], imdb_id: str, api_key: str, media_type: str) -> Optional[str]:
+    """Minimal TMDB lookup for just a title - avoids the overhead of the full
+    _fetch_tmdb_show_data / _fetch_tmdb_movie_data fallback fetchers below,
+    which build out seasons/episodes/genres/etc. that aren't needed here.
+    Falls back to resolving the TMDB ID from the IMDb ID only if the caller
+    doesn't already have one from TVDB's own remoteIds."""
+    if not tmdb_id:
+        tmdb_id = _resolve_tmdb_id_from_imdb(imdb_id, api_key, media_type=media_type)
+    if not tmdb_id:
+        return None
+    endpoint = 'tv' if media_type == 'show' else 'movie'
+    try:
+        resp = requests.get(
+            f"https://api.themoviedb.org/3/{endpoint}/{tmdb_id}",
+            params={'api_key': api_key},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            return None
+        raw = resp.json()
+        return raw.get('name') if media_type == 'show' else raw.get('title')
+    except Exception as e:
+        logger.debug(f"TMDB title-only lookup failed for {imdb_id}: {e}")
+        return None
+
+
+def _resolve_display_title(title: str, raw: dict, imdb_id: str, media_type: str) -> str:
+    """When `title` (TVDB's primary name) contains non-Latin script, try to find
+    a usable Latin-script title instead, in order:
+      1. A TVDB nameTranslations 'eng' entry that's itself actually Latin-clean -
+         not just the first 'eng' entry array-order, since TVDB's community data
+         sometimes has the non-Latin name copied verbatim into the eng slot, or a
+         mixed-script entry (e.g. a stray non-Latin word left in an otherwise
+         English translation), ahead of a genuinely clean one further down.
+      2. TMDB's own title for the same item, when TVDB has no clean translation -
+         TMDB's editorial title is often present even when TVDB's
+         community-contributed translations are missing or unusable.
+
+    Detected via the presence of any non-Latin *letter*, not "lacks a Latin
+    letter" — a title can contain both, e.g. Naruto's TVDB primary name is
+    'NARUTO－ナルト－' (has plenty of Latin letters, but still half Japanese
+    katakana); requiring the *absence* of Latin letters missed this case
+    entirely. Also not just "any ASCII survives encoding" — a title like
+    '怪獣8号' has a literal ASCII digit in it, so that check would call it
+    "representable" too. Script-agnostic (Japanese, Korean, Chinese, Hindi,
+    Cyrillic, Arabic, etc.) rather than enumerating specific scripts one at a
+    time - see utilities.text_utils.has_non_latin_letter.
+
+    Falls through to the original non-Latin title if nothing usable is found
+    anywhere - the symlink-path layer (utilities/local_library_scan.py) has its
+    own independent ID-based fallback for that case, so this never risks a
+    folder collision either way, only display/scraping accuracy.
+    """
+    from utilities.text_utils import has_non_latin_letter
+    if not title or not has_non_latin_letter(title):
+        return title
+
+    for t in (raw.get('translations', {}).get('nameTranslations') or []):
+        candidate = t.get('name')
+        if t.get('language') == 'eng' and candidate and not has_non_latin_letter(candidate):
+            logger.info(
+                f"TVDB primary name {title!r} is non-Latin — using clean TVDB "
+                f"English translation {candidate!r} instead"
+            )
+            return candidate
+
+    try:
+        tmdb_api_key = _get_tmdb_api_key()
+        if tmdb_api_key:
+            tmdb_id = _extract_tmdb_id_from_remote_ids(raw)
+            tmdb_title = _fetch_tmdb_title_only(tmdb_id, imdb_id, tmdb_api_key, media_type)
+            if tmdb_title and not has_non_latin_letter(tmdb_title):
+                logger.info(
+                    f"TVDB primary name {title!r} is non-Latin with no clean TVDB "
+                    f"translation — using TMDB title {tmdb_title!r} instead"
+                )
+                return tmdb_title
+    except Exception as e:
+        logger.debug(f"TMDB title fallback failed for {imdb_id}: {e}")
+
+    logger.warning(
+        f"TVDB primary name {title!r} is non-Latin and no clean English title "
+        f"found via TVDB or TMDB — leaving as-is (symlink layer will use its "
+        f"own ID-based fallback)"
+    )
+    return title
+
+
 def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
     """Build a Trakt-compatible show metadata dict from TVDB series data."""
     ids = {
@@ -751,27 +858,9 @@ def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
     # romanized or English form at all. Storing that as the canonical title breaks
     # every ASCII-dependent downstream consumer — scraper query normalization strips
     # it to an empty (or badly mangled) string, and symlink path generation strips it
-    # down too. Fall back to the English nameTranslations entry instead, when the
-    # primary name actually contains non-Latin script.
-    #
-    # Detected via the presence of any non-Latin letter, not "lacks a Latin
-    # letter" — a title can contain both, e.g. Naruto's TVDB primary name is
-    # 'NARUTO－ナルト－' (has plenty of Latin letters, but still half Japanese
-    # katakana); requiring the *absence* of Latin letters missed this case entirely.
-    # Also not just "any ASCII survives encoding" — a title like '怪獣8号' has a
-    # literal ASCII digit in it, so that check would call it "representable" too.
-    # Script-agnostic (Japanese, Korean, Chinese, Hindi, Cyrillic, Arabic, etc.)
-    # rather than enumerating specific scripts one at a time.
-    from utilities.text_utils import has_non_latin_letter
-    if title and has_non_latin_letter(title):
-        for t in (raw.get('translations', {}).get('nameTranslations') or []):
-            if t.get('language') == 'eng' and t.get('name'):
-                logger.info(
-                    f"TVDB primary name {title!r} has no Latin-representable content — "
-                    f"using English translation {t['name']!r} instead"
-                )
-                title = t['name']
-                break
+    # down too. Fall back to a usable Latin-script title instead, when the primary
+    # name actually contains non-Latin script.
+    title = _resolve_display_title(title, raw, imdb_id, media_type='show')
 
     # Airs info
     airs = {}
@@ -1140,13 +1229,17 @@ def _build_movie_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
             except ValueError:
                 pass
 
-    # Find English overview/title
+    # Find title/overview. Unlike overview (always fine to prefer the English
+    # translation when present), the primary name must NOT be unconditionally
+    # replaced — a TVDB 'eng' nameTranslations entry is sometimes a wrong
+    # marketing AKA rather than a true localization (e.g. "Gangs of Manila" for
+    # "Batang Quiapo"), so only fall back to it when the primary name actually
+    # contains non-Latin script and can't be used as-is. See
+    # _resolve_display_title's docstring for the full detection/fallback chain
+    # (TVDB clean translation, then TMDB, then leave as-is).
     title = raw.get('name', '')
     overview = raw.get('overview', '')
-    for t in raw.get('translations', {}).get('nameTranslations', []) or []:
-        if t.get('language') == 'eng' and t.get('name'):
-            title = t['name']
-            break
+    title = _resolve_display_title(title, raw, imdb_id, media_type='movie')
     for t in raw.get('translations', {}).get('overviewTranslations', []) or []:
         if t.get('language') == 'eng':
             overview = t.get('overview', overview)

--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -8,7 +8,6 @@ Rate limiting: No preemptive tracking; 429s handled with exponential backoff.
 """
 
 import json
-import re
 import time
 import logging
 import threading
@@ -755,19 +754,16 @@ def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
     # down too. Fall back to the English nameTranslations entry instead, when the
     # primary name actually contains non-Latin script.
     #
-    # Detected via the presence of CJK/Kana/Hangul characters, not "lacks a Latin
+    # Detected via the presence of any non-Latin letter, not "lacks a Latin
     # letter" — a title can contain both, e.g. Naruto's TVDB primary name is
     # 'NARUTO－ナルト－' (has plenty of Latin letters, but still half Japanese
     # katakana); requiring the *absence* of Latin letters missed this case entirely.
     # Also not just "any ASCII survives encoding" — a title like '怪獣8号' has a
     # literal ASCII digit in it, so that check would call it "representable" too.
-    _non_latin_script = re.compile(
-        r'[぀-ヿ'   # Hiragana + Katakana
-        r'㐀-䶿'    # CJK Extension A
-        r'一-鿿'    # CJK Unified Ideographs
-        r'가-힣]'   # Hangul syllables
-    )
-    if title and _non_latin_script.search(title):
+    # Script-agnostic (Japanese, Korean, Chinese, Hindi, Cyrillic, Arabic, etc.)
+    # rather than enumerating specific scripts one at a time.
+    from utilities.text_utils import has_non_latin_letter
+    if title and has_non_latin_letter(title):
         for t in (raw.get('translations', {}).get('nameTranslations') or []):
             if t.get('language') == 'eng' and t.get('name'):
                 logger.info(

--- a/cli_battery/app/tvdb_client.py
+++ b/cli_battery/app/tvdb_client.py
@@ -8,6 +8,7 @@ Rate limiting: No preemptive tracking; 429s handled with exponential backoff.
 """
 
 import json
+import re
 import time
 import logging
 import threading
@@ -745,6 +746,36 @@ def _build_show_dict(raw: dict, imdb_id: str, tvdb_id: int) -> dict:
     # rather than a true localization, so it must not override the primary name here —
     # it's still captured separately via _extract_aliases() for search matching.
     title = raw.get('name', '')
+
+    # Exception: some series (commonly anime) have their primary TVDB name stored
+    # partly or entirely in non-Latin script (e.g. Japanese/Chinese/Korean), with no
+    # romanized or English form at all. Storing that as the canonical title breaks
+    # every ASCII-dependent downstream consumer — scraper query normalization strips
+    # it to an empty (or badly mangled) string, and symlink path generation strips it
+    # down too. Fall back to the English nameTranslations entry instead, when the
+    # primary name actually contains non-Latin script.
+    #
+    # Detected via the presence of CJK/Kana/Hangul characters, not "lacks a Latin
+    # letter" — a title can contain both, e.g. Naruto's TVDB primary name is
+    # 'NARUTO－ナルト－' (has plenty of Latin letters, but still half Japanese
+    # katakana); requiring the *absence* of Latin letters missed this case entirely.
+    # Also not just "any ASCII survives encoding" — a title like '怪獣8号' has a
+    # literal ASCII digit in it, so that check would call it "representable" too.
+    _non_latin_script = re.compile(
+        r'[぀-ヿ'   # Hiragana + Katakana
+        r'㐀-䶿'    # CJK Extension A
+        r'一-鿿'    # CJK Unified Ideographs
+        r'가-힣]'   # Hangul syllables
+    )
+    if title and _non_latin_script.search(title):
+        for t in (raw.get('translations', {}).get('nameTranslations') or []):
+            if t.get('language') == 'eng' and t.get('name'):
+                logger.info(
+                    f"TVDB primary name {title!r} has no Latin-representable content — "
+                    f"using English translation {t['name']!r} instead"
+                )
+                title = t['name']
+                break
 
     # Airs info
     airs = {}

--- a/database/plex_movie_boxsets.py
+++ b/database/plex_movie_boxsets.py
@@ -316,26 +316,37 @@ def build_boxset_list(name_pattern: str, min_movies: int = 2) -> List[dict]:
     conn = _get_db()
     try:
         rows = conn.execute(
-            """SELECT tmdb_collection_id, tmdb_collection_name,
-                      GROUP_CONCAT(imdb_id) as imdb_ids,
-                      GROUP_CONCAT(ms_item_id) as ms_item_ids
+            """SELECT tmdb_collection_id, tmdb_collection_name, imdb_id, tmdb_id, ms_item_id
                FROM media_items
                WHERE type = 'movie'
                  AND tmdb_collection_id != ''
                  AND tmdb_collection_id IS NOT NULL
                  AND state = 'Collected'
-                 AND ms_item_id IS NOT NULL
-               GROUP BY tmdb_collection_id""",
+                 AND ms_item_id IS NOT NULL""",
         ).fetchall()
     finally:
         conn.close()
 
-    boxsets = []
+    # Group individual movie rows by collection in Python rather than GROUP_CONCAT —
+    # GROUP_CONCAT across multiple columns doesn't guarantee correlated ordering, and
+    # sync_plex_collections() needs each movie's imdb_id/tmdb_id kept together (not
+    # just independent sets) to resolve section-local ratingKeys correctly.
+    collections_grouped: Dict[str, dict] = {}
     for row in rows:
         coll_id = row['tmdb_collection_id']
-        tmdb_name = row['tmdb_collection_name'] or ''
-        owned_imdb_ids = set(i for i in (row['imdb_ids'] or '').split(',') if i)
-        owned_ms_ids = set(i for i in (row['ms_item_ids'] or '').split(',') if i)
+        entry = collections_grouped.setdefault(coll_id, {'name': row['tmdb_collection_name'], 'movies': []})
+        entry['movies'].append({
+            'imdb_id': row['imdb_id'],
+            'tmdb_id': row['tmdb_id'],
+            'ms_item_id': row['ms_item_id'],
+        })
+
+    boxsets = []
+    for coll_id, grouped in collections_grouped.items():
+        tmdb_name = grouped['name'] or ''
+        owned_movies = grouped['movies']
+        owned_imdb_ids = set(m['imdb_id'] for m in owned_movies if m['imdb_id'])
+        owned_ms_ids = set(m['ms_item_id'] for m in owned_movies if m['ms_item_id'])
 
         if len(owned_ms_ids) < min_movies:
             logger.debug(f"[BoxSets] Collection {coll_id} has {len(owned_ms_ids)} owned movie(s), below threshold {min_movies} — skipping")
@@ -396,6 +407,7 @@ def build_boxset_list(name_pattern: str, min_movies: int = 2) -> List[dict]:
             'poster_path': poster_path,
             'owned_imdb_ids': owned_imdb_ids,
             'owned_ms_ids': owned_ms_ids,
+            'owned_movies': owned_movies,
             'all_parts': all_parts,
         })
 
@@ -412,12 +424,38 @@ def sync_plex_collections(boxsets: List[dict], plex_url: str, token: str,
     For each boxset, find or create a Plex collection and ensure all owned
     movies are members. Returns {collection_id: plex_rating_key}.
     """
+    from database.plex_collections import _get_section_id_map
+
     plex_map = {}
+
+    # Resolve section-local ratingKeys — a movie's stored ms_item_id may come from a
+    # different Plex library section (e.g. a split HD/4K setup), or be stale after a
+    # library re-add. Fetch all items in this section keyed by IMDB/TMDB ID so we only
+    # add items that actually exist here, using the correct ratingKey — the same
+    # pattern plex_collections.py uses for the non-boxset collections feature.
+    id_map = _get_section_id_map(plex_url, token, section_key, 'movie')
+    if not id_map:
+        logger.warning(f"[BoxSets] Section {section_key} id_map empty (fetch failed?), skipping sync to avoid data loss")
+        return plex_map
 
     for bs in boxsets:
         display_name = bs['display_name']
-        owned_ms_ids = list(bs['owned_ms_ids'])
         coll_id = bs['collection_id']
+
+        desired_rks = []
+        for m in bs['owned_movies']:
+            imdb = m.get('imdb_id') or ''
+            tmdb = str(m.get('tmdb_id') or '')
+            local_rk = id_map.get(imdb) or (id_map.get('tmdb:' + tmdb) if tmdb else None)
+            if local_rk:
+                desired_rks.append(local_rk)
+
+        if not desired_rks:
+            logger.warning(f"[BoxSets] '{display_name}': none of the {len(bs['owned_movies'])} owned movie(s) found in Plex section {section_key} — skipping (wrong library section?)")
+            continue
+
+        if len(desired_rks) < len(bs['owned_movies']):
+            logger.info(f"[BoxSets] '{display_name}': resolved {len(desired_rks)}/{len(bs['owned_movies'])} owned movie(s) to local ratingKeys in section {section_key}")
 
         try:
             collection_rk = _get_or_create_collection(plex_url, token, section_key, display_name, sort_order)
@@ -428,13 +466,13 @@ def sync_plex_collections(boxsets: List[dict], plex_url: str, token: str,
 
             # Find which owned movies are not yet in the collection
             existing_rks = _get_collection_item_ratingkeys(plex_url, token, collection_rk)
-            to_add = [rk for rk in owned_ms_ids if rk not in existing_rks]
+            to_add = [rk for rk in desired_rks if rk not in existing_rks]
 
             if to_add:
                 _add_items_to_collection(plex_url, token, machine_id, collection_rk, to_add)
                 logger.info(f"[BoxSets] '{display_name}': added {len(to_add)} movies to Plex collection (rk={collection_rk})")
             else:
-                logger.info(f"[BoxSets] '{display_name}': all {len(owned_ms_ids)} movies already in collection (rk={collection_rk})")
+                logger.info(f"[BoxSets] '{display_name}': all {len(desired_rks)} movies already in collection (rk={collection_rk})")
 
         except Exception as e:
             logger.error(f"[BoxSets] Failed to sync Plex collection '{display_name}': {e}", exc_info=True)

--- a/database/wanted_items.py
+++ b/database/wanted_items.py
@@ -554,7 +554,7 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input, un
                     for version_vs, state_vs, _ in existing_movies[tmdb_id]:
                         existing_versions_set_vs.add(version_vs); existing_states_set_vs.add(state_vs)
 
-                if not enable_granular_versions:
+                if not (enable_granular_versions or is_user_initiated_add):
                     if existing_versions_set_vs:
                         skip = True
                         if imdb_id and imdb_id in existing_movies: skip_stats['existing_movie_imdb'] += 1
@@ -599,7 +599,7 @@ def add_wanted_items(media_items_batch: List[Dict[str, Any]], versions_input, un
                         for version_vs, state_vs, _, _ in existing_episodes[tmdb_key_vs]:
                             existing_versions_set_vs.add(version_vs); existing_states_set_vs.add(state_vs)
 
-                if not enable_granular_versions:
+                if not (enable_granular_versions or is_user_initiated_add):
                     if existing_versions_set_vs:
                         skip = True
                         if imdb_key_vs and imdb_key_vs in existing_episodes: skip_stats['existing_episode_imdb'] += 1

--- a/queues/adding_queue.py
+++ b/queues/adding_queue.py
@@ -93,6 +93,35 @@ class AddingQueue:
         else:
             logging.error("Attempted to remove item without ID from queue")
         
+    def _torrent_has_other_active_owner(self, torrent_id: str, exclude_item_id) -> bool:
+        """True if another media_items row still actively depends on this torrent_id.
+
+        Debrid season-pack sibling reuse (torrent_processor.py's _check_sibling_debrid_pack)
+        means multiple episodes can now legitimately share the same torrent_id — something
+        that never happened before that fix, since every debrid torrent used to belong to
+        exactly one item. Callers that remove a torrent from the debrid service in response
+        to *this* item's own failure (no matching files, filter match, etc.) must check this
+        first: removing a still-needed shared pack breaks every sibling relying on it, even
+        though only one of them actually failed.
+        """
+        if not torrent_id or str(torrent_id).startswith('nzb:'):
+            return False
+        try:
+            from database import get_db_connection
+            conn = get_db_connection()
+            try:
+                row = conn.execute(
+                    "SELECT 1 FROM media_items WHERE filled_by_torrent_id=? AND id!=? "
+                    "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 1",
+                    (torrent_id, exclude_item_id)
+                ).fetchone()
+            finally:
+                conn.close()
+            return row is not None
+        except Exception as e:
+            logging.warning(f"Could not check for other owners of torrent {torrent_id}: {e} — assuming shared, skipping removal to be safe")
+            return True
+
     def remove_unwanted_torrent(self, torrent_id: str, is_nzb: bool = False):
         """
         Remove an unwanted torrent from the debrid service and track the removal
@@ -866,8 +895,10 @@ class AddingQueue:
                 # --- START EDIT: Check if failure was due to filter and remove torrent ---
                 if "matched filter-out list" in error:
                     logging.info(f"Upgrade for {item_identifier} failed due to filename filter. Attempting to remove torrent.")
-                    if item.get('torrent_id'):
+                    if item.get('torrent_id') and not self._torrent_has_other_active_owner(item['torrent_id'], item.get('id')):
                         self.remove_unwanted_torrent(item['torrent_id'], is_nzb=is_nzb)
+                    elif item.get('torrent_id'):
+                        logging.info(f"Torrent {item['torrent_id']} still needed by other episode(s) sharing this pack — not removing")
                 # --- END EDIT ---
 
                 # Remove from Adding queue memory regardless of restore success for upgrades
@@ -881,9 +912,12 @@ class AddingQueue:
                "No matching files found in parsed files" in error or \
                "No valid video files found in torrent" in error:
                 logging.info(f"Media matching failed for {item_identifier}, moving back to Wanted queue. Error: {error}")
-                # Remove torrent if ID is present
-                if item.get('torrent_id'):
+                # Remove torrent if ID is present — but only if no sibling episode sharing this
+                # (season-pack-reused) torrent still actively needs it.
+                if item.get('torrent_id') and not self._torrent_has_other_active_owner(item['torrent_id'], item.get('id')):
                     self.remove_unwanted_torrent(item['torrent_id'])
+                elif item.get('torrent_id'):
+                    logging.info(f"Torrent {item['torrent_id']} still needed by other episode(s) sharing this pack — not removing")
                 queue_manager.move_to_wanted(item, "Adding")
                 # move_to_wanted handles removing from self.items
                 return
@@ -891,8 +925,10 @@ class AddingQueue:
             # --- NEW: Handle filename/title filter match ---
             elif "matched filter-out list" in error:
                 logging.info(f"Item {item_identifier} matched filename/title filter, moving back to Wanted queue. Error: {error}")
-                if item.get('torrent_id'):
+                if item.get('torrent_id') and not self._torrent_has_other_active_owner(item['torrent_id'], item.get('id')):
                     self.remove_unwanted_torrent(item['torrent_id'], is_nzb=is_nzb)
+                elif item.get('torrent_id'):
+                    logging.info(f"Torrent {item['torrent_id']} still needed by other episode(s) sharing this pack — not removing")
                 queue_manager.move_to_wanted(item, "Adding")
                 # move_to_wanted handles removing from self.items
                 return

--- a/queues/checking_queue.py
+++ b/queues/checking_queue.py
@@ -1657,6 +1657,35 @@ class CheckingQueue:
         # Iterate over a copy of self.items for safety if handlers modify it.
         items_for_stalled_torrent = [item for item in list(self.items) if item.get('filled_by_torrent_id') == torrent_id]
 
+        # Debrid season-pack sibling reuse means a sibling episode can already be Collected
+        # on this same torrent_id while another sibling is still stuck stalling in this
+        # queue - such a sibling has left self.items entirely, so it's invisible to the
+        # in-memory check above. Removing the torrent here would silently break that
+        # already-Collected episode's playback. Check the DB for any such episode first.
+        if not str(torrent_id).startswith('nzb:'):
+            try:
+                from database import get_db_connection as _gdb_stall
+                _known_ids = {i['id'] for i in items_for_stalled_torrent}
+                _conn = _gdb_stall()
+                try:
+                    _placeholders = ','.join('?' * len(_known_ids)) if _known_ids else 'NULL'
+                    _other = _conn.execute(
+                        f"SELECT 1 FROM media_items WHERE filled_by_torrent_id=? "
+                        f"AND state IN ('Collected','Upgrading') "
+                        f"AND id NOT IN ({_placeholders}) LIMIT 1",
+                        (torrent_id, *_known_ids)
+                    ).fetchone()
+                finally:
+                    _conn.close()
+                if _other:
+                    logging.info(f"Torrent {torrent_id} has a Collected/Upgrading sibling outside this queue's stalled check — not removing, only handling the items stalled here")
+                    for item_to_move in items_for_stalled_torrent:
+                        if self.contains_item_id(item_to_move['id']):
+                            queue_manager.move_to_wanted(item_to_move, "Checking")
+                    return
+            except Exception as e:
+                logging.warning(f"Could not check for Collected siblings of torrent {torrent_id}: {e} — proceeding with normal stalled handling")
+
         if not items_for_stalled_torrent:
             logging.warning(f"No items found for stalled torrent {torrent_id} at the moment of handling.")
             # Clean up strike counter if it exists, as there are no items to process

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -5181,12 +5181,15 @@ class ProgramRunner:
                     logging.error(f"[REPLACE] Error in reconciliation replace hook: {_replace_err}")
             # --- End Step 1b ---
 
-            # --- Step 1c: Collect stranded NZB coalesced items in Adding state ---
+            # --- Step 1c: Resolve stranded NZB coalesced items in Adding state ---
             # When a season pack NZB is submitted, only the initiator episode goes through
             # health check → Checking → _resolve_nzb_file_info → Collected.
             # The coalesced siblings sit in Adding with filled_by_torrent_id=nzb:xxx but no
-            # filled_by_file. If a sibling is already Collected (via Plex scan), collect them
-            # immediately with proper file info copied from the Collected sibling.
+            # filled_by_file. If a sibling is already Collected, look up the pack's actual
+            # file listing on cli_mount and match each stranded item to its own episode file
+            # by SxxEyy (same matching checking_queue._resolve_nzb_file_info uses) before
+            # moving it into Checking - never straight to Collected, since that would mark
+            # an item done with no real file/symlink ever created for it.
             try:
                 stranded_rows = cursor.execute("""
                     SELECT a.id, a.imdb_id, a.season_number, a.episode_number, a.title
@@ -5199,7 +5202,7 @@ class ProgramRunner:
                 """).fetchall()
 
                 if stranded_rows:
-                    stranded_collected = []
+                    stranded_matches = []
                     for row in stranded_rows:
                         # Prefer the initiator row (has nzb torrent_id + folder info),
                         # fall back to any Collected sibling with a filled_by_file.
@@ -5216,17 +5219,52 @@ class ProgramRunner:
                             LIMIT 1
                         """, (row['imdb_id'], row['season_number'], row['id'])).fetchone()
                         if sibling:
-                            stranded_collected.append((row['id'], dict(sibling), dict(row)))
+                            stranded_matches.append((row['id'], dict(sibling), dict(row)))
 
-                    if stranded_collected:
-                        for item_id, sib, item in stranded_collected:
-                            # Use filled_by_title as location_basename (folder name) — sibling's
-                            # location_basename may be a filename if set before the fix.
+                    if stranded_matches:
+                        import re as _re_sc
+                        from usenet.climount_client import get_climount_client as _get_dc_sc
+                        _dc_sc = _get_dc_sc()
+                        _folder_files_cache = {}  # folder_name -> video_files list, avoid repeat lookups
+
+                        for item_id, sib, item in stranded_matches:
                             folder_name = sib['filled_by_title'] or sib['debrid_folder_name'] or sib['location_basename']
+                            if not folder_name:
+                                continue
+
+                            if folder_name not in _folder_files_cache:
+                                try:
+                                    _result = _dc_sc.get_nzb_folder_all_files(folder_name)
+                                    _folder_files_cache[folder_name] = _result[1] if _result else []
+                                except Exception as _lookup_err:
+                                    logging.warning(f"[NZBCoalesce] Folder lookup failed for {folder_name!r}: {_lookup_err}")
+                                    _folder_files_cache[folder_name] = []
+                            video_files = _folder_files_cache[folder_name]
+
+                            season = item['season_number']
+                            episode = item['episode_number']
+                            matched_file = None
+                            if season is not None and episode is not None:
+                                ep_pat = _re_sc.compile(rf'[Ss]{season:02d}[Ee]{episode:02d}(?![0-9])', _re_sc.IGNORECASE)
+                                for vf in video_files:
+                                    if ep_pat.search(vf):
+                                        matched_file = vf
+                                        break
+
+                            if not matched_file:
+                                # Can't confirm this item's own file exists in the pack folder yet -
+                                # leave it in Adding rather than falsely marking it done.
+                                reconciliation_logger.debug(
+                                    f"[NZBCoalesce] Stranded item {item_id} '{item['title']}' "
+                                    f"S{item['season_number']}E{item['episode_number']} — no matching file "
+                                    f"found yet in folder {folder_name!r}, leaving in Adding"
+                                )
+                                continue
+
                             cursor.execute("""
                                 UPDATE media_items SET
-                                    state = 'Collected',
-                                    collected_at = ?,
+                                    state = 'Checking',
+                                    filled_by_file = ?,
                                     filled_by_torrent_id = ?,
                                     filled_by_title = ?,
                                     debrid_folder_name = ?,
@@ -5235,7 +5273,7 @@ class ProgramRunner:
                                     real_debrid_original_title = ?
                                 WHERE id = ?
                             """, (
-                                now_str,
+                                matched_file,
                                 sib['filled_by_torrent_id'],
                                 folder_name,
                                 folder_name,
@@ -5245,9 +5283,9 @@ class ProgramRunner:
                                 item_id,
                             ))
                             reconciliation_logger.info(
-                                f"[NZBCoalesce] Collected stranded Adding item {item_id} "
+                                f"[NZBCoalesce] Resolved stranded Adding item {item_id} "
                                 f"'{item['title']}' S{item['season_number']}E{item['episode_number']} "
-                                f"— sibling {sib['id']} already Collected"
+                                f"→ {matched_file!r}, moved to Checking (sibling {sib['id']} already Collected)"
                             )
             except Exception as _sc_err:
                 logging.error(f"[NZBCoalesce] Step 1c error: {_sc_err}", exc_info=True)

--- a/queues/scraping_queue.py
+++ b/queues/scraping_queue.py
@@ -326,25 +326,42 @@ class ScrapingQueue:
                         _coal_check_title = _sibling_nzb[4] if _sibling_nzb else None  # original_scraped_torrent_title
                         if not _coal_check_title and _sibling_nzb:
                             _coal_check_title = _sibling_nzb[1]  # fall back to filled_by_file
-                        if _sibling_nzb and not _re_coal.search(r'[Ss]\d{2}[Ee]\d{2}', _coal_check_title or ''):
+                        # An empty title here is not evidence of a pack - it usually just means
+                        # the sibling's own submission hasn't finished writing back yet. Requiring
+                        # a real title before concluding "pack" avoids wrongly coalescing this item
+                        # into an unrelated individual episode's job.
+                        if _sibling_nzb and _coal_check_title and not _re_coal.search(r'[Ss]\d{2}[Ee]\d{2}', _coal_check_title):
                             _job_id = _sibling_nzb[0]
-                            _job_url = _sibling_nzb[2] or ''
-                            _job_title = _sibling_nzb[3] or ''
-                            _job_orig = _sibling_nzb[4] or ''
-                            _job_seg = _sibling_nzb[5] or ''
-                            logging.info(f'[NZBPack] {item_identifier}: season pack already submitted (job={_job_id}), coalescing into same job')
-                            from database.database_writing import update_media_item, update_media_item_state
-                            update_media_item_state(item_to_process['id'], 'Adding')
-                            _coal_seg_kwargs = {'nzb_segment_id': _job_seg} if _job_seg else {}
-                            update_media_item(item_to_process['id'],
-                                filled_by_torrent_id=_job_id,
-                                filled_by_magnet=_job_url,
-                                filled_by_title=_job_title,
-                                original_scraped_torrent_title=_job_orig,
-                                **_coal_seg_kwargs,
-                            )
-                            self.remove_item(item_to_process)
-                            return True
+                            # Verify the shared job is still actually queryable on the provider
+                            # before reusing it - a job that completed and was since cleaned up
+                            # (or never existed) will ghost every retry forever if reused blindly,
+                            # since nothing else ever re-checks it once it's written to this item.
+                            _job_hash_for_check = _job_id[4:] if str(_job_id).startswith('nzb:') else _job_id
+                            try:
+                                from usenet.climount_client import is_nzb_job_alive as _is_job_alive
+                                _coalesce_job_alive = _is_job_alive(_job_hash_for_check)
+                            except Exception:
+                                _coalesce_job_alive = True  # unknown due to error - don't block a legitimate reuse
+                            if not _coalesce_job_alive:
+                                logging.warning(f'[NZBPack] {item_identifier}: sibling job {_job_id} no longer alive on provider - not coalescing, submitting fresh')
+                            else:
+                                _job_url = _sibling_nzb[2] or ''
+                                _job_title = _sibling_nzb[3] or ''
+                                _job_orig = _sibling_nzb[4] or ''
+                                _job_seg = _sibling_nzb[5] or ''
+                                logging.info(f'[NZBPack] {item_identifier}: season pack already submitted (job={_job_id}), coalescing into same job')
+                                from database.database_writing import update_media_item, update_media_item_state
+                                update_media_item_state(item_to_process['id'], 'Adding')
+                                _coal_seg_kwargs = {'nzb_segment_id': _job_seg} if _job_seg else {}
+                                update_media_item(item_to_process['id'],
+                                    filled_by_torrent_id=_job_id,
+                                    filled_by_magnet=_job_url,
+                                    filled_by_title=_job_title,
+                                    original_scraped_torrent_title=_job_orig,
+                                    **_coal_seg_kwargs,
+                                )
+                                self.remove_item(item_to_process)
+                                return True
                     except Exception as _ce:
                         logging.debug(f'[NZBPack] Season pack coalesce check failed: {_ce}')
 

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -509,6 +509,124 @@ class TorrentProcessor:
                 except Exception as e:
                     logging.error(f"Error cleaning up temp file {temp_file}: {e}")
                     
+    def _check_sibling_debrid_pack(self, item: Optional[Dict] = None, adding_queue_items: Optional[list] = None) -> Optional[Tuple]:
+        """If another episode of the same show/season/version already has a debrid season-pack
+        job, reuse it instead of independently scraping and adding a duplicate pack.
+
+        Mirrors _process_nzb_result's sibling-reuse logic, adapted for the debrid path, which
+        previously had no equivalent check at all - every episode of a whole-show/whole-season
+        request scraped and submitted completely independently, and since a successful add
+        immediately blacklists that release's hash via add_to_not_wanted(), each subsequent
+        sibling's scrape fell through to the next-best *distinct* pack (often a different
+        release group) instead of reusing the one already grabbed. Confirmed live: this
+        downloaded ~12 different season-pack torrents for one anime show before this fix.
+
+        Unlike NZB reuse (which returns an empty files list and defers resolution to a separate
+        reconciliation task), debrid's get_torrent_info() is synchronous and already returns the
+        full file listing - so this returns a real, populated torrent_info dict and rides the
+        existing _parse_file_info -> find_best_match_from_parsed -> find_related_items pipeline
+        in adding_queue.py completely unmodified to resolve this episode's own file.
+        """
+        if not item or item.get('type') != 'episode':
+            return None
+        _imdb = item.get('imdb_id')
+        _season = item.get('season_number')
+        if not _imdb or _season is None:
+            return None
+
+        import re as _re_sib
+        _item_version = (item.get('version') or '').rstrip('*')
+
+        def _is_pack_title(title: str) -> bool:
+            return bool(title) and not _re_sib.search(r'[Ss]\d{2}[Ee]\d{2}', title)
+
+        _episode = item.get('episode_number')
+        _ep_pattern = (
+            _re_sib.compile(rf'[Ss]{_season:02d}[Ee]{_episode:02d}(?!\d)')
+            if _episode is not None else None
+        )
+
+        def _try_reuse(torrent_id: str, check_title: str, magnet: Optional[str]) -> Optional[Tuple]:
+            if not _is_pack_title(check_title):
+                return None
+            for provider in self._providers:
+                try:
+                    info = provider.get_torrent_info(torrent_id)
+                except Exception as e:
+                    logging.debug(f"[{provider.PROVIDER_NAME}] get_torrent_info failed for sibling reuse {torrent_id}: {e}")
+                    continue
+                if not (info and info.get('files')):
+                    continue
+                # Verify this specific episode is actually present in the candidate pack before
+                # reusing it - some season "packs" only cover part of the season (e.g. a
+                # "Part 1"/"Part 2" split, common for long anime seasons). Blindly reusing a
+                # pack that doesn't contain this episode stuck it in a permanent loop: every
+                # retry re-hit this same sibling check, got pointed at the same non-containing
+                # pack again, failed to match, and never got a chance to scrape fresh for the
+                # pack that actually has it.
+                if _ep_pattern is not None:
+                    _files = info.get('files', [])
+                    _has_episode = any(
+                        _ep_pattern.search(f.get('path') or f.get('filename') or '')
+                        for f in _files
+                    )
+                    if not _has_episode:
+                        logging.info(f"[{item.get('title', 'Unknown')}] Sibling pack {torrent_id} does not "
+                                     f"contain S{_season:02d}E{_episode:02d} — not reusing, trying next candidate")
+                        return None
+                self.debrid_provider = provider
+                info = dict(info)
+                info['original_scraped_torrent_title'] = check_title
+                logging.info(f"[{item.get('title', 'Unknown')}] Season pack already submitted for "
+                             f"S{_season:02d} (torrent_id={torrent_id}) — reusing instead of duplicate submission")
+                return info, magnet, None
+            return None
+
+        # In-memory check first: catches a sibling submitted this same tick, before it's
+        # written back to the DB.
+        if adding_queue_items:
+            for _mem_item in adding_queue_items:
+                if (_mem_item.get('id') == item.get('id') or
+                        _mem_item.get('imdb_id') != _imdb or
+                        _mem_item.get('season_number') != _season or
+                        (_mem_item.get('version') or '').rstrip('*') != _item_version):
+                    continue
+                _mem_torrent_id = _mem_item.get('filled_by_torrent_id')
+                if not _mem_torrent_id or str(_mem_torrent_id).startswith('nzb:'):
+                    continue
+                _mem_check_title = _mem_item.get('original_scraped_torrent_title') or _mem_item.get('filled_by_file') or ''
+                reused = _try_reuse(_mem_torrent_id, _mem_check_title, _mem_item.get('filled_by_magnet'))
+                if reused:
+                    return reused
+
+        # DB check second - covers siblings resolved on a prior tick.
+        try:
+            from database import get_db_connection as _gdb
+            _conn = _gdb()
+            try:
+                _siblings = _conn.execute(
+                    "SELECT filled_by_torrent_id, filled_by_file, original_scraped_torrent_title, filled_by_magnet "
+                    "FROM media_items "
+                    "WHERE imdb_id=? AND season_number=? AND type='episode' "
+                    "AND id!=? AND filled_by_torrent_id IS NOT NULL AND filled_by_torrent_id NOT LIKE 'nzb:%' "
+                    "AND REPLACE(COALESCE(version,''),'*','')=? "
+                    "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 5",
+                    (_imdb, _season, item.get('id', -1), _item_version)
+                ).fetchall()
+            finally:
+                _conn.close()
+        except Exception as e:
+            logging.debug(f"Sibling debrid-pack DB check failed: {e}")
+            return None
+
+        for _sib in _siblings:
+            _sib_check_title = _sib[2] or _sib[1] or ''
+            reused = _try_reuse(_sib[0], _sib_check_title, _sib[3])
+            if reused:
+                return reused
+
+        return None
+
     def _process_nzb_result(self, result: Dict, item: Optional[Dict] = None, adding_queue_items: Optional[list] = None) -> Optional[Tuple]:
         """Submit an NZB result to cli_mount and return a synthetic torrent_info tuple."""
         from usenet.climount_client import get_climount_client, reset_climount_client
@@ -953,7 +1071,11 @@ class TorrentProcessor:
         """
         item_identifier = item.get('title', 'Unknown') if item else 'Unknown'
         logging.info(f"[{item_identifier}] Starting to process {len(results)} results (accept_uncached={accept_uncached})")
-        
+
+        sibling_pack = self._check_sibling_debrid_pack(item, adding_queue_items=adding_queue_items)
+        if sibling_pack:
+            return sibling_pack
+
         for idx, result in enumerate(results, 1):
             chosen_result_for_return = None # Initialize variable to hold the chosen result
             try:

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -579,7 +579,19 @@ class TorrentProcessor:
                 info['original_scraped_torrent_title'] = check_title
                 logging.info(f"[{item.get('title', 'Unknown')}] Season pack already submitted for "
                              f"S{_season:02d} (torrent_id={torrent_id}) — reusing instead of duplicate submission")
-                return info, magnet, None
+                # chosen_result_info must reflect THIS reused torrent's own title, not None -
+                # adding_queue.py falls back to results[0] (the fresh scrape's top candidate,
+                # unrelated to what we're actually reusing) whenever this is falsy, which writes
+                # a mismatched title into original_scraped_torrent_title. That's usually masked by
+                # debrid_folder_name (set separately from this torrent's own info) still letting
+                # check_local_file_for_item resolve the file via a different fallback attempt, but
+                # not always - live-reproduced as "not found in any checked location" recurring
+                # once something else also disrupted that fallback.
+                chosen_result_info = {
+                    'title': check_title,
+                    'original_scraped_torrent_title': check_title,
+                }
+                return info, magnet, chosen_result_info
             return None
 
         # In-memory check first: catches a sibling submitted this same tick, before it's

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -577,6 +577,15 @@ class TorrentProcessor:
                 self.debrid_provider = provider
                 info = dict(info)
                 info['original_scraped_torrent_title'] = check_title
+                # debrid_folder_name must reflect the provider's OWN real mount folder name
+                # (info['filename']/'original_filename'), not the indexer's cosmetic display
+                # title (check_title) - those two frequently differ (e.g. a release named
+                # "[Fuchs] Mushoku Tensei - S02 (BD 1080p HEVC Opus 2.0)..." by the indexer but
+                # actually stored on the mount as "Mushoku.Tensei.S02.1080p.BluRay...-Fuchs" by
+                # whoever uploaded it). check_local_file_for_item's first folder-name guess
+                # (debrid_folder_name) needs the real one to succeed without depending on the
+                # other, title-based fallback guesses also happening to match by luck.
+                info['debrid_folder_name'] = info.get('filename') or info.get('original_filename') or check_title
                 logging.info(f"[{item.get('title', 'Unknown')}] Season pack already submitted for "
                              f"S{_season:02d} (torrent_id={torrent_id}) — reusing instead of duplicate submission")
                 # chosen_result_info must reflect THIS reused torrent's own title, not None -
@@ -721,7 +730,12 @@ class TorrentProcessor:
         from database import get_media_item_by_id as _gmi_con
         from utilities.local_library_scan import check_local_file_for_item as _clffi_con
 
-        new_debrid_folder_name = torrent_info.get('debrid_folder_name') or torrent_info.get('title')
+        new_debrid_folder_name = (
+            torrent_info.get('debrid_folder_name')
+            or torrent_info.get('filename')
+            or torrent_info.get('original_filename')
+            or torrent_info.get('title')
+        )
         old_torrent_ids_touched = set()
 
         for sib in siblings:

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -561,6 +561,18 @@ class TorrentProcessor:
                         _mem_is_pack = bool(_mem_check_title) and not _re_mem.search(r'[Ss]\d{2}[Ee]\d{2}', _mem_check_title)
                         _mem_job = _mem_item.get('filled_by_torrent_id')
                         _mem_id = _mem_job[4:] if _mem_job and _mem_job.startswith('nzb:') else _mem_job
+                        if _mem_is_pack:
+                            # Verify the shared pack job is still actually queryable on the
+                            # provider before reusing it - a job that completed and was since
+                            # cleaned up (or never existed) will ghost every retry forever if
+                            # reused blindly, since nothing else ever re-checks it afterward.
+                            try:
+                                from usenet.climount_client import is_nzb_job_alive as _is_job_alive
+                                if not _is_job_alive(_mem_id):
+                                    logging.warning(f'[{item_identifier}] [Memory] Sibling job {_mem_job} no longer alive on provider - not reusing')
+                                    continue
+                            except Exception:
+                                pass  # unknown due to error - don't block a legitimate reuse
                         if _is_pack and _mem_is_pack:
                             logging.info(f'[{item_identifier}] [Memory] Season pack already submitted for S{_season:02d} '
                                          f'(job={_mem_job}) — reusing')
@@ -604,6 +616,19 @@ class TorrentProcessor:
                         # Empty title is not evidence of a pack - see matching comment in the
                         # in-memory check above. Defaulting True here risks the same wrong-job-reuse.
                         _sibling_is_pack = bool(_sibling_check_title) and not _re_dedup.search(r'[Ss]\d{2}[Ee]\d{2}', _sibling_check_title)
+                        if _sibling_is_pack:
+                            # Verify the shared pack job is still actually queryable on the
+                            # provider before reusing it - a job that completed and was since
+                            # cleaned up (or never existed) will ghost every retry forever if
+                            # reused blindly, since nothing else ever re-checks it afterward.
+                            try:
+                                from usenet.climount_client import is_nzb_job_alive as _is_job_alive
+                                _sib_job_hash = _sibling[0][4:] if _sibling[0].startswith('nzb:') else _sibling[0]
+                                if not _is_job_alive(_sib_job_hash):
+                                    logging.warning(f'[{item_identifier}] Sibling job {_sibling[0]} no longer alive on provider - not reusing, submitting fresh')
+                                    _sibling_is_pack = False
+                            except Exception:
+                                pass  # unknown due to error - don't block a legitimate reuse
                         if _is_pack and _sibling_is_pack:
                             # New result is a pack, existing job is a pack — reuse existing
                             _existing_job = _sibling[0]

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -616,13 +616,26 @@ class TorrentProcessor:
             from database import get_db_connection as _gdb
             _conn = _gdb()
             try:
+                # Dedup by filled_by_torrent_id via a MIN(id)-per-group subquery, not a bare
+                # GROUP BY on the outer SELECT - SQLite does not guarantee that non-aggregated
+                # ("bare") columns in a GROUP BY come from the same physical row as the grouped
+                # column, so filled_by_file/original_scraped_torrent_title/filled_by_magnet could
+                # end up mismatched against a *different* row's torrent_id than the one actually
+                # being reused. Confirmed live: this silently wrote a completely different
+                # release's title onto the correct, already-working torrent_id, breaking the
+                # downstream folder-name guess in check_local_file_for_item for every episode
+                # that inherited the wrong title.
                 _siblings = _conn.execute(
                     "SELECT filled_by_torrent_id, filled_by_file, original_scraped_torrent_title, filled_by_magnet "
                     "FROM media_items "
-                    "WHERE imdb_id=? AND season_number=? AND type='episode' "
-                    "AND id!=? AND filled_by_torrent_id IS NOT NULL AND filled_by_torrent_id NOT LIKE 'nzb:%' "
-                    "AND REPLACE(COALESCE(version,''),'*','')=? "
-                    "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 5",
+                    "WHERE id IN ("
+                    "  SELECT MIN(id) FROM media_items "
+                    "  WHERE imdb_id=? AND season_number=? AND type='episode' "
+                    "  AND id!=? AND filled_by_torrent_id IS NOT NULL AND filled_by_torrent_id NOT LIKE 'nzb:%' "
+                    "  AND REPLACE(COALESCE(version,''),'*','')=? "
+                    "  AND state IN ('Adding','Checking','Collected','Upgrading') "
+                    "  GROUP BY filled_by_torrent_id"
+                    ") LIMIT 5",
                     (_imdb, _season, item.get('id', -1), _item_version)
                 ).fetchall()
             finally:
@@ -631,13 +644,139 @@ class TorrentProcessor:
             logging.debug(f"Sibling debrid-pack DB check failed: {e}")
             return None
 
+        # Evaluate all distinct candidates rather than stopping at the first that contains the
+        # target episode - prefer the most complete pack (most files) when more than one
+        # legitimately covers this episode, so a still-pending episode lands on the bigger of two
+        # known sibling packs instead of whichever was found first.
+        best, best_file_count = None, -1
         for _sib in _siblings:
             _sib_check_title = _sib[2] or _sib[1] or ''
             reused = _try_reuse(_sib[0], _sib_check_title, _sib[3])
             if reused:
-                return reused
+                file_count = len(reused[0].get('files', []))
+                if file_count > best_file_count:
+                    best, best_file_count = reused, file_count
 
-        return None
+        return best
+
+    def _consolidate_covered_siblings(self, item: Optional[Dict], torrent_info: Dict) -> None:
+        """If the torrent just finalized for `item` also fully covers other episodes that are
+        already Collected on a smaller/different torrent (e.g. a wide pack scraped after those
+        episodes already landed on single-episode releases), repoint those episodes' symlinks
+        onto this torrent live, in this same tick, and remove the old torrent once nothing else
+        references it.
+
+        Deliberately reuses check_local_file_for_item for the actual file-resolution + symlink
+        swap (it already does source_file resolution and create_symlink's own safe "existing
+        symlink pointing elsewhere -> unlink and recreate" handling, unconditionally, regardless
+        of upgrade status) rather than any new path logic. `upgrading_from` is deliberately left
+        unset on the synthetic item so check_local_file_for_item's upgrade-cleanup block (which
+        removes the old torrent unconditionally, no sibling-owner check) never runs - old-torrent
+        removal here is instead done explicitly, once, after every covered sibling is swapped.
+        """
+        if not item or item.get('type') != 'episode':
+            return
+        if get_setting('File Management', 'file_collection_management') != 'Symlinked/Local':
+            return
+        _imdb = item.get('imdb_id')
+        _season = item.get('season_number')
+        _new_torrent_id = torrent_info.get('id')
+        if not _imdb or _season is None or not _new_torrent_id:
+            return
+        _item_version = (item.get('version') or '').rstrip('*')
+        _files = torrent_info.get('files', [])
+        if not _files:
+            return
+
+        import re as _re_con
+
+        def _filename_for_episode(episode_number: int) -> Optional[str]:
+            pattern = _re_con.compile(rf'[Ss]{_season:02d}[Ee]{episode_number:02d}(?!\d)')
+            for f in _files:
+                path = f.get('path') or f.get('filename') or ''
+                if pattern.search(path):
+                    return os.path.basename(path)
+            return None
+
+        try:
+            from database import get_db_connection as _gdb_con
+            conn = _gdb_con()
+            try:
+                siblings = conn.execute(
+                    "SELECT id, episode_number, filled_by_torrent_id FROM media_items "
+                    "WHERE imdb_id=? AND season_number=? AND type='episode' "
+                    "AND id!=? AND state='Collected' AND filled_by_torrent_id IS NOT NULL "
+                    "AND filled_by_torrent_id NOT LIKE 'nzb:%' AND filled_by_torrent_id!=? "
+                    "AND REPLACE(COALESCE(version,''),'*','')=?",
+                    (_imdb, _season, item.get('id', -1), _new_torrent_id, _item_version)
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception as e:
+            logging.debug(f"Sibling consolidation DB lookup failed: {e}")
+            return
+        if not siblings:
+            return
+
+        from database import get_media_item_by_id as _gmi_con
+        from utilities.local_library_scan import check_local_file_for_item as _clffi_con
+
+        new_debrid_folder_name = torrent_info.get('debrid_folder_name') or torrent_info.get('title')
+        old_torrent_ids_touched = set()
+
+        for sib in siblings:
+            sib_filename = _filename_for_episode(sib['episode_number'])
+            if not sib_filename:
+                continue
+            sib_item = _gmi_con(sib['id'])
+            if not sib_item or sib_item.get('state') != 'Collected':
+                continue  # re-check live state; skip if it moved (e.g. into Upgrading) since the query ran
+            old_torrent_id = sib_item.get('filled_by_torrent_id')
+            synthetic_item = dict(sib_item)
+            synthetic_item['filled_by_torrent_id'] = _new_torrent_id
+            synthetic_item['filled_by_file'] = sib_filename
+            synthetic_item['filled_by_magnet'] = torrent_info.get('magnet') or synthetic_item.get('filled_by_magnet')
+            synthetic_item['original_scraped_torrent_title'] = new_debrid_folder_name
+            synthetic_item['debrid_folder_name'] = new_debrid_folder_name
+            synthetic_item.pop('upgrading_from', None)
+            synthetic_item.pop('upgrading_from_torrent_id', None)
+            try:
+                swapped = _clffi_con(synthetic_item, skip_multifile_scan=True)
+            except Exception as e:
+                logging.warning(f"Consolidation swap failed for sibling {sib['id']} (S{_season:02d}E{sib['episode_number']:02d}): {e}")
+                continue
+            if swapped:
+                logging.info(f"[{item.get('title', 'Unknown')}] Consolidated S{_season:02d}E{sib['episode_number']:02d} "
+                             f"onto torrent {_new_torrent_id} (was {old_torrent_id})")
+                if old_torrent_id:
+                    old_torrent_ids_touched.add(old_torrent_id)
+            else:
+                logging.debug(f"Consolidation swap did not confirm success for sibling {sib['id']}; leaving as-is")
+
+        for old_torrent_id in old_torrent_ids_touched:
+            try:
+                from database import get_db_connection as _gdb_con2
+                conn2 = _gdb_con2()
+                try:
+                    still_used = conn2.execute(
+                        "SELECT 1 FROM media_items WHERE filled_by_torrent_id=? "
+                        "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 1",
+                        (old_torrent_id,)
+                    ).fetchone()
+                finally:
+                    conn2.close()
+                if still_used:
+                    logging.debug(f"Old torrent {old_torrent_id} still referenced after consolidation — not removing")
+                    continue
+                for provider in self._providers:
+                    try:
+                        provider.remove_torrent(old_torrent_id, removal_reason="Consolidated onto a wider sibling pack")
+                        logging.info(f"Removed consolidated-away torrent {old_torrent_id} (superseded by {_new_torrent_id})")
+                        break
+                    except Exception as e:
+                        logging.debug(f"[{provider.PROVIDER_NAME}] remove_torrent failed for {old_torrent_id}: {e}")
+            except Exception as e:
+                logging.warning(f"Error removing consolidated-away torrent {old_torrent_id}: {e}")
 
     def _process_nzb_result(self, result: Dict, item: Optional[Dict] = None, adding_queue_items: Optional[list] = None) -> Optional[Tuple]:
         """Submit an NZB result to cli_mount and return a synthetic torrent_info tuple."""
@@ -1070,14 +1209,34 @@ class TorrentProcessor:
         item: Optional[Dict] = None,
         adding_queue_items: Optional[list] = None,
     ) -> Tuple[Optional[Dict], Optional[str], Optional[Dict]]:
+        """Thin wrapper around _process_results_inner that also consolidates any already-Collected
+        siblings the finalized torrent happens to cover onto it, live, in the same tick - see
+        _consolidate_covered_siblings for details."""
+        torrent_info, magnet, chosen_result = self._process_results_inner(
+            results, accept_uncached=accept_uncached, item=item, adding_queue_items=adding_queue_items,
+        )
+        if torrent_info:
+            try:
+                self._consolidate_covered_siblings(item, torrent_info)
+            except Exception as e:
+                logging.warning(f"Sibling pack consolidation failed (non-fatal): {e}", exc_info=True)
+        return torrent_info, magnet, chosen_result
+
+    def _process_results_inner(
+        self,
+        results: list[Dict],
+        accept_uncached: bool = False,
+        item: Optional[Dict] = None,
+        adding_queue_items: Optional[list] = None,
+    ) -> Tuple[Optional[Dict], Optional[str], Optional[Dict]]:
         """
         Process a list of results to find the best match
-        
+
         Args:
             results: List of results to process
             accept_uncached: Whether to accept uncached results
             item: Optional media item for tracking successful results
-            
+
         Returns:
             Tuple of (torrent_info, magnet_link, chosen_result) if successful, (None, None, None) otherwise
         """

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -553,7 +553,12 @@ class TorrentProcessor:
                         # releases and was wrongly read as "not a normal episode filename,
                         # must be an unresolved pack".
                         _mem_check_title = _mem_item.get('original_scraped_torrent_title') or _mem_item.get('filled_by_file') or ''
-                        _mem_is_pack = not _re_mem.search(r'[Ss]\d{2}[Ee]\d{2}', _mem_check_title)
+                        # An empty title here usually means this sibling's own submission
+                        # (earlier this same tick) hasn't been reflected back into this
+                        # in-memory snapshot yet - not evidence it's a pack. Defaulting to
+                        # "is a pack" in that case caused a different episode's individual
+                        # NZB job to be reused here, symlinking the wrong file to this item.
+                        _mem_is_pack = bool(_mem_check_title) and not _re_mem.search(r'[Ss]\d{2}[Ee]\d{2}', _mem_check_title)
                         _mem_job = _mem_item.get('filled_by_torrent_id')
                         _mem_id = _mem_job[4:] if _mem_job and _mem_job.startswith('nzb:') else _mem_job
                         if _is_pack and _mem_is_pack:
@@ -596,7 +601,9 @@ class TorrentProcessor:
                         # single-episode usenet releases and was wrongly read as "not a normal
                         # episode filename, must be an unresolved pack".
                         _sibling_check_title = _sibling[2] or _sibling[1] or ''
-                        _sibling_is_pack = not _re_dedup.search(r'[Ss]\d{2}[Ee]\d{2}', _sibling_check_title)
+                        # Empty title is not evidence of a pack - see matching comment in the
+                        # in-memory check above. Defaulting True here risks the same wrong-job-reuse.
+                        _sibling_is_pack = bool(_sibling_check_title) and not _re_dedup.search(r'[Ss]\d{2}[Ee]\d{2}', _sibling_check_title)
                         if _is_pack and _sibling_is_pack:
                             # New result is a pack, existing job is a pack — reuse existing
                             _existing_job = _sibling[0]

--- a/routes/content_requestor_routes.py
+++ b/routes/content_requestor_routes.py
@@ -259,7 +259,14 @@ def request_content():
             track_action('library_add_manual', detail=_detail, user_id=_uid)
         except Exception:
             pass
-        return jsonify({'success': True, 'item': wanted_item})
+        if items_added == 0:
+            return jsonify({
+                'success': True,
+                'item': wanted_item,
+                'items_added': 0,
+                'message': f"Already have {data.get('title', 'this title')} in the requested version(s)"
+            })
+        return jsonify({'success': True, 'item': wanted_item, 'items_added': items_added})
         
     except Exception as e:
         logging.error(f"Error processing content request: {str(e)}")

--- a/routes/debrid_manager_routes.py
+++ b/routes/debrid_manager_routes.py
@@ -3610,7 +3610,23 @@ def api_symlink_audit_delete():
 
     symlink_dir = get_setting('File Management', 'symlinked_files_path', '/mnt/symlinked')
     rclone_dir  = get_setting('File Management', 'original_files_path',  '/mnt/zurg/__all__')
-    deleted, failed, errors = 0, 0, []
+    deleted, failed, errors, skipped = 0, 0, [], 0
+
+    # Re-verify against the CURRENT filesystem state right before deleting -
+    # the caller's path list came from a cached scan that may be stale (a new
+    # symlink may have been created pointing at one of these paths since the
+    # scan ran, e.g. by normal ongoing collection activity). Trusting the
+    # cache blindly can delete a file a real, currently-active symlink now
+    # depends on.
+    current_linked_targets = set()
+    for root, dirs, files in os.walk(symlink_dir, followlinks=False):
+        for name in files:
+            full = os.path.join(root, name)
+            if os.path.islink(full):
+                raw = os.readlink(full)
+                target = raw if os.path.isabs(raw) else os.path.normpath(
+                    os.path.join(os.path.dirname(full), raw))
+                current_linked_targets.add(target)
 
     for p in paths:
         if not isinstance(p, str):
@@ -3619,6 +3635,9 @@ def api_symlink_audit_delete():
         if not (p.startswith(symlink_dir) or p.startswith(rclone_dir)):
             errors.append(f'Refused: {p}')
             failed += 1
+            continue
+        if p in current_linked_targets:
+            skipped += 1
             continue
         try:
             os.remove(p)
@@ -3639,7 +3658,7 @@ def api_symlink_audit_delete():
         except Exception:
             pass
 
-    return jsonify({'success': True, 'deleted': deleted, 'failed': failed, 'errors': errors[:20]})
+    return jsonify({'success': True, 'deleted': deleted, 'failed': failed, 'skipped': skipped, 'errors': errors[:20]})
 
 
 # ---------------------------------------------------------------------------

--- a/routes/debug_routes.py
+++ b/routes/debug_routes.py
@@ -5119,11 +5119,14 @@ def scan_duplicate_symlinks():
 @debug_bp.route('/api/rescrape_duplicate_symlinks', methods=['POST'])
 @admin_required
 def rescrape_duplicate_symlinks():
-    """Move the given item IDs back to Wanted so they get rescraped fresh -
-    same cleanup /statistics/move_to_wanted already does for a single item.
-    Doesn't touch the symlink file or the debrid/usenet source - the new
-    symlink created by the fresh scrape overwrites the stale one at the same
-    destination path once it lands."""
+    """Fully delete the given items (media server entry, symlink, source file/
+    debrid-or-usenet download, cache) the same way deleting an episode from the
+    library does, then move them back to Wanted so they get rescraped fresh.
+    Deletion runs as one batch via DeletionManager.delete_multiple_items, whose
+    sibling guard already excludes other items in the same batch when deciding
+    whether a shared season-pack torrent/NZB is still needed elsewhere - so
+    rescraping an entire duplicate-target group in one go won't have the items
+    block each other's cleanup."""
     from database import get_db_connection
 
     try:
@@ -5131,6 +5134,26 @@ def rescrape_duplicate_symlinks():
         item_ids = data.get('item_ids') or []
         if not item_ids:
             return jsonify({'success': False, 'error': 'No item_ids provided'}), 400
+
+        debrid_provider = get_debrid_provider()
+        deletion_manager = DeletionManager(debrid_provider=debrid_provider)
+        result = deletion_manager.delete_multiple_items(
+            item_ids=item_ids,
+            blacklist=False,
+            blacklist_sources=False,
+            delete_from_media_server=True,
+            delete_files=True,
+            delete_from_debrid=True,
+            delete_symlinks=True,
+            clear_cache=True,
+            remove_from_content_source=False,
+            skip_database=True  # We reset state to Wanted ourselves below instead of deleting the row
+        )
+
+        if not result.get('success'):
+            errors_list = result.get('errors', ['Deletion failed'])
+            logging.error(f"Error deleting duplicate-symlink items before rescrape: {errors_list}")
+            return jsonify({'success': False, 'error': errors_list[0] if errors_list else 'Deletion failed', 'errors': errors_list}), 500
 
         conn = get_db_connection()
         cursor = conn.cursor()

--- a/routes/debug_routes.py
+++ b/routes/debug_routes.py
@@ -5042,6 +5042,120 @@ def run_bulk_subtitle_scan():
     task_id = task_queue.add_task(async_run_bulk_subs)
     return jsonify({'task_id': task_id}), 202
 
+@debug_bp.route('/api/scan_duplicate_symlinks', methods=['POST'])
+@admin_required
+def scan_duplicate_symlinks():
+    """Read-only scan: find TV episode symlinks that point at the same underlying
+    file. Usually means a season pack was mismatched during collection and
+    multiple "different" episodes actually got symlinked to the same single
+    file instead of their own - so playing S01E04 actually plays S01E01, etc.
+    Makes no changes; rescraping affected items is a separate explicit action."""
+    import os
+    from collections import defaultdict
+    from database import get_db_connection
+
+    try:
+        symlink_root = get_setting('File Management', 'symlinked_files_path', '')
+        tv_root = os.path.join(symlink_root, 'TV Shows') if symlink_root else ''
+        if not symlink_root or not os.path.isdir(tv_root):
+            return jsonify({'success': False, 'error': f'TV Shows symlink folder not found (checked: {tv_root or "no symlinked_files_path configured"})'}), 400
+
+        by_target = defaultdict(list)
+        scanned = 0
+        for dirpath, dirnames, filenames in os.walk(tv_root):
+            for name in filenames:
+                full = os.path.join(dirpath, name)
+                if not os.path.islink(full):
+                    continue
+                scanned += 1
+                try:
+                    target = os.readlink(full)
+                except OSError:
+                    continue
+                by_target[target].append(full)
+
+        dupe_groups = {t: paths for t, paths in by_target.items() if len(paths) > 1}
+
+        conn = get_db_connection()
+        groups_out = []
+        for target, paths in dupe_groups.items():
+            items = []
+            for p in paths:
+                row = conn.execute(
+                    "SELECT id, title, year, season_number, episode_number FROM media_items WHERE location_on_disk = ?",
+                    (p,)
+                ).fetchone()
+                items.append({
+                    'path': p,
+                    'item_id': row['id'] if row else None,
+                    'title': row['title'] if row else None,
+                    'year': row['year'] if row else None,
+                    'season_number': row['season_number'] if row else None,
+                    'episode_number': row['episode_number'] if row else None,
+                })
+            groups_out.append({'target': target, 'items': items})
+        conn.close()
+
+        groups_out.sort(key=lambda g: -len(g['items']))
+
+        return jsonify({
+            'success': True,
+            'scanned': scanned,
+            'group_count': len(groups_out),
+            'affected_count': sum(len(g['items']) for g in groups_out),
+            'groups': groups_out,
+        })
+    except Exception as e:
+        logging.error(f"Error scanning for duplicate symlink targets: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@debug_bp.route('/api/rescrape_duplicate_symlinks', methods=['POST'])
+@admin_required
+def rescrape_duplicate_symlinks():
+    """Move the given item IDs back to Wanted so they get rescraped fresh -
+    same cleanup /statistics/move_to_wanted already does for a single item."""
+    from database import get_db_connection
+
+    try:
+        data = request.get_json(silent=True) or {}
+        item_ids = data.get('item_ids') or []
+        if not item_ids:
+            return jsonify({'success': False, 'error': 'No item_ids provided'}), 400
+
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        now = datetime.now()
+        moved = 0
+        for item_id in item_ids:
+            cursor.execute('''
+                UPDATE media_items
+                SET state = 'Wanted',
+                    filled_by_file = NULL,
+                    filled_by_title = NULL,
+                    filled_by_magnet = NULL,
+                    filled_by_torrent_id = NULL,
+                    collected_at = NULL,
+                    last_updated = ?,
+                    disable_not_wanted_check = TRUE,
+                    location_on_disk = NULL,
+                    original_path_for_symlink = NULL,
+                    original_scraped_torrent_title = NULL,
+                    upgrading_from = NULL,
+                    version = TRIM(version, '*'),
+                    upgrading = NULL
+                WHERE id = ?
+                AND state NOT IN ('Wanted', 'Scraping', 'Adding')
+            ''', (now, item_id))
+            moved += cursor.rowcount
+        conn.commit()
+        conn.close()
+        return jsonify({'success': True, 'moved': moved})
+    except Exception as e:
+        logging.error(f"Error rescraping duplicate-symlink items: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
 @debug_bp.route('/api/fix_zurg_symlinks', methods=['POST'])
 @admin_required
 def fix_zurg_symlinks():

--- a/routes/debug_routes.py
+++ b/routes/debug_routes.py
@@ -5056,23 +5056,32 @@ def scan_duplicate_symlinks():
 
     try:
         symlink_root = get_setting('File Management', 'symlinked_files_path', '')
-        tv_root = os.path.join(symlink_root, 'TV Shows') if symlink_root else ''
-        if not symlink_root or not os.path.isdir(tv_root):
-            return jsonify({'success': False, 'error': f'TV Shows symlink folder not found (checked: {tv_root or "no symlinked_files_path configured"})'}), 400
+        if not symlink_root:
+            return jsonify({'success': False, 'error': 'no symlinked_files_path configured'}), 400
+
+        tv_folder_names = [get_setting('Debug', 'tv_shows_folder_name', 'TV Shows')]
+        if get_setting('Debug', 'enable_separate_anime_folders', False):
+            tv_folder_names.append(get_setting('Debug', 'anime_tv_shows_folder_name', 'Anime TV Shows'))
+
+        tv_roots = [os.path.join(symlink_root, name) for name in tv_folder_names]
+        existing_roots = [r for r in tv_roots if os.path.isdir(r)]
+        if not existing_roots:
+            return jsonify({'success': False, 'error': f'No TV symlink folders found (checked: {", ".join(tv_roots)})'}), 400
 
         by_target = defaultdict(list)
         scanned = 0
-        for dirpath, dirnames, filenames in os.walk(tv_root):
-            for name in filenames:
-                full = os.path.join(dirpath, name)
-                if not os.path.islink(full):
-                    continue
-                scanned += 1
-                try:
-                    target = os.readlink(full)
-                except OSError:
-                    continue
-                by_target[target].append(full)
+        for tv_root in existing_roots:
+            for dirpath, dirnames, filenames in os.walk(tv_root):
+                for name in filenames:
+                    full = os.path.join(dirpath, name)
+                    if not os.path.islink(full):
+                        continue
+                    scanned += 1
+                    try:
+                        target = os.readlink(full)
+                    except OSError:
+                        continue
+                    by_target[target].append(full)
 
         dupe_groups = {t: paths for t, paths in by_target.items() if len(paths) > 1}
 

--- a/routes/debug_routes.py
+++ b/routes/debug_routes.py
@@ -5085,15 +5085,21 @@ def scan_duplicate_symlinks():
                     "SELECT id, title, year, season_number, episode_number FROM media_items WHERE location_on_disk = ?",
                     (p,)
                 ).fetchone()
+                # Only items matched to a real database row are actionable from
+                # this UI (nothing to safely rescrape otherwise) - drop the rest
+                # rather than showing an inert "not matched" row.
+                if not row:
+                    continue
                 items.append({
                     'path': p,
-                    'item_id': row['id'] if row else None,
-                    'title': row['title'] if row else None,
-                    'year': row['year'] if row else None,
-                    'season_number': row['season_number'] if row else None,
-                    'episode_number': row['episode_number'] if row else None,
+                    'item_id': row['id'],
+                    'title': row['title'],
+                    'year': row['year'],
+                    'season_number': row['season_number'],
+                    'episode_number': row['episode_number'],
                 })
-            groups_out.append({'target': target, 'items': items})
+            if len(items) > 1:
+                groups_out.append({'target': target, 'items': items})
         conn.close()
 
         groups_out.sort(key=lambda g: -len(g['items']))
@@ -5114,7 +5120,10 @@ def scan_duplicate_symlinks():
 @admin_required
 def rescrape_duplicate_symlinks():
     """Move the given item IDs back to Wanted so they get rescraped fresh -
-    same cleanup /statistics/move_to_wanted already does for a single item."""
+    same cleanup /statistics/move_to_wanted already does for a single item.
+    Doesn't touch the symlink file or the debrid/usenet source - the new
+    symlink created by the fresh scrape overwrites the stale one at the same
+    destination path once it lands."""
     from database import get_db_connection
 
     try:

--- a/routes/debug_routes.py
+++ b/routes/debug_routes.py
@@ -5108,7 +5108,28 @@ def scan_duplicate_symlinks():
                     'episode_number': row['episode_number'],
                 })
             if len(items) > 1:
-                groups_out.append({'target': target, 'items': items})
+                # Distinguish a genuine mismatch (different episodes wrongly sharing a file)
+                # from a legitimate combined multi-episode release file (e.g. a premiere
+                # packaged as one S01E01E02.mkv covering both episodes) - same episode/season
+                # numbers on both sides is the signal either way, but only the latter is
+                # expected/harmless. Reuse the same title parser the scraper already uses for
+                # ranking (parse_with_ptt) rather than writing new episode-detection logic.
+                is_multi_episode_release = False
+                try:
+                    from scraper.functions.ptt_parser import parse_with_ptt
+                    target_basename = os.path.basename(target)
+                    parsed = parse_with_ptt(target_basename)
+                    parsed_episodes = set(parsed.get('episodes') or [])
+                    group_episodes = {i['episode_number'] for i in items if i.get('episode_number') is not None}
+                    if group_episodes and parsed_episodes == group_episodes:
+                        is_multi_episode_release = True  # "possible" - PTT parsing isn't infallible, still shown for review either way
+                except Exception as e:
+                    logging.debug(f"Multi-episode release detection failed for {target}: {e}")
+                groups_out.append({
+                    'target': target,
+                    'items': items,
+                    'is_multi_episode_release': is_multi_episode_release,
+                })
         conn.close()
 
         groups_out.sort(key=lambda g: -len(g['items']))

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1214,35 +1214,31 @@ def scrape(imdb_id: str, tmdb_id: str, title: str, year: int, content_type: str,
                     aliases = metadata.get('aliases', {})
                     romanized_found = False
                     
-                    # Look for romanized titles in aliases (prioritize Japanese romanization patterns)
+                    # Look for a romanized title specifically among Japan-sourced aliases.
+                    # Previously this scanned every country's aliases and guessed "is this
+                    # Japanese?" from short substring patterns (e.g. 'ta', 'na', 'ri') — far
+                    # too permissive to be reliable, since those substrings show up
+                    # constantly in other languages too. Confirmed live: "Angriff auf Titan"
+                    # (German for "Attack on Titan") matched the pattern for 'ri' (in
+                    # "Angriff") and 'ta' (in "Titan") and got misfiled as a "Japanese
+                    # romanized alias," triggering a second, pointless scrape. The alias
+                    # dict is already keyed by the country/language it actually came from —
+                    # use that directly instead of guessing from the text.
                     for country_code, alias_list in aliases.items():
+                        if country_code.lower() != 'jp':
+                            continue
                         if isinstance(alias_list, list):
                             for alias in alias_list:
-                                # Check if this alias looks like a romanized Japanese title
+                                # Only the Latin-script form of a Japan-sourced alias is a
+                                # useful search query — the native kanji/kana form isn't.
                                 if alias and re.match(r'^[a-zA-Z\s\-]+$', alias) and alias.lower() not in tried_titles_lower:
                                     # Skip if it's just the English title again
                                     if alias.lower() != title.lower():
-                                        # Check for Japanese romanization patterns (common Japanese words/patterns)
-                                        japanese_patterns = [
-                                            r'\bno\b',  # "no" particle is very common in Japanese titles
-                                            r'(yama|kawa|saki|mura|hara|da|ta|ka|na|ma|sa|ra|wa|ga|zu|ji|chi|shi|ki|mi|ni|hi|ri|ai|ei|ou|uu)',  # Common Japanese syllable patterns
-                                            r'\w+(?:gami|kami|sama|chan|kun|san)\b',  # Japanese honorifics
-                                            r'\w+(?:ya|ko|ro|to|go|bo|po|zo|do|ba|pa)\b'  # Common Japanese ending patterns
-                                        ]
-                                        
-                                        # Check if it matches Japanese romanization patterns
-                                        is_likely_japanese = any(re.search(pattern, alias.lower()) for pattern in japanese_patterns)
-                                        
-                                        # Also check if it's NOT common English words
-                                        common_english_words = ['drugstore', 'soliloquy', 'pharmacy', 'apothecary', 'diary', 'diaries', 'story', 'tale', 'chronicles']
-                                        has_english_words = any(word in alias.lower() for word in common_english_words)
-                                        
-                                        if is_likely_japanese and not has_english_words:
-                                            logging.info(f"Adding Japanese romanized alias for anime: {alias}")
-                                            titles_to_try.append(('romanized_alias', alias))
-                                            tried_titles_lower.add(alias.lower())
-                                            romanized_found = True
-                                            break
+                                        logging.info(f"Adding Japanese romanized alias for anime: {alias}")
+                                        titles_to_try.append(('romanized_alias', alias))
+                                        tried_titles_lower.add(alias.lower())
+                                        romanized_found = True
+                                        break
                         if romanized_found:
                             break
                     

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1299,11 +1299,9 @@ def scrape(imdb_id: str, tmdb_id: str, title: str, year: int, content_type: str,
                     titles_to_try.append(('country_alias', alias))
                     tried_titles_lower.add(alias.lower())
 
-        # Execute scraping based on the determined titles with threading and deduplication protection
+        # Execute scraping based on the determined titles with threading
         logging.info(f"Will search with {len(titles_to_try)} titles: {[source for source, _ in titles_to_try]}")
-        
-        # Track already scraped episode formats to avoid duplicates
-        scraped_episode_formats = set()
+
         all_results_lock = threading.Lock()
         
         # Aggregate per-segment timings across all title searches
@@ -1311,19 +1309,11 @@ def scrape(imdb_id: str, tmdb_id: str, title: str, year: int, content_type: str,
         timing_reports_count = 0
         
         def scrape_single_title(args):
-            """Helper function to scrape a single title with deduplication protection"""
+            """Helper function to scrape a single title. titles_to_try is already
+            deduplicated by tried_titles_lower at build time, so every call here
+            is for a genuinely distinct title — no further dedup needed."""
             source, search_title = args
-            
-            # For anime, check if we've already scraped this episode format
-            if is_anime and episode_formats:
-                # Create a key based on the episode formats to avoid duplicate scraping
-                format_key = tuple(sorted(episode_formats.values()))
-                with all_results_lock:
-                    if format_key in scraped_episode_formats:
-                        logging.info(f"Skipping duplicate episode format scrape for {source}: {search_title}")
-                        return [], [], {}
-                    scraped_episode_formats.add(format_key)
-            
+
             logging.info(f"Scraping with {source}: {search_title}")
             logging.debug(f"[scrape_main] Calling _do_scrape for '{search_title}' (source: {source}).")
 

--- a/static/js/discover.js
+++ b/static/js/discover.js
@@ -9562,7 +9562,7 @@ async function requestContent(content, selectedVersions, selectedFolder = null, 
         hideLoadingMessage();
 
         if (result.success) {
-            showPopup({ type: 'success', title: 'Success', message: `Successfully requested ${content.title}` });
+            showPopup({ type: 'success', title: 'Success', message: result.message || `Successfully requested ${content.title}` });
         } else {
             showPopup({ type: 'error', title: 'Error', message: result.error || 'Failed to request content' });
         }

--- a/static/js/discover_details.js
+++ b/static/js/discover_details.js
@@ -1156,7 +1156,7 @@ if (selTags) payload.selected_tags = selTags;
             window.showPopup({
                 type: window.POPUP_TYPES.SUCCESS,
                 title: 'Success',
-                message: `Successfully requested ${contentData.title}`,
+                message: result.message || `Successfully requested ${contentData.title}`,
                 autoClose: 3000
             });
         } else {
@@ -1202,7 +1202,7 @@ async function requestContentDirectly(data) {
             window.showPopup({
                 type: window.POPUP_TYPES.SUCCESS,
                 title: 'Success',
-                message: `Successfully requested ${data.title}`,
+                message: result.message || `Successfully requested ${data.title}`,
                 autoClose: 3000
             });
         } else {

--- a/static/js/library_movie.js
+++ b/static/js/library_movie.js
@@ -1274,7 +1274,7 @@ async function submitRequest(selectedVersions) {
         const data = await response.json();
 
         if (data.success || response.ok) {
-            showPopup({ message: `Successfully requested: ${movieData.title}`, type: POPUP_TYPES.SUCCESS });
+            showPopup({ message: data.message || `Successfully requested: ${movieData.title}`, type: POPUP_TYPES.SUCCESS });
         } else {
             throw new Error(data.error || 'Request failed');
         }

--- a/templates/debrid_manager.html
+++ b/templates/debrid_manager.html
@@ -7364,7 +7364,7 @@ async function _slDeleteAll(kind) {
                 });
                 const d = await r.json();
                 if (d.success) {
-                    showPopup({ type: 'success', title: 'Success', message: `Deleted ${d.deleted}${d.failed ? `, failed ${d.failed}` : ''}`, autoClose: 4000 });
+                    showPopup({ type: 'success', title: 'Success', message: `Deleted ${d.deleted}${d.skipped ? `, skipped ${d.skipped} (now in use)` : ''}${d.failed ? `, failed ${d.failed}` : ''}`, autoClose: 4000 });
                     // Re-scan to refresh
                     await _slStartScan();
                 } else {

--- a/templates/debug_functions.html
+++ b/templates/debug_functions.html
@@ -3591,6 +3591,9 @@ if (document.readyState === 'loading') {
             html += `<button type="button" id="rescrape-all-dupe-groups-btn" style="margin-bottom:10px;">Rescrape All (${data.affected_count})</button>`;
             data.groups.forEach((group, gIdx) => {
                 html += `<div class="dupe-group" style="margin-bottom:16px;border:1px solid #444;padding:10px;border-radius:6px;">`;
+                if (group.is_multi_episode_release) {
+                    html += `<div style="display:inline-block;background:#2d5f3f;color:#9fe6b8;font-size:0.75em;padding:2px 8px;border-radius:10px;margin-bottom:6px;">Possible multi-episode release &mdash; filename appears to cover all episodes below</div>`;
+                }
                 html += `<div class="path-cell" style="word-break:break-all;color:#aaa;font-size:0.85em;margin-bottom:6px;">Target: ${group.target}</div>`;
                 html += `<button type="button" class="rescrape-dupe-group-btn" data-group="${gIdx}" style="margin-bottom:8px;">Rescrape This Group (${group.items.length})</button>`;
                 html += `<table class="preview-results-table"><thead><tr><th>Show</th><th>Season/Episode</th><th>Path</th></tr></thead><tbody>`;

--- a/templates/debug_functions.html
+++ b/templates/debug_functions.html
@@ -1273,7 +1273,7 @@ body:not(.tangerine-theme) #tngDebug { display: none !important; }
         </div>
         <div class="debug_item">
             <h3>Duplicate Symlink Targets</h3>
-            <p class="description">Scans TV Shows symlinks for episodes pointing at the same underlying file - usually means a season pack was mismatched and multiple "different" episodes are actually playing identical content. Read-only scan; nothing changes until you choose to rescrape.</p>
+            <p class="description">Scans TV Shows symlinks for episodes pointing at the same underlying file - usually means a season pack was mismatched and multiple "different" episodes are actually playing identical content. Read-only scan; rescraping fully deletes the affected episode(s) - symlink, source file/debrid download, media server entry - before moving them back to Wanted.</p>
             <button type="button" id="scan-duplicate-symlinks-btn">Scan for Duplicates</button>
             <div id="duplicate-symlinks-results" class="results-area" style="margin-top: 15px;"></div>
         </div>
@@ -3551,8 +3551,8 @@ if (document.readyState === 'loading') {
             if (!itemIds.length) return;
             showPopup({
                 type: POPUP_TYPES.CONFIRM,
-                message: `Move ${itemIds.length} episode(s) back to Wanted for rescraping? This clears their current symlink/collection state.`,
-                title: 'Confirm Rescrape',
+                message: `Delete ${itemIds.length} episode(s) - symlink, source file/debrid download, media server entry - and move them back to Wanted for rescraping?`,
+                title: 'Confirm Delete & Rescrape',
                 onConfirm: () => {
                     Loading.show();
                     fetch('/debug/api/rescrape_duplicate_symlinks', {
@@ -3564,7 +3564,7 @@ if (document.readyState === 'loading') {
                     .then(data => {
                         Loading.hide();
                         if (data.success) {
-                            showPopup({ type: POPUP_TYPES.SUCCESS, message: `Moved ${data.moved} item(s) back to Wanted.`, title: 'Rescrape Queued', autoClose: true });
+                            showPopup({ type: POPUP_TYPES.SUCCESS, message: `Deleted and moved ${data.moved} item(s) back to Wanted.`, title: 'Rescrape Queued', autoClose: true });
                             if (scanDupeBtn) scanDupeBtn.click();
                         } else {
                             throw new Error(data.error || 'An unknown error occurred.');

--- a/templates/debug_functions.html
+++ b/templates/debug_functions.html
@@ -3594,9 +3594,8 @@ if (document.readyState === 'loading') {
                 html += `<button type="button" class="rescrape-dupe-group-btn" data-group="${gIdx}" style="margin-bottom:8px;">Rescrape This Group (${group.items.length})</button>`;
                 html += `<table class="preview-results-table"><thead><tr><th>Show</th><th>Season/Episode</th><th>Path</th></tr></thead><tbody>`;
                 group.items.forEach(item => {
-                    const matched = item.item_id !== null && item.item_id !== undefined;
-                    const showLabel = matched ? `${item.title || 'Unknown'} (${item.year || ''})` : '<i>Not matched to a database item</i>';
-                    const se = matched ? `S${String(item.season_number).padStart(2, '0')}E${String(item.episode_number).padStart(2, '0')}` : '-';
+                    const showLabel = `${item.title || 'Unknown'} (${item.year || ''})`;
+                    const se = `S${String(item.season_number).padStart(2, '0')}E${String(item.episode_number).padStart(2, '0')}`;
                     html += `<tr>
                         <td class="title-cell">${showLabel}</td>
                         <td>${se}</td>

--- a/templates/debug_functions.html
+++ b/templates/debug_functions.html
@@ -1272,6 +1272,12 @@ body:not(.tangerine-theme) #tngDebug { display: none !important; }
             </form>
         </div>
         <div class="debug_item">
+            <h3>Duplicate Symlink Targets</h3>
+            <p class="description">Scans TV Shows symlinks for episodes pointing at the same underlying file - usually means a season pack was mismatched and multiple "different" episodes are actually playing identical content. Read-only scan; nothing changes until you choose to rescrape.</p>
+            <button type="button" id="scan-duplicate-symlinks-btn">Scan for Duplicates</button>
+            <div id="duplicate-symlinks-results" class="results-area" style="margin-top: 15px;"></div>
+        </div>
+        <div class="debug_item">
             <h3>Rclone Mount to Symlinks</h3>
             <p class="description">Scan an Rclone mount, fetch metadata, create DB entries, and generate symlinks.</p>
             <form id="rclone-to-symlinks-form">
@@ -3537,6 +3543,109 @@ if (document.readyState === 'loading') {
         // --- End Rclone Mount to Symlinks Logic ---
 
         // --- Fix Zurg Symlinks Logic ---
+        const scanDupeBtn = document.getElementById('scan-duplicate-symlinks-btn');
+        const dupeResultsDiv = document.getElementById('duplicate-symlinks-results');
+        let dupeGroupsData = [];
+
+        function rescrapeDupeItems(itemIds) {
+            if (!itemIds.length) return;
+            showPopup({
+                type: POPUP_TYPES.CONFIRM,
+                message: `Move ${itemIds.length} episode(s) back to Wanted for rescraping? This clears their current symlink/collection state.`,
+                title: 'Confirm Rescrape',
+                onConfirm: () => {
+                    Loading.show();
+                    fetch('/debug/api/rescrape_duplicate_symlinks', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ item_ids: itemIds })
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        Loading.hide();
+                        if (data.success) {
+                            showPopup({ type: POPUP_TYPES.SUCCESS, message: `Moved ${data.moved} item(s) back to Wanted.`, title: 'Rescrape Queued', autoClose: true });
+                            if (scanDupeBtn) scanDupeBtn.click();
+                        } else {
+                            throw new Error(data.error || 'An unknown error occurred.');
+                        }
+                    })
+                    .catch(error => {
+                        Loading.hide();
+                        showPopup({ type: POPUP_TYPES.ERROR, message: error.message, title: 'Error', autoClose: false });
+                    });
+                }
+            });
+        }
+
+        function renderDupeGroups(data) {
+            dupeGroupsData = data.groups;
+            let html = `<h4>Results:</h4>`;
+            html += `<p>Symlinks scanned: ${data.scanned} &middot; Duplicate groups: ${data.group_count} &middot; Episodes affected: ${data.affected_count}</p>`;
+            if (data.group_count === 0) {
+                html += `<p>No duplicate targets found - every episode points to its own distinct file.</p>`;
+                dupeResultsDiv.innerHTML = html;
+                return;
+            }
+            html += `<button type="button" id="rescrape-all-dupe-groups-btn" style="margin-bottom:10px;">Rescrape All (${data.affected_count})</button>`;
+            data.groups.forEach((group, gIdx) => {
+                html += `<div class="dupe-group" style="margin-bottom:16px;border:1px solid #444;padding:10px;border-radius:6px;">`;
+                html += `<div class="path-cell" style="word-break:break-all;color:#aaa;font-size:0.85em;margin-bottom:6px;">Target: ${group.target}</div>`;
+                html += `<button type="button" class="rescrape-dupe-group-btn" data-group="${gIdx}" style="margin-bottom:8px;">Rescrape This Group (${group.items.length})</button>`;
+                html += `<table class="preview-results-table"><thead><tr><th>Show</th><th>Season/Episode</th><th>Path</th></tr></thead><tbody>`;
+                group.items.forEach(item => {
+                    const matched = item.item_id !== null && item.item_id !== undefined;
+                    const showLabel = matched ? `${item.title || 'Unknown'} (${item.year || ''})` : '<i>Not matched to a database item</i>';
+                    const se = matched ? `S${String(item.season_number).padStart(2, '0')}E${String(item.episode_number).padStart(2, '0')}` : '-';
+                    html += `<tr>
+                        <td class="title-cell">${showLabel}</td>
+                        <td>${se}</td>
+                        <td class="path-cell">${item.path}</td>
+                    </tr>`;
+                });
+                html += `</tbody></table></div>`;
+            });
+            dupeResultsDiv.innerHTML = html;
+
+            document.querySelectorAll('.rescrape-dupe-group-btn').forEach(btn => {
+                btn.addEventListener('click', function () {
+                    const gIdx = parseInt(this.dataset.group, 10);
+                    const ids = dupeGroupsData[gIdx].items.filter(i => i.item_id).map(i => i.item_id);
+                    rescrapeDupeItems(ids);
+                });
+            });
+            const rescrapeAllBtn = document.getElementById('rescrape-all-dupe-groups-btn');
+            if (rescrapeAllBtn) {
+                rescrapeAllBtn.addEventListener('click', function () {
+                    const ids = [];
+                    dupeGroupsData.forEach(g => g.items.forEach(i => { if (i.item_id) ids.push(i.item_id); }));
+                    rescrapeDupeItems(ids);
+                });
+            }
+        }
+
+        if (scanDupeBtn) {
+            scanDupeBtn.addEventListener('click', function () {
+                Loading.show();
+                dupeResultsDiv.innerHTML = '';
+                fetch('/debug/api/scan_duplicate_symlinks', { method: 'POST' })
+                    .then(response => response.json())
+                    .then(data => {
+                        Loading.hide();
+                        if (data.success) {
+                            renderDupeGroups(data);
+                        } else {
+                            throw new Error(data.error || 'An unknown error occurred.');
+                        }
+                    })
+                    .catch(error => {
+                        Loading.hide();
+                        showPopup({ type: POPUP_TYPES.ERROR, message: error.message, title: 'Error', autoClose: false });
+                        dupeResultsDiv.innerHTML = `<p class="error">Error: ${error.message}</p>`;
+                    });
+            });
+        }
+
         const fixZurgForm = document.getElementById('fix-zurg-symlinks-form');
         const fixZurgResultsDiv = document.getElementById('fix-zurg-results');
 

--- a/templates/debug_functions.html
+++ b/templates/debug_functions.html
@@ -403,6 +403,7 @@ body:not(.tangerine-theme) #tngDebug { display: none !important; }
     'Fix Zurg Symlinks':'symlink',
     'Modify Symlink Base Paths':'symlink',
     'Resync Symlinks with New Settings':'symlink',
+    'Duplicate Symlink Targets':'symlink',
     'Rclone Mount to Symlinks':'symlink',
     'Current Rate Limit State':'monitoring',
     'Plex Token Status':'monitoring',

--- a/usenet/climount_client.py
+++ b/usenet/climount_client.py
@@ -901,6 +901,31 @@ def get_climount_client():
     return _client_instance
 
 
+def is_nzb_job_alive(job_hash: str) -> bool:
+    """
+    Check whether a shared season-pack job is still queryable on the usenet
+    provider before reusing its reference for a different episode. A job that
+    completed and was later cleaned up server-side (or genuinely never
+    existed) returns no populated status - reusing it anyway just produces
+    another dead reference that will ghost every retry forever, since nothing
+    else ever re-verifies it. Result is cached briefly so many sibling
+    episodes checking the same job within one pass don't each re-query it.
+    """
+    from debrid.common.cache import timed_lru_cache
+
+    @timed_lru_cache(seconds=20)
+    def _check(_job_hash: str) -> bool:
+        try:
+            status = get_climount_client().get_job_status(_job_hash)
+            return bool(status and status.get('raw'))
+        except Exception as exc:
+            logging.debug(f'[cli_mount] is_nzb_job_alive check failed for {_job_hash!r}: {exc}')
+            # Unknown due to a transient error - don't block a legitimate reuse over it.
+            return True
+
+    return _check(job_hash)
+
+
 def reset_climount_client() -> None:
     global _client_instance
     _client_instance = None

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -796,16 +796,12 @@ def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup
         # titled shows released the same year landing in the same directory and silently
         # interleaving episode files. Fall back to a stable, unique identifier whenever
         # the title contains any non-Latin script at all, rather than only when nothing
-        # survives — checked via presence of CJK/Kana/Hangul characters, matching the
+        # survives — checked via presence of any non-Latin letter (script-agnostic:
+        # Japanese, Korean, Chinese, Hindi, Cyrillic, Arabic, etc. all match), the
         # same detection used for the TVDB-side fix for this same underlying issue.
-        _non_latin_script = re.compile(
-            r'[぀-ヿ'   # Hiragana + Katakana
-            r'㐀-䶿'    # CJK Extension A
-            r'一-鿿'    # CJK Unified Ideographs
-            r'가-힣]'   # Hangul syllables
-        )
+        from utilities.text_utils import has_non_latin_letter
         effective_title = raw_title
-        if raw_title and raw_title.strip() and _non_latin_script.search(raw_title):
+        if raw_title and raw_title.strip() and has_non_latin_letter(raw_title):
             effective_title = imdb_id or item.get('tmdb_id', '') or 'unknown'
             logging.warning(
                 f"[SymlinkPath] Title {raw_title!r} has no ASCII-safe representation — "

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1476,6 +1476,17 @@ def check_local_file_for_item(item: Dict[str, Any], is_webhook: bool = False, ex
                 else:
                     logging.warning(f"[ffprobe] Playability check FAILED for '{source_file}' — rejecting and reverting to Wanted")
                     _reject_unplayable_source(item, _is_nzb_for_probe)
+                    # _reject_unplayable_source only updates the DB row - without also
+                    # moving the item out of the in-memory CheckingQueue, the DB says
+                    # Wanted while the queue still holds it with its stale filled_by_*
+                    # fields, until the next queue refresh reconciles them. The Plex-mode
+                    # equivalent (run_program.py's _ffprobe_gate_or_reject) already does
+                    # this; mirror it here for parity.
+                    try:
+                        from queues.queue_manager import QueueManager
+                        QueueManager().move_to_wanted(item, 'Checking')
+                    except Exception as e_wanted:
+                        logging.error(f"[ffprobe] Failed to move item {item.get('id')} back to Wanted after failed probe: {e_wanted}")
                     return False
 
             # Get destination path based on settings (using the found source_file)

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -784,9 +784,37 @@ def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup
         imdb_id = item.get('imdb_id', '')
         if imdb_id == 'tt0000000':
             imdb_id = ''
-            
+
+        raw_title = item.get('title', 'Unknown')
+        # sanitize_filename ASCII-encodes and drops anything it can't represent — for a
+        # title that's partly or entirely non-Latin script, that can strip it down to
+        # nothing (or to a short, non-distinguishing fragment — e.g. '怪獣8号' survives
+        # as just "8", 'NARUTO－ナルト－' survives as "NARUTO", which happens to be fine
+        # here but isn't guaranteed to be unique for some other mixed-script title). The
+        # show-level folder template ('{title} ({year})') has no other uniqueness anchor,
+        # so a collapsed or barely-distinguishing title risks two different non-Latin
+        # titled shows released the same year landing in the same directory and silently
+        # interleaving episode files. Fall back to a stable, unique identifier whenever
+        # the title contains any non-Latin script at all, rather than only when nothing
+        # survives — checked via presence of CJK/Kana/Hangul characters, matching the
+        # same detection used for the TVDB-side fix for this same underlying issue.
+        _non_latin_script = re.compile(
+            r'[぀-ヿ'   # Hiragana + Katakana
+            r'㐀-䶿'    # CJK Extension A
+            r'一-鿿'    # CJK Unified Ideographs
+            r'가-힣]'   # Hangul syllables
+        )
+        effective_title = raw_title
+        if raw_title and raw_title.strip() and _non_latin_script.search(raw_title):
+            effective_title = imdb_id or item.get('tmdb_id', '') or 'unknown'
+            logging.warning(
+                f"[SymlinkPath] Title {raw_title!r} has no ASCII-safe representation — "
+                f"falling back to {effective_title!r} to avoid colliding with other "
+                f"items released in {item.get('year', '')!r}"
+            )
+
         template_vars = {
-            'title': item.get('title', 'Unknown'),
+            'title': effective_title,
             'year': item.get('year', ''),
             'imdb_id': imdb_id,
             'tmdb_id': item.get('tmdb_id', ''),

--- a/utilities/text_utils.py
+++ b/utilities/text_utils.py
@@ -1,0 +1,35 @@
+import unicodedata
+
+# Unicode code point ranges covering Latin-script letters (base Latin plus the
+# extended blocks used by accented/diacritic Latin text, e.g. Vietnamese).
+# Anything else letter-like (CJK, Hangul, Devanagari, Cyrillic, Arabic, Thai,
+# etc.) falls outside these ranges.
+_LATIN_LETTER_RANGES = (
+    (0x0041, 0x005A), (0x0061, 0x007A),  # Basic Latin A-Z a-z
+    (0x00C0, 0x00FF),  # Latin-1 Supplement letters
+    (0x0100, 0x017F),  # Latin Extended-A
+    (0x0180, 0x024F),  # Latin Extended-B
+    (0x1E00, 0x1EFF),  # Latin Extended Additional (Vietnamese etc.)
+    (0x2C60, 0x2C7F),  # Latin Extended-C
+    (0xA720, 0xA7FF),  # Latin Extended-D
+)
+
+
+def has_non_latin_letter(text: str) -> bool:
+    """Return True if `text` contains any Unicode *letter* character outside
+    the Latin script ranges above - script-agnostic (Japanese, Chinese,
+    Korean, Hindi, Cyrillic, Arabic, Thai, etc. all match), unlike checking
+    for specific script blocks one at a time.
+
+    Only flags actual letters (Unicode category starting with 'L') - digits,
+    punctuation, and spaces never trigger this, so e.g. a title with a stray
+    ASCII digit alongside non-Latin letters is still correctly flagged.
+    """
+    if not text:
+        return False
+    for ch in text:
+        if unicodedata.category(ch).startswith('L') and not any(
+            lo <= ord(ch) <= hi for lo, hi in _LATIN_LETTER_RANGES
+        ):
+            return True
+    return False


### PR DESCRIPTION
## Summary

Built a new debug tool to find and repair TV episodes whose symlinks point at the wrong underlying file (season-pack mismatches), then found and fixed six real, pre-existing bugs while validating that tool against live batches: four in the mode-agnostic NZB season-pack coalescing/reconciliation pipeline (affecting both `Plex` and `Symlinked/Local` file-management modes, not just symlink mode), one Plex/symlink-mode parity gap found during a follow-up review of related recently-merged PRs, and one stale-cache data-loss bug found live in the (separate, pre-existing) debrid manager symlink cleanup tool. Also includes two unrelated fixes (Bugs 7 & 8 below) for separately-reported issues, bundled into this branch rather than opened as their own PRs.

## New feature: Duplicate Symlink Targets (Debug > Symlink tab)

- **Scan**: walks the TV Shows symlink tree (and the anime TV folder too, when `enable_separate_anime_folders` is on — reads the same `Debug.tv_shows_folder_name`/`Debug.anime_tv_shows_folder_name` settings the rest of the app uses, rather than a hardcoded `'TV Shows'`), groups by `readlink()` target, and reports any target with 2+ symlinks pointing at it (only items matched to a real `media_items` row are shown — nothing actionable otherwise).
- **Rescrape**: for a selected group, runs the exact same deletion pipeline as deleting an episode from the library (`DeletionManager.delete_multiple_items` — media server entry, symlink, source file/debrid-or-usenet download, cache) before resetting state to `Wanted`, rather than only resetting DB state. `delete_multiple_items`'s sibling guard already excludes items in the same batch when deciding whether a shared season-pack torrent/NZB is still needed elsewhere, so rescraping an entire duplicate-target group in one action doesn't have the items block each other's cleanup.
- Also fixes the card being visible under "All" in the tangerine-theme debug UI but missing from the "Symlink" tab filter specifically — that theme categorizes cards via a hardcoded title→category lookup instead of deriving it from which tab div the card lives in, and the new card was missing from that table.
- **Multi-episode release labeling**: a duplicate-target group where the target filename itself parses (via the same title parser the scraper already uses for ranking) to exactly the same episode numbers as the group gets tagged "Possible multi-episode release" instead of looking like an unlabeled duplicate — distinguishes a genuine mismatch (different episodes wrongly sharing a file) from a legitimate combined-episode release (e.g. a premiere packaged as one `S01E01E02.mkv`). Purely additive: every group is still shown, still counted, still rescrape-able either way.

## Bug 1 & 2: empty-title season-pack misdetection (two locations)

`torrent_processor.py`'s in-memory and DB-based sibling checks, and `scraping_queue.py`'s `[NZBPack]` coalescing check, all decide "is this existing job a genuine season pack, safe to share with a different episode?" by checking whether the sibling's title lacks an `SxxEyy` pattern. When the title field is empty (e.g. a same-tick timing gap where a sibling's own submission hasn't been reflected back into the snapshot/DB yet), `re.search(pattern, '')` also returns no match — so an *unknown* title was being treated as *proof* it's a pack, and a different episode's individual NZB job got silently reused. This is what caused a real episode (Blue Mountain State S03E07) to symlink to a completely different episode's file (S03E02) live in testing.

Fix: require a non-empty title before concluding "pack." An empty/unknown title now correctly falls through to "not a pack" (worst case: a harmless duplicate submission) instead of defaulting to the unsafe "assume pack, reuse" direction.

Note: PR #459 (merged) already fixed a related failure mode of this same heuristic — `filled_by_file` being an obfuscated hex string for usenet releases, also misread as "must be a pack." This PR's fixes address a different failure mode (empty title, not obfuscated title) that #459 didn't cover, in three call sites (two of which #459 also touched, one of which — `scraping_queue.py` — it didn't).

## Bug 3: stranded season-pack siblings falsely marked Collected

`run_program.py`'s `task_reconcile_queues` "Step 1c" (`[NZBCoalesce]`) exists to rescue season-pack sibling episodes that get stranded in `Adding` forever (only the pack's "initiator" episode normally goes through `Checking` → file resolution → `Collected`; siblings otherwise sit indefinitely). The existing implementation, when it found a stranded sibling next to an already-Collected one, just copied the Collected sibling's torrent/title/folder metadata onto the stranded item and flipped its state straight to `Collected` — without ever resolving *that item's own* file, without setting `location_on_disk`, and without creating any symlink. This produced episodes that show `Collected` in the database with literally nothing on disk.

Fix: instead of blindly copying and flipping state, look up the pack's actual file listing on the provider (`climount_client.get_nzb_folder_all_files`, per-folder cached) and match each stranded item to its own episode via the same `SxxEyy` regex used elsewhere in the resolution pipeline. Only items with a confirmed match get `filled_by_file` set and move to `Checking` (never straight to `Collected`) — letting the normal symlink-creation pipeline actually run and only reach `Collected` for real. Items with no match are left in `Adding` rather than falsely marked done.

## Bug 4: infinite dead-job reuse loop

None of the three season-pack job-reuse sites (the ones fixed in bugs 1 & 2) verified that a shared job was still actually alive/queryable on the usenet provider before reusing its reference. A job that completed and was later cleaned up server-side (or genuinely never existed) got reused forever, since nothing ever re-checked it — every dependent episode would ghost on retry, get bounced back to `Wanted`, and the very next scrape cycle would find the same dead reference again via the same sibling lookup, looping indefinitely. In live testing this blacklisted 16 real, otherwise-resolvable episodes after they exhausted retries against a dead job.

Fix: added `is_nzb_job_alive()` (`usenet/climount_client.py`, provider-agnostic via the existing `get_job_status`, cached 20s to avoid redundant checks when many sibling episodes check the same job in one pass) and wired it into all three reuse sites. A dead reference now falls through to a fresh submission instead of being reused blindly.

## Bug 5: symlink-mode ffprobe rejection didn't clear the in-memory CheckingQueue entry

Found while reviewing recently-merged PRs for Plex/symlink-mode parity (prompted by #476, which added Plex-mode ffprobe support). When a file fails the ffprobe playability check, `_reject_unplayable_source` (`local_library_scan.py`) updates the DB row to `Wanted` — but the original symlink-mode gate (from #465) never called `move_to_wanted()` afterward, so the item stayed in the in-memory `CheckingQueue` with its stale `filled_by_title`/`filled_by_magnet`/`filled_by_torrent_id`/`filled_by_file` fields until the next queue refresh reconciled it, leaving DB and in-memory state briefly disagreeing. Plex mode's equivalent gate (`_ffprobe_gate_or_reject`, added in #476) already called `move_to_wanted()` correctly — this brings the original symlink-mode gate to parity with it.

## Bug 6: stale-cache data loss in the debrid manager's symlink audit delete

Found live, the hard way, while using the debrid manager's separate "Symlink Audit" tool (Unlinked/Broken/Mismatched file cleanup - a different feature from the Debug tool above, but in the same general area). Its bulk `/api/symlink_audit/delete` endpoint deletes whatever paths the frontend sends it, and those paths come from a cached scan result. If a new symlink got created pointing at one of those paths *after* the scan ran but *before* the delete was clicked (completely plausible on a system that's continuously scraping/collecting in the background), the cached "unlinked"/"broken" list has no way of knowing that - clicking "Delete All" would remove a file a real, currently-active symlink now depends on. This is exactly what happened during testing tonight: a movie (Cars 2) and a TV episode (Breaking Bad S05E15) each had their only remaining source file deleted this way, breaking their playback in Plex.

Fix: rebuild the current linked-targets set fresh (one directory walk) immediately before the delete loop runs, and skip any path that's since become linked instead of removing it. One extra walk per bulk-delete click, not per file, so the cost is negligible. Response now reports a `skipped` count, surfaced in the UI's success message, so it's visible when the safety check actually caught something.

## Bug 7: Request button silently ignores a missing/deleted version when another version is already Collected

Reported via Discord (not yet filed as its own GitHub issue): a movie collected in two versions (e.g. `2160p` + `1080p`) had one version deleted after the file broke; re-requesting that specific version from the Library or Discover page reported success but never actually rescraped it.

`add_wanted_items()` (`database/wanted_items.py`) already computes a per-item `is_user_initiated_add` flag (`content_source in ('content_requester', 'Magnet_Assigner')`) specifically to bypass the blanket "already Collected" skip for user-initiated requests — but the movie/episode version-diff block immediately after it ignored that flag entirely and skipped based only on a default-off `Debug.enable_granular_version_additions` setting. That block treats "some version exists" (regardless of state, and regardless of whether it's the version actually being requested) as reason enough to skip — so a movie with `2160p` still Collected would block a request for a *different, currently-missing* `1080p`, without ever checking whether `1080p` itself was present.

Fix: the existing (already-correct) per-version diff logic — which only skips versions that are actually already present — now also runs whenever `is_user_initiated_add` is true, not just when the Debug flag is on. Automated content sources (Trakt, Overseerr, Plex Watchlist, etc.) are unaffected and keep their original coarse dedup behavior.

Also fixes `request_content()` unconditionally reporting `success: True` even when 0 items were actually added, and updates the three frontend request call sites (`library_movie.js`, `discover_details.js` x2, `discover.js`) to surface that message instead of a generic "Successfully requested" toast that masked the no-op.

## Bug 8: Plex Movie Box Sets — add-items 400s because ratingKeys aren't resolved to the target section

Issue #475: box set collections got created in Plex and received a poster, but no movies were ever added — logs showed `Add items batch returned 400 for collection {id}`.

`sync_plex_collections()` (`database/plex_movie_boxsets.py`) passed each boxset's `owned_ms_ids` (raw `ms_item_id` DB values) straight to `_add_items_to_collection()` as if they were valid ratingKeys for the resolved movie section. `ms_item_id` is a Plex ratingKey that's section-specific — in a split HD/4K library the same movie has distinct ratingKeys per section, and the DB only stores one per row; it can also be stale after a library re-add. Since `_add_items_to_collection` batches up to 100 keys into a single PUT request, one bad/foreign/stale key 400s the entire batch, silently dropping up to 100 movies.

Fix: reuse `_get_section_id_map()` from `plex_collections.py` (already solves this exact problem for the non-boxset collections feature) to resolve each owned movie's `imdb_id`/`tmdb_id` to a ratingKey confirmed to actually exist in the target section, instead of trusting the stored `ms_item_id` directly. `build_boxset_list()` now fetches individual movie rows (keeping `imdb_id`/`tmdb_id`/`ms_item_id` correlated per movie) instead of three parallel `GROUP_CONCAT`s, since the id-map lookup needs each movie's own id pair together.

# Also included: fixes ported from PR #470 (non-Latin anime titles + debrid duplicate season-pack downloads)

The sections below were originally developed and tested on a separate branch/PR (#470) but are included here too since they touch related scraping/matching code and were verified together in the same live testing session as the fixes above.

**Note for anyone upgrading:** the title fixes below (Bugs 9-12) only affect *newly resolved* titles - a show already cached with the old, wrong title (non-Latin, or a bad marketing-AKA translation) won't be corrected automatically just by updating the code, since cli_battery won't re-fetch metadata for something it already has cached. To pick up the fix for an already-added show:
- **Targeted (recommended)**: use the per-show "Refresh Metadata" button (Library page -> show -> Refresh Metadata, or `POST /library/refresh_metadata/show/<media_id>`) - forces a fresh metadata fetch for just that show.
- **Broad**: the Debug page's "Reset Battery Cache" action clears `last_trakt_fetch` for every show, forcing all of them to refetch on the next cycle - only needed if you have many affected shows and don't want to refresh them one at a time; more disruptive since it applies to everything, not just non-Latin titles.

## Bug 9: Root cause — `cli_battery/app/tvdb_client.py`
`_build_show_dict` deliberately always used TVDB's primary series name as the canonical title, never the "eng" `nameTranslations` entry, specifically to avoid a prior bug where that translation was sometimes a wrong marketing AKA (e.g. "Gangs of Manila" incorrectly overriding "Batang Quiapo"). That fix over-corrected: many series — commonly anime — have their TVDB primary name stored partly or entirely in non-Latin script (Japanese, Chinese, Korean), with no romanized or English form at all. Always preferring the primary name meant those shows got an unusable title with no way to recover.

Now falls back to the English translation whenever the primary name contains any CJK/Kana/Hangul script — not only when the primary name is *entirely* non-Latin, since a mixed title like Naruto's actual TVDB primary name (`NARUTO－ナルト－`) still has Latin letters in it but is still half Japanese. A genuinely Latin-script primary name (including one with a bad "marketing AKA" translation available) is still always preferred exactly as before, so the original bug this guarded against stays fixed.

## Bug 10: Defense-in-depth — `utilities/local_library_scan.py`
`sanitize_filename`'s Unicode-to-ASCII conversion drops any character it can't represent — for a title that's partly or entirely non-Latin script, that can strip it down to nothing, or to a short, non-distinguishing fragment. The show-level folder template (`{title} ({year})`) has no other uniqueness anchor, so two different non-Latin-titled shows released the same year could land in the exact same directory and silently interleave each other's episode files.

Falls back to the item's IMDB ID (or TMDB ID) whenever the title contains any CJK/Kana/Hangul script — always unique per show, so a stable, collision-proof folder instead of a collapsed or coincidentally-colliding one. Independent safety net for any title that reaches this point non-Latin from a source other than TVDB.

## Bug 11: Scraper dedup guard — `scraper/scraper.py`
Anime scraping builds multiple title variants to search with (original, translated, romanized alias, etc.) specifically to handle non-English content — but a dedup guard meant to prevent redundant scrapes was keyed *only* on episode format, which is identical across every title variant for the same episode. So whichever title's thread won a race to grab a lock first was the *only* one ever actually scraped, for any anime item with episode formats set. The CJK original title reliably wins that race (submitted first), so the working romanized alternative never got a chance to run at all. A comment a few lines later in the same function already documented the intended behavior this guard was silently violating ("Always continue searching all titles... to ensure comprehensive results from both original and romanized titles"). Every title in the search list is already deduplicated by exact string at build time, so this guard had no legitimate purpose left — removed.

## Bug 12: Japanese-alias false positives — `scraper/scraper.py`
Separately found via a real scrape log: the heuristic that decides "is this alias a Japanese romanization" scanned every country's aliases for short substrings like `ta`, `na`, `ri`, `ka` — far too permissive, since those show up constantly in other languages too. Confirmed live: "Angriff auf Titan" (German for "Attack on Titan") matched on `ri` (in "Angriff") and `ta` (in "Titan") and got misfiled as a "Japanese romanized alias," triggering a second, entirely pointless scrape for a German phrase no indexer will ever match — doubling indexer load for every affected title, including doubling exposure to any slow/hanging indexer in that round. The alias dict is already keyed by the country/language each alias actually came from (both TVDB and Trakt use 2-letter codes, `jp` for Japan) — now uses that directly instead of guessing from text.

## Follow-up: generalized beyond CJK/Kana/Hangul + fixed a real translation-selection bug

Real-world testing (external user report) confirmed the original fix works for Japanese/Korean, but found it didn't help Hindi content at all. Root cause: the detection regex only matched CJK Unified/Extension-A, Hiragana/Katakana, and Hangul syllable ranges — Devanagari, Cyrillic, Arabic, etc. were invisible to it.

### Generalized detection (`utilities/text_utils.py`, new)
`has_non_latin_letter()` flags any Unicode *letter* outside the Latin script ranges, instead of enumerating specific scripts one at a time — one check instead of a growing per-language allowlist. Verified against every case from the original test plan (Naruto, Kaiju No. 8, Batang Quiapo) plus newly added Hindi/Cyrillic/Arabic cases, live against real TVDB data (88 items across all 4 language groups, 100% pass, no regressions).

### Second-pass testing against obscure/low-score titles surfaced two more real gaps:

1. **`_build_show_dict` took the first `eng` translation candidate unconditionally.** TVDB's community-contributed data sometimes has the non-Latin name copied verbatim into the `eng` slot (or a mixed-script entry) *ahead of* a genuinely usable translation further down the list — e.g. Russian show "Вольная грамота" has a garbage `eng` entry equal to its own Cyrillic name, followed by the real "Life of a Mistress" translation; the old code took the first one and stopped. Fixed: now only accepts a candidate that's itself Latin-clean, and keeps scanning if not.
2. **`_build_movie_dict` never got the original fix at all** — it unconditionally overwrote a movie's title with the first `eng` translation regardless of whether the primary name needed it, which is literally the original marketing-AKA bug this whole feature exists to prevent. Now shares the same validated resolution logic as shows.
3. **Added a TMDB cross-check as a further fallback**, since TVDB's own translations are sometimes missing or unusable entirely (e.g. "Пётр I" has zero `eng` translations on TVDB, but TMDB has "Peter I"). Only used when TVDB has nothing clean; falls through to the original title if neither source has anything usable, same as before — the symlink-path layer's independent ID-based fallback already covers that case safely regardless.

Verified against all 4 real broken cases the second pass found (Пётр I, Вольная грамота, Щит и меч, and an Arabic-mixed movie title) — all now resolve to clean Latin titles — plus a regression spot-check confirming no change to previously-correct cases.


### Third-pass: regression check + movie marketing-AKA verification

Re-ran the full obscure-title batch (240 items, 60/group across CJK/Hindi/Cyrillic/Arabic) against the fixed code: zero exceptions, zero regressions — all 4 previously-broken cases stay fixed, everything that passed before still passes.

Also specifically tested the movie-side fix (never exercised before, since `_build_movie_dict` had no protection at all until this branch): 30 real movies with an already-correct Latin primary title *and* a differing `eng` translation available (e.g. `Il buono, il brutto, il cattivo` / `The Good, the Bad and the Ugly`) — **30/30 correctly kept the real primary title** instead of getting overridden by the alternate. Confirms the marketing-AKA protection now works for movies the same way it always has for shows.

**Known, deliberately unfixed limitation:** one obscure Arabic show picked a broadcaster name (`MBC`) over a better, correctly-romanized candidate (`Majmo'at Insan`) sitting later in TVDB's translation list — `has_non_latin_letter` only screens for script contamination, not "is this plausibly a title vs. a channel/network name." Affects 1 of 240 obscure test items; not a crash or a broken symlink path, just a wrong-but-plausible title in a narrow case. Left as a known follow-up rather than fixed now — a title-plausibility heuristic (e.g. deprioritizing short all-caps single-token candidates) would need its own verification to avoid over-filtering genuinely short titles.


## Additional fix (2026-08-19): debrid path downloading a duplicate season pack per episode

Reported via Discord: requesting Mushoku Tensei (2 seasons + 1 running) caused cli_debrid to request 12 duplicate season packs, exhausting the user's debrid limit, reproducing every time. Root cause: the debrid/torrent add path (`torrent_processor.py`) had no sibling-awareness at all — unlike the pre-existing NZB path, which already reused a sibling episode's in-flight pack instead of grabbing a duplicate. Every episode independently scraped and added its own pack, and a successful add immediately blacklists that release's hash (`add_to_not_wanted`), pushing each subsequent episode onto a *different* release-group's pack instead of reusing what was already grabbed. Anime is hit hardest since it commonly has 5-10+ interchangeable fansub packs per season.

### Fix (4 commits, `queues/torrent_processor.py` + `queues/adding_queue.py` + `queues/checking_queue.py`)

1. **Sibling-pack reuse for the debrid path** — new `_check_sibling_debrid_pack`, mirroring the NZB path's existing logic: checks in-memory and DB for a sibling episode (same show/season/version) that already has a debrid job, and reuses it instead of submitting a duplicate. Includes a file-membership check (does the candidate pack actually contain this episode?) to avoid an infinite retry loop against a partial "Part 1"/"Part 2" split pack. Since multiple episodes can now legitimately share one torrent_id, added `_torrent_has_other_active_owner` — a guard in `adding_queue.py` and `checking_queue.py` that checks the DB before letting a single episode's own failure delete a torrent other episodes still depend on.
2. **Title-mismatch fix** — the reuse path was returning an empty `chosen_result_info`, which made the caller fall back to an unrelated fresh-scrape candidate's title instead of the reused torrent's own title, corrupting `original_scraped_torrent_title` and breaking file-location resolution for affected episodes (surfaced as episodes permanently stuck in "Checking").
3. **Candidate dedup + prefer-largest** — the sibling candidate query now dedups by torrent_id (via a `MIN(id)` subquery — a bare `GROUP BY` isn't safe here, SQLite doesn't guarantee non-aggregated columns come from the same row as the grouped one) and picks the most complete pack when more than one legitimately covers the needed episode.
4. **Live consolidation of already-Collected siblings** — when a wider pack gets chosen for the episode currently being processed, and that pack also covers other episodes that already landed on a smaller/different torrent earlier, their symlinks get repointed onto the wider pack live, in the same tick (reuses the existing file-resolution/symlink-creation code, no new path logic), with the old torrent removed only once nothing else references it. Symlink-mode only (Plex mode has no symlink layer to safely repoint). Also fixed a related bug where the reused torrent's *real* mount folder name (from the provider) wasn't being used, falling back to the indexer's cosmetic display title instead — the two frequently differ and only the real one reliably resolves on disk.

### Real-world testing
Live-verified against 3 real shows on a production instance, with both a debrid provider and a usenet provider (cli_mount) enabled simultaneously to confirm no cross-protocol duplication:
- **Mushoku Tensei** (anime, the original bug report): Seasons 1-2 (47 episodes, both fully aired) converged from 12+ duplicate packs down to **3 distinct torrents**. Season 3 is currently airing with no season pack released yet by any group, so its episodes correctly fell to individual per-episode grabs (8 distinct torrents for 8 episodes so far) — expected behavior, not a regression, since sibling-reuse can only reuse a pack that actually exists to be found.
- **Prison Break S02** (non-anime): 22 episodes → **1 torrent**, S03-S05 each fully converged onto their own single shared pack
- **Reacher**: full-season packs correctly reused across all episodes; also the only show where a usenet grab won the race for a few episodes, confirmed via direct DB query afterward that none of those episodes were *also* independently grabbed via debrid — no cross-protocol duplication
- Confirmed via direct diff that the pre-existing NZB sibling-reuse path (`_process_nzb_result`) is untouched by any of this work

## Test plan

- [x] Python syntax and Jinja2 template checks on every changed file
- [x] Live-verified against a running instance across multiple real batches, checking `readlink()` output directly before/after each fix:
  - Blue Mountain State S03E02/E07 (the original wrong-episode-symlink case) — confirmed distinct, correct targets after rescrape
  - FROM (2022) S02 and S03, 10 episodes each — 0 duplicate targets, 0 broken links
  - The Pitt (2025) S01E01-03
  - High Potential S02, 18 episodes — first attempt (pre-fix) produced 16 `Blacklisted` episodes via the dead-job loop; same reset-to-`Wanted` retry with all four fixes applied produced 16 `Collected` episodes with correct, distinct symlink targets matching their labeled episode number
  - Mr Inbetween S02, 5 pre-existing phantom-`Collected` episodes (same bug class, predating this session) — reset and re-resolved cleanly
  - Prison Break S01, 22 episodes, added fresh after all fixes were live — 0 duplicate targets, 0 broken links, no ghost/coalescing issues
- [x] Full-library duplicate-symlink scan before/after: confirmed nothing newly introduced, and all shows actually touched during testing came back clean
- [x] Bug 6 (stale-cache delete): reproduced the exact loss against the running instance (verified via `readlink()`/`os.path.exists()` on the two affected files before and after), captured a full snapshot of every "unlinked" path pre-delete and confirmed all 3,532 were actually gone from the mount post-delete (25 initial stragglers were a transient FUSE hiccup, confirmed by successful retry), then patched and live-verified the fix doesn't block legitimate deletions while correctly excluding currently-linked paths
- [x] Duplicate Symlink Targets scan folder-name fix: verified against the live instance's actual settings that folder resolution is unchanged when using default `TV Shows` with anime folders disabled (this instance's config), confirming no behavior change for the common case while the anime-folder/custom-name path is now correctly wired for others
- [x] Shameless (US) S01-S04 (~70 episodes) added fresh with all six fixes live, monitored end-to-end (scraping, ffprobe playability checks, Checking→Collected transitions) — this exercised `[NZBBatch]` (the separate combined-submission mechanism that bundles 5+ individually-available episodes into one pass, unrelated to the genuine-season-pack coalescing `[NZBPack]`/`[NZBCoalesce]` code Bugs 1-4 fix, since `disable_nzb_season_packs` was on for this show), not genuine season-pack coalescing — no batch-detection misfires, no dead-job/blacklist loop, no ffprobe failures, duplicate-symlink scan clean throughout
- [x] Bug 7: verified in two stages before going live. First, an isolated test against a copy of the production database (separate `USER_DB_CONTENT`, zero risk to real data) confirmed the core logic: requesting a missing version now adds it (`items_added: 1`), while re-requesting an already-Collected version still correctly skips (`items_added: 0`). Then reproduced the exact real-world scenario end-to-end on the live instance: took a movie (Pirates of the Caribbean: The Curse of the Black Pearl) collected in `1080p`, requested `4k` (added and collected correctly, confirming the fix doesn't just handle the "originally reported" direction), then deleted the `1080p` row/file/symlink/Plex entry entirely and re-requested `1080p` — confirmed via live logs it went to `Scraping` (previously would have silently no-op'd) and successfully re-collected a fresh `1080p` copy, ending with both versions correctly `Collected` side by side
- [x] Bug 8: live-verified against a running instance — ran the real `run_plex_movie_boxsets()` task end-to-end (527 movies checked against TMDB, 41 box sets built and synced). Zero 400 errors and zero "Failed to sync" errors across the entire run, versus the previous unconditional failure. Spot-checked a newly-created collection directly via the Plex API (`/library/collections/{rk}/children`) and confirmed it actually contained its correct movies, not just an absence of errors


- **PR #470 fixes (ported into this branch):**
- [x] Live-verified fix (Bug 9) against 27 real anime shows via TVDB's actual API (not synthetic data) — every one now resolves to its correct English title, including mixed-script titles (Naruto) and titles with a stray ASCII digit in an otherwise non-Latin name (Kaiju No. 8's primary name is `怪獣8号`)
- [x] Live-verified fix (Bug 10) by calling `get_symlink_path` directly against a real running instance with a synthetic non-Latin title — confirmed it produces an ID-based, collision-proof folder instead of collapsing to bare `(Year)`; cleaned up the test directory afterward
- [x] Live-verified fixes (Bug 11 and 12) together end-to-end against a real production scrape of Attack on Titan: confirms only two legitimate titles are searched (`Attack on Titan`, `Shingeki no Kyojin`) — the previous run had misfired on `Angriff auf Titan` (German) instead
- [x] Broad follow-up test: verified the fixed Japanese-alias detection against 20 more real anime shows via live metadata calls — every result is either a correct romanization or a safe `None` (no clean alias available), zero false positives on any other language

🤖 Generated with [Claude Code](https://claude.com/claude-code)






