### PR TITLE
Fix Cloudflare-bypass browser permanently failing after Xvfb leaves a stale X11 socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,13 @@ RUN apt-get update && \
     xvfb fonts-liberation fonts-unifont libnss3 libnspr4 libatk1.0-0 \
     libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libxcomposite1 \
     libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2 libpango-1.0-0 \
-    libcairo2 libatspi2.0-0 && \
+    libcairo2 libatspi2.0-0 \
+    # DejaVu Sans — last-resort system-font fallback for poster overlay text
+    # (see overlays/font_manager.py's _LOCAL_FONT_MAP). Without this package
+    # the fallback path was silently unreachable: the font_manager fell
+    # through to trying a Google Fonts download for "DejaVuSans-Bold", which
+    # isn't a real Google Fonts family name and always failed.
+    fonts-dejavu-core && \
     # Cleanup
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/database/database_writing.py
+++ b/database/database_writing.py
@@ -501,6 +501,52 @@ def update_media_item(item_id: int, **kwargs):
         if conn:
             conn.close()
 
+def enable_fallback_to_single_scraper(item: dict, reason: str = ""):
+    """Sets fall_back_to_single_scraper=True for `item` and every other pending
+    episode of the same series/season/version, regardless of episode number.
+
+    Multi-pack mode (queues/scraping_queue.py) is forced on for any episode
+    scrape older than 7 days - a single stuck-in-multi episode (e.g. episode 1,
+    since nothing "before" it can ever propagate the flag to it) can otherwise
+    be starved of single-episode candidates forever if the only multi-pack
+    result available gets filtered out for an unrelated reason (bad language,
+    wrong group, etc.), since forcing multi-pack rejects every single-episode
+    result outright. Previously this only propagated to *later* episodes
+    (episode_number > current), which is exactly what let episode 1 get stuck.
+    """
+    item_id = item.get('id')
+    if not item_id or item.get('fall_back_to_single_scraper'):
+        return
+    update_media_item(item_id, fall_back_to_single_scraper=True)
+    logging.info(f"Enabled single scraper fallback for item ID {item_id} ({item.get('title')}){f': {reason}' if reason else ''}")
+
+    if item.get('type') != 'episode':
+        return
+    series_title = item.get('series_title', '') or item.get('title', '')
+    season = item.get('season') or item.get('season_number')
+    version = item.get('version')
+    current_id = item_id
+
+    from .database_reading import stream_all_media_items
+    for candidate in stream_all_media_items(state=None, media_type='episode'):
+        try:
+            if candidate.get('id') == current_id:
+                continue
+            if (candidate.get('series_title', '') or candidate.get('title', '')) != series_title:
+                continue
+            if (candidate.get('season') or candidate.get('season_number')) != season:
+                continue
+            if candidate.get('version') != version:
+                continue
+            if candidate.get('fall_back_to_single_scraper'):
+                continue
+            match_id = candidate.get('id')
+            if match_id:
+                update_media_item(match_id, fall_back_to_single_scraper=True)
+                logging.debug(f"Enabled single scraper fallback for related item ID: {match_id} ({candidate.get('title')})")
+        except Exception as iter_err:
+            logging.error(f"Error while streaming candidate items for single scraper fallback: {iter_err}")
+
 @retry_on_db_lock()
 def update_blacklisted_date(item_id: int, blacklisted_date: datetime | None):
     conn = get_db_connection()

--- a/queues/adding_queue.py
+++ b/queues/adding_queue.py
@@ -15,6 +15,108 @@ from .torrent_processor import TorrentProcessor
 from .media_matcher import MediaMatcher
 from database.torrent_tracking import update_adding_error
 
+
+def torrent_has_other_active_owner(torrent_id: str, exclude_item_id) -> bool:
+    """True if another media_items row still actively depends on this torrent_id.
+
+    Debrid season-pack sibling reuse (torrent_processor.py's _check_sibling_debrid_pack)
+    means multiple episodes can now legitimately share the same torrent_id — something
+    that never happened before that fix, since every debrid torrent used to belong to
+    exactly one item. Callers that remove a torrent from the debrid service in response
+    to *this* item's own failure (no matching files, filter match, failed playability
+    check, etc.) must check this first: removing a still-needed shared pack breaks every
+    sibling relying on it, even though only one of them actually failed.
+    """
+    if not torrent_id or str(torrent_id).startswith('nzb:'):
+        return False
+    try:
+        from database import get_db_connection
+        conn = get_db_connection()
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM media_items WHERE filled_by_torrent_id=? AND id!=? "
+                "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 1",
+                (torrent_id, exclude_item_id)
+            ).fetchone()
+        finally:
+            conn.close()
+        return row is not None
+    except Exception as e:
+        logging.warning(f"Could not check for other owners of torrent {torrent_id}: {e} — assuming shared, skipping removal to be safe")
+        return True
+
+
+def remove_unwanted_torrent(torrent_id: str, is_nzb: bool = False, debrid_provider=None, removal_reason: str = "Removed due to unwanted media item"):
+    """
+    Remove an unwanted torrent from the debrid service and track the removal.
+
+    Args:
+        torrent_id: ID of the torrent to remove. May be an 'nzb:'-prefixed or bare
+            cli_mount job ID rather than a real debrid torrent ID — pass is_nzb=True
+            (or use the 'nzb:' prefix) so it's routed to cli_mount instead of the
+            debrid provider.
+        is_nzb: True if torrent_id identifies a cli_mount NZB job, not a debrid torrent.
+        debrid_provider: Provider instance to use; fetched fresh via get_debrid_provider()
+            if not supplied (callers that already hold one, e.g. AddingQueue, should pass
+            it to avoid a redundant re-init).
+    """
+    if not torrent_id:
+        logging.warning("Attempted to remove torrent with empty ID")
+        return
+
+    # NZB job IDs are never valid debrid torrent IDs — calling
+    # get_torrent_info/remove_torrent on one 404s against the debrid provider.
+    # Cancel the cli_mount job instead.
+    if is_nzb or str(torrent_id).startswith('nzb:'):
+        job_hash = torrent_id[4:] if str(torrent_id).startswith('nzb:') else torrent_id
+        try:
+            from usenet.climount_client import get_climount_client
+            get_climount_client().remove_nzb(job_hash)
+            logging.info(f"Cancelled unwanted NZB job {job_hash}")
+        except Exception as e:
+            logging.warning(f"Could not cancel NZB job {job_hash}: {e}")
+        return
+
+    if debrid_provider is None:
+        debrid_provider = get_debrid_provider()
+
+    hash_value = None # Initialize hash_value
+    try:
+        # Get torrent info before removal to record hash
+        try:
+            info = debrid_provider.get_torrent_info(torrent_id)
+            if info:
+                hash_value = info.get('hash', '').lower()
+                if hash_value:
+                    from database.not_wanted_magnets import add_to_not_wanted
+                    try:
+                        add_to_not_wanted(hash_value)
+                        logging.info(f"Added hash {hash_value} to not wanted list")
+                    except Exception as e:
+                        logging.error(f"Failed to add to not wanted list: {str(e)}")
+        except Exception as e:
+            logging.warning(f"Could not get torrent info before removal: {str(e)}")
+
+        # Remove the torrent with a descriptive reason
+        debrid_provider.remove_torrent(
+            torrent_id,
+            removal_reason=removal_reason
+        )
+        logging.info(f"Successfully removed unwanted torrent {torrent_id}")
+
+        # Update tracking record with adding error (use hash if available)
+        if hash_value:
+            try:
+                update_adding_error(hash_value)
+            except Exception as e:
+                logging.debug(f"Failed to update tracking record for adding error: {str(e)}")
+        else:
+             logging.warning(f"Could not update adding error count as hash was not found for torrent {torrent_id}")
+
+    except Exception as e:
+        logging.error(f"Failed to remove unwanted torrent {torrent_id}: {str(e)}", exc_info=True)
+
+
 class AddingQueue:
     """Manages the queue of items being added to the debrid service"""
     
@@ -94,98 +196,17 @@ class AddingQueue:
             logging.error("Attempted to remove item without ID from queue")
         
     def _torrent_has_other_active_owner(self, torrent_id: str, exclude_item_id) -> bool:
-        """True if another media_items row still actively depends on this torrent_id.
-
-        Debrid season-pack sibling reuse (torrent_processor.py's _check_sibling_debrid_pack)
-        means multiple episodes can now legitimately share the same torrent_id — something
-        that never happened before that fix, since every debrid torrent used to belong to
-        exactly one item. Callers that remove a torrent from the debrid service in response
-        to *this* item's own failure (no matching files, filter match, etc.) must check this
-        first: removing a still-needed shared pack breaks every sibling relying on it, even
-        though only one of them actually failed.
-        """
-        if not torrent_id or str(torrent_id).startswith('nzb:'):
-            return False
-        try:
-            from database import get_db_connection
-            conn = get_db_connection()
-            try:
-                row = conn.execute(
-                    "SELECT 1 FROM media_items WHERE filled_by_torrent_id=? AND id!=? "
-                    "AND state IN ('Adding','Checking','Collected','Upgrading') LIMIT 1",
-                    (torrent_id, exclude_item_id)
-                ).fetchone()
-            finally:
-                conn.close()
-            return row is not None
-        except Exception as e:
-            logging.warning(f"Could not check for other owners of torrent {torrent_id}: {e} — assuming shared, skipping removal to be safe")
-            return True
+        return torrent_has_other_active_owner(torrent_id, exclude_item_id)
 
     def remove_unwanted_torrent(self, torrent_id: str, is_nzb: bool = False):
-        """
-        Remove an unwanted torrent from the debrid service and track the removal
+        """Remove an unwanted torrent from the debrid service and track the removal."""
+        remove_unwanted_torrent(
+            torrent_id,
+            is_nzb=is_nzb,
+            debrid_provider=self.debrid_provider,
+            removal_reason="Removed due to no matching files for media item"
+        )
 
-        Args:
-            torrent_id: ID of the torrent to remove. May be an 'nzb:'-prefixed or bare
-                cli_mount job ID rather than a real debrid torrent ID — pass is_nzb=True
-                (or use the 'nzb:' prefix) so it's routed to cli_mount instead of the
-                debrid provider.
-            is_nzb: True if torrent_id identifies a cli_mount NZB job, not a debrid torrent.
-        """
-        if not torrent_id:
-            logging.warning("Attempted to remove torrent with empty ID")
-            return
-
-        # NZB job IDs are never valid debrid torrent IDs — calling
-        # get_torrent_info/remove_torrent on one 404s against the debrid provider.
-        # Cancel the cli_mount job instead.
-        if is_nzb or str(torrent_id).startswith('nzb:'):
-            job_hash = torrent_id[4:] if str(torrent_id).startswith('nzb:') else torrent_id
-            try:
-                from usenet.climount_client import get_climount_client
-                get_climount_client().remove_nzb(job_hash)
-                logging.info(f"Cancelled unwanted NZB job {job_hash}")
-            except Exception as e:
-                logging.warning(f"Could not cancel NZB job {job_hash}: {e}")
-            return
-
-        hash_value = None # Initialize hash_value
-        try:
-            # Get torrent info before removal to record hash
-            try:
-                info = self.debrid_provider.get_torrent_info(torrent_id)
-                if info:
-                    hash_value = info.get('hash', '').lower()
-                    if hash_value:
-                        from database.not_wanted_magnets import add_to_not_wanted
-                        try:
-                            add_to_not_wanted(hash_value)
-                            logging.info(f"Added hash {hash_value} to not wanted list")
-                        except Exception as e:
-                            logging.error(f"Failed to add to not wanted list: {str(e)}")
-            except Exception as e:
-                logging.warning(f"Could not get torrent info before removal: {str(e)}")
-                
-            # Remove the torrent with a descriptive reason
-            self.debrid_provider.remove_torrent(
-                torrent_id,
-                removal_reason="Removed due to no matching files for media item"
-            )
-            logging.info(f"Successfully removed unwanted torrent {torrent_id}")
-            
-            # Update tracking record with adding error (use hash if available)
-            if hash_value:
-                try:
-                    update_adding_error(hash_value)
-                except Exception as e:
-                    logging.debug(f"Failed to update tracking record for adding error: {str(e)}")
-            else:
-                 logging.warning(f"Could not update adding error count as hash was not found for torrent {torrent_id}")
-            
-        except Exception as e:
-            logging.error(f"Failed to remove unwanted torrent {torrent_id}: {str(e)}", exc_info=True)
-                
     def process(self, queue_manager: Any, ignore_upgrade_lock: bool = False) -> bool:
         """
         Process items in the queue
@@ -939,37 +960,9 @@ class AddingQueue:
 
             if not fall_back_to_single_scraper and get_setting('Scraping', 'fallback_to_single_enabled', default=True):
                 logging.info(f"Falling back to single scraper for {item_identifier} due to error: {error}")
-                if item_id: update_media_item(item_id, fall_back_to_single_scraper=True)
-
-                # Update related items (keep existing logic)
-                if item_id and item.get('type') == 'episode':
-                    series_title = item.get('series_title', '') or item.get('title', '')
-                    season = item.get('season') or item.get('season_number')
-                    current_episode = item.get('episode') or item.get('episode_number')
-                    version = item.get('version')
-
-                    # Stream items from DB to avoid loading entire table into memory
-                    from database import stream_all_media_items  # Local import
-
-                    for candidate in stream_all_media_items(state=None, media_type='episode'):
-                        try:
-                            if ((candidate.get('series_title', '') or candidate.get('title', '')) != series_title):
-                                continue
-                            if (candidate.get('season') or candidate.get('season_number')) != season:
-                                continue
-                            if (candidate.get('episode') or candidate.get('episode_number', -1)) <= current_episode:
-                                continue
-                            if candidate.get('version') != version:
-                                continue
-                            if candidate.get('fall_back_to_single_scraper'):
-                                continue
-
-                            match_id = candidate.get('id')
-                            if match_id:
-                                update_media_item(match_id, fall_back_to_single_scraper=True)
-                                logging.debug(f"Enabled single scraper fallback for related item ID: {match_id} ({candidate.get('title')})")
-                        except Exception as iter_err:
-                            logging.error(f"Error while streaming candidate items for single scraper fallback: {iter_err}")
+                if item_id:
+                    from database.database_writing import enable_fallback_to_single_scraper
+                    enable_fallback_to_single_scraper({**item, 'id': item_id}, reason=f"Adding-queue error: {error}")
 
                 queue_manager.move_to_scraping(item, "Adding")
                 # move_to_scraping handles removal from self.items

--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -6196,6 +6196,29 @@ class ProgramRunner:
                 except Exception:
                     pass
 
+                # An item reaches Checking as soon as its NZB job is *matched*
+                # (file list known from NZB/par2 metadata), not once the job has
+                # actually finished downloading - unlike Symlinked/Local mode
+                # (confirmed working, left untouched), Plex mode's file-discovery
+                # here has no extra settle/retry delay before the probe fires, so
+                # it's more exposed to catching the file mid-download. The
+                # readability probe samples a random point 20-80% into the file's
+                # duration - if that point hasn't downloaded yet, the read fails
+                # cleanly (not an inconclusive/timeout case), so the probe's own
+                # conservative "assume readable" fallback never catches this and
+                # a genuinely-fine file gets wrongly rejected. Defer the probe
+                # until cli_mount reports the job at/near complete instead of
+                # judging a file that isn't fully there yet.
+                try:
+                    job_hash = torrent_id[4:] if torrent_id.startswith('nzb:') else torrent_id
+                    from usenet.climount_client import get_climount_client
+                    job_status = get_climount_client().get_job_status(job_hash)
+                    if job_status and job_status.get('state') != 'completed' and job_status.get('progress', 100) < 95:
+                        logging.info(f"[ffprobe] Deferring {probe_key} for item {item.get('id')} — job {job_hash} still downloading ({job_status.get('progress', 0)}%)")
+                        return True
+                except Exception as e:
+                    logging.debug(f"[ffprobe] Could not check job download progress for {torrent_id}: {e}")
+
             logging.info(f"[ffprobe] Running playability check ({probe_key}) on '{actual_file_path}'")
             from usenet.repair_engine import _verify_file_readable
             if _verify_file_readable(actual_file_path):

--- a/queues/torrent_processor.py
+++ b/queues/torrent_processor.py
@@ -549,6 +549,7 @@ class TorrentProcessor:
         def _try_reuse(torrent_id: str, check_title: str, magnet: Optional[str]) -> Optional[Tuple]:
             if not _is_pack_title(check_title):
                 return None
+            from utilities.session_bad_torrents import is_torrent_known_unplayable
             for provider in self._providers:
                 try:
                     info = provider.get_torrent_info(torrent_id)
@@ -566,13 +567,24 @@ class TorrentProcessor:
                 # pack that actually has it.
                 if _ep_pattern is not None:
                     _files = info.get('files', [])
-                    _has_episode = any(
-                        _ep_pattern.search(f.get('path') or f.get('filename') or '')
-                        for f in _files
-                    )
-                    if not _has_episode:
+                    _matched_file = None
+                    for f in _files:
+                        _fpath = f.get('path') or f.get('filename') or ''
+                        if _ep_pattern.search(_fpath):
+                            _matched_file = _fpath
+                            break
+                    if _matched_file is None:
                         logging.info(f"[{item.get('title', 'Unknown')}] Sibling pack {torrent_id} does not "
                                      f"contain S{_season:02d}E{_episode:02d} — not reusing, trying next candidate")
+                        return None
+                    # Per-file, not per-torrent: a season pack can be a mix of playable
+                    # and broken files, so only skip the specific file already proven
+                    # dead this session - a different file in the same torrent may be
+                    # completely fine.
+                    if is_torrent_known_unplayable(torrent_id, _matched_file):
+                        logging.info(f"[{item.get('title', 'Unknown')}] Sibling pack {torrent_id}'s "
+                                     f"S{_season:02d}E{_episode:02d} file already confirmed unplayable "
+                                     f"this session — not reusing, trying next candidate")
                         return None
                 self.debrid_provider = provider
                 info = dict(info)
@@ -795,6 +807,7 @@ class TorrentProcessor:
     def _process_nzb_result(self, result: Dict, item: Optional[Dict] = None, adding_queue_items: Optional[list] = None) -> Optional[Tuple]:
         """Submit an NZB result to cli_mount and return a synthetic torrent_info tuple."""
         from usenet.climount_client import get_climount_client, reset_climount_client
+        from utilities.session_bad_torrents import has_any_known_unplayable_file
         reset_climount_client()
         client = get_climount_client()
 
@@ -856,18 +869,26 @@ class TorrentProcessor:
                                     continue
                             except Exception:
                                 pass  # unknown due to error - don't block a legitimate reuse
-                        if _is_pack and _mem_is_pack:
-                            logging.info(f'[{item_identifier}] [Memory] Season pack already submitted for S{_season:02d} '
-                                         f'(job={_mem_job}) — reusing')
-                            return {'id': _mem_id, 'filename': title, 'original_title': title,
-                                    'status': 'downloading', 'files': [], 'progress': 0,
-                                    '_provider': 'cli_mount', '_is_nzb': True, '_nzb_url': nzb_url}, nzb_url, result
-                        elif not _is_pack and _mem_is_pack:
-                            logging.info(f'[{item_identifier}] [Memory] Season pack already submitted for S{_season:02d} '
-                                         f'(job={_mem_job}) — skipping individual episode submission')
-                            return {'id': _mem_id, 'filename': title, 'original_title': title,
-                                    'status': 'downloading', 'files': [], 'progress': 0,
-                                    '_provider': 'cli_mount', '_is_nzb': True, '_nzb_url': nzb_url}, nzb_url, result
+                        if (_is_pack and _mem_is_pack) or (not _is_pack and _mem_is_pack):
+                            # Job-level check, not per-file: unlike the debrid reuse path, the
+                            # specific file within this job for THIS episode isn't resolved yet
+                            # at this point (that happens later, downstream) - so this can only
+                            # block reuse of the whole job, not a single file within it.
+                            if has_any_known_unplayable_file(_mem_job):
+                                logging.info(f'[{item_identifier}] [Memory] Sibling job {_mem_job} has a file already '
+                                             f'confirmed unplayable this session — not reusing')
+                            elif _is_pack:
+                                logging.info(f'[{item_identifier}] [Memory] Season pack already submitted for S{_season:02d} '
+                                             f'(job={_mem_job}) — reusing')
+                                return {'id': _mem_id, 'filename': title, 'original_title': title,
+                                        'status': 'downloading', 'files': [], 'progress': 0,
+                                        '_provider': 'cli_mount', '_is_nzb': True, '_nzb_url': nzb_url}, nzb_url, result
+                            else:
+                                logging.info(f'[{item_identifier}] [Memory] Season pack already submitted for S{_season:02d} '
+                                             f'(job={_mem_job}) — skipping individual episode submission')
+                                return {'id': _mem_id, 'filename': title, 'original_title': title,
+                                        'status': 'downloading', 'files': [], 'progress': 0,
+                                        '_provider': 'cli_mount', '_is_nzb': True, '_nzb_url': nzb_url}, nzb_url, result
                         elif _is_pack and not _mem_is_pack:
                             # New result is a pack, existing job is individual — fall through to submit pack
                             break
@@ -912,29 +933,34 @@ class TorrentProcessor:
                                     _sibling_is_pack = False
                             except Exception:
                                 pass  # unknown due to error - don't block a legitimate reuse
-                        if _is_pack and _sibling_is_pack:
-                            # New result is a pack, existing job is a pack — reuse existing
+                        if (_is_pack and _sibling_is_pack) or (not _is_pack and _sibling_is_pack):
                             _existing_job = _sibling[0]
-                            _existing_file = title
-                            _existing_id = _existing_job[4:] if _existing_job.startswith('nzb:') else _existing_job
-                            logging.info(f'[{item_identifier}] Season pack already submitted for S{_season:02d} '
-                                         f'(job={_existing_job}) — reusing instead of duplicate submission')
-                            return {'id': _existing_id, 'filename': _existing_file,
-                                    'original_title': _existing_file, 'status': 'downloading',
-                                    'files': [], 'progress': 0,
-                                    '_provider': 'cli_mount', '_is_nzb': True,
-                                    '_nzb_url': nzb_url}, nzb_url, result
-                        elif not _is_pack and _sibling_is_pack:
-                            # New result is individual episode, existing job is a season pack — skip individual
-                            _existing_job = _sibling[0]
-                            _existing_id = _existing_job[4:] if _existing_job.startswith('nzb:') else _existing_job
-                            logging.info(f'[{item_identifier}] Season pack already submitted for S{_season:02d} '
-                                         f'(job={_existing_job}) — skipping individual episode submission')
-                            return {'id': _existing_id, 'filename': title,
-                                    'original_title': title, 'status': 'downloading',
-                                    'files': [], 'progress': 0,
-                                    '_provider': 'cli_mount', '_is_nzb': True,
-                                    '_nzb_url': nzb_url}, nzb_url, result
+                            # Job-level check, not per-file — see matching comment in the
+                            # in-memory check above.
+                            if has_any_known_unplayable_file(_existing_job):
+                                logging.info(f'[{item_identifier}] Sibling job {_existing_job} has a file already '
+                                             f'confirmed unplayable this session — not reusing, submitting fresh')
+                            elif _is_pack:
+                                # New result is a pack, existing job is a pack — reuse existing
+                                _existing_file = title
+                                _existing_id = _existing_job[4:] if _existing_job.startswith('nzb:') else _existing_job
+                                logging.info(f'[{item_identifier}] Season pack already submitted for S{_season:02d} '
+                                             f'(job={_existing_job}) — reusing instead of duplicate submission')
+                                return {'id': _existing_id, 'filename': _existing_file,
+                                        'original_title': _existing_file, 'status': 'downloading',
+                                        'files': [], 'progress': 0,
+                                        '_provider': 'cli_mount', '_is_nzb': True,
+                                        '_nzb_url': nzb_url}, nzb_url, result
+                            else:
+                                # New result is individual episode, existing job is a season pack — skip individual
+                                _existing_id = _existing_job[4:] if _existing_job.startswith('nzb:') else _existing_job
+                                logging.info(f'[{item_identifier}] Season pack already submitted for S{_season:02d} '
+                                             f'(job={_existing_job}) — skipping individual episode submission')
+                                return {'id': _existing_id, 'filename': title,
+                                        'original_title': title, 'status': 'downloading',
+                                        'files': [], 'progress': 0,
+                                        '_provider': 'cli_mount', '_is_nzb': True,
+                                        '_nzb_url': nzb_url}, nzb_url, result
                         elif _is_pack and not _sibling_is_pack:
                             # New result is a pack, existing jobs are individual episodes.
                             # Cancel the individual cli_mount jobs so we don't end up with

--- a/utilities/cloudflare_bypass.py
+++ b/utilities/cloudflare_bypass.py
@@ -33,6 +33,40 @@ _MAX_COOKIE_AGE_SECONDS = 2 * 60 * 60  # 2 hours
 _refresh_lock = Lock()
 
 
+def _clean_stale_x11_sockets():
+    """Remove orphaned /tmp/.X11-unix/X<N> sockets left behind by a Xvfb
+    process that died abnormally (crash, container restart, kill) without
+    unlinking its own socket file. A genuinely running Xvfb always has both
+    the socket AND a matching /tmp/.X<N>-lock file (containing its PID); a
+    socket with no matching lock file is unambiguously dead. Left alone,
+    every subsequent Display() attempt collides with the same stale socket
+    and fails with "server already running" forever, since nothing else
+    ever cleans it up.
+    """
+    x11_dir = '/tmp/.X11-unix'
+    if not os.path.isdir(x11_dir):
+        return
+    try:
+        for name in os.listdir(x11_dir):
+            if not name.startswith('X'):
+                continue
+            try:
+                display_nr = int(name[1:])
+            except ValueError:
+                continue
+            lock_path = f'/tmp/.X{display_nr}-lock'
+            if os.path.exists(lock_path):
+                continue  # a real lock file exists - assume it's live, don't touch it
+            stale_socket = os.path.join(x11_dir, name)
+            try:
+                os.remove(stale_socket)
+                logging.info(f"[CloudflareBypass] Removed stale X11 socket {stale_socket} (no matching lock file)")
+            except OSError as e:
+                logging.debug(f"[CloudflareBypass] Could not remove stale X11 socket {stale_socket}: {e}")
+    except Exception as e:
+        logging.debug(f"[CloudflareBypass] Error scanning {x11_dir} for stale sockets: {e}")
+
+
 def _load_cache() -> Optional[Dict]:
     try:
         with open(_CACHE_FILE, 'r') as f:
@@ -73,6 +107,7 @@ def _solve_challenge(url: str, timeout_seconds: int = 30) -> Optional[Dict]:
     display = None
     try:
         from pyvirtualdisplay import Display
+        _clean_stale_x11_sockets()
         display = Display(visible=False, size=(1280, 800))
         display.start()
     except ImportError:
@@ -150,8 +185,10 @@ def _solve_challenge(url: str, timeout_seconds: int = 30) -> Optional[Dict]:
         if display:
             try:
                 display.stop()
-            except Exception:
-                pass
+            except Exception as e:
+                # Swallowing this silently is exactly what let stale sockets
+                # accumulate unnoticed - log it so a failed cleanup is visible.
+                logging.debug(f"[CloudflareBypass] display.stop() failed (may leave a stale X11 socket): {e}")
 
 
 def get_clearance(domain: str, challenge_url: str, force_refresh: bool = False) -> Optional[Dict]:

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1191,6 +1191,17 @@ def _reject_unplayable_source(item: Dict[str, Any], is_nzb: bool) -> None:
     except Exception as e:
         logging.warning(f"[ffprobe] Failed to add unplayable source to not-wanted: {e}")
 
+    # not_wanted only stops a *fresh scrape* from picking this release again -
+    # sibling-reuse (debrid and NZB) picks a candidate straight from a known
+    # torrent_id without ever consulting it, so without this a sibling episode
+    # would keep reusing (and re-failing) this exact torrent for the rest of
+    # the season. See utilities/session_bad_torrents.py.
+    try:
+        from utilities.session_bad_torrents import mark_torrent_unplayable
+        mark_torrent_unplayable(item.get('filled_by_torrent_id'), item.get('filled_by_file'))
+    except Exception as e:
+        logging.warning(f"[ffprobe] Failed to mark torrent as known-unplayable: {e}")
+
     try:
         update_media_item_state(item.get('id'), 'Wanted')
     except Exception as e:

--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -1202,6 +1202,38 @@ def _reject_unplayable_source(item: Dict[str, Any], is_nzb: bool) -> None:
     except Exception as e:
         logging.warning(f"[ffprobe] Failed to mark torrent as known-unplayable: {e}")
 
+    # Actually remove the dead torrent/NZB job from the debrid service / cli_mount,
+    # not just blacklist it locally - otherwise it sits there forever taking up
+    # space even though nothing will ever reuse it. Skipped if another item still
+    # actively depends on the same torrent_id (a shared season pack where only one
+    # sibling episode's file was bad) - removing it would break that sibling too.
+    try:
+        torrent_id = item.get('filled_by_torrent_id')
+        if torrent_id:
+            from queues.adding_queue import torrent_has_other_active_owner, remove_unwanted_torrent
+            if not torrent_has_other_active_owner(torrent_id, item.get('id')):
+                remove_unwanted_torrent(
+                    torrent_id,
+                    is_nzb=is_nzb,
+                    removal_reason="Removed due to failed ffprobe playability check"
+                )
+            else:
+                logging.info(f"[ffprobe] Torrent {torrent_id} still needed by other episode(s) sharing this pack — not removing")
+    except Exception as e:
+        logging.warning(f"[ffprobe] Failed to remove unplayable torrent from debrid service: {e}")
+
+    # An episode stuck in forced multi-pack scraping (queues/scraping_queue.py,
+    # any scrape >7 days old) that fails here via ffprobe - rather than the
+    # Adding-queue matching-failure path that normally sets this flag - would
+    # otherwise never get single-episode candidates and could loop on this
+    # rejection indefinitely if the only multi-pack result available keeps
+    # getting filtered out for an unrelated reason.
+    try:
+        from database.database_writing import enable_fallback_to_single_scraper
+        enable_fallback_to_single_scraper(item, reason="ffprobe playability check failed")
+    except Exception as e:
+        logging.warning(f"[ffprobe] Failed to enable single scraper fallback: {e}")
+
     try:
         update_media_item_state(item.get('id'), 'Wanted')
     except Exception as e:

--- a/utilities/session_bad_torrents.py
+++ b/utilities/session_bad_torrents.py
@@ -1,0 +1,64 @@
+"""In-process registry of (torrent/NZB job ID, filename) pairs that ffprobe
+has confirmed are unplayable this session. Sibling-reuse (both the debrid
+and NZB paths) picks a candidate purely by "does this pack contain my
+episode" - it has no awareness that a sibling episode already proved a
+specific file inside this exact torrent is dead moments ago via a
+playability check, so without this it would keep reusing (and re-failing)
+that same file for every remaining sibling that maps to it.
+
+Keyed per-file, not per-torrent: a season pack can be a mix of playable and
+broken files (partial corruption, mismuxed episodes, etc.), so one bad file
+must not block reuse of the same torrent for a *different* file that's
+actually fine.
+
+Deliberately in-memory only, not persisted: this only needs to cover
+already-in-flight items for the remainder of this run. Separately,
+add_to_not_wanted/add_to_not_wanted_urls (called alongside this) already
+handles the permanent, cross-restart blacklist for fresh scrapes.
+"""
+import os
+import threading
+from typing import Optional
+
+_lock = threading.Lock()
+_bad_files: set[tuple[str, str]] = set()
+
+
+def _key(torrent_id, filename) -> Optional[tuple]:
+    if not torrent_id or not filename:
+        return None
+    return (str(torrent_id), os.path.basename(str(filename)))
+
+
+def mark_torrent_unplayable(torrent_id, filename=None) -> None:
+    """filename should be the specific file within torrent_id that failed
+    (item['filled_by_file']). Kept optional for backwards compatibility, but
+    without it this can't scope to just that file — callers should always
+    pass it when available."""
+    key = _key(torrent_id, filename)
+    if key is None:
+        return
+    with _lock:
+        _bad_files.add(key)
+
+
+def is_torrent_known_unplayable(torrent_id, filename) -> bool:
+    key = _key(torrent_id, filename)
+    if key is None:
+        return False
+    with _lock:
+        return key in _bad_files
+
+
+def has_any_known_unplayable_file(torrent_id) -> bool:
+    """Job-level check for reuse sites (NZB) that decide whether to reuse a
+    job before the specific file within it is resolved, so a per-file check
+    isn't possible at that point - blocks reuse if ANY file in this job has
+    been proven dead this session. Coarser than is_torrent_known_unplayable
+    (a genuinely mixed pack could over-block a fine sibling file), but it's
+    what the NZB reuse decision point can actually act on."""
+    if not torrent_id:
+        return False
+    tid = str(torrent_id)
+    with _lock:
+        return any(t == tid for t, _ in _bad_files)


### PR DESCRIPTION
## Summary

FlixPatrol Top-10 scraping (Discover-page trending data) uses `utilities/cloudflare_bypass.py`'s `_solve_challenge()` to solve Cloudflare's managed challenge via a real, headed Chrome under a virtual display (Xvfb, via `patchright` — not stock Playwright). A user shared a startup debug log showing 272 consecutive failed launch attempts, each ending in `BrowserType.launch_persistent_context: Target page, context or browser has been closed`.

## Root cause (confirmed live against a running instance)

Xvfb does not reliably unlink its own `/tmp/.X11-unix/X<N>` socket file on exit — verified directly: even a clean `display.stop()` leaves the socket behind (the matching `/tmp/.X<N>-lock` file gets removed, but the socket persists). Found two real orphaned sockets sitting in `/tmp/.X11-unix/` on the live instance (one from an earlier boot, one from a same-night restart), with zero Xvfb processes actually running. Every subsequent `Display()` call then collides with these ghost sockets and fails with "server already running," permanently, since nothing ever cleans them up.

## Fix

`_clean_stale_x11_sockets()` in `utilities/cloudflare_bypass.py` — before starting a new `Display()`, remove any `/tmp/.X11-unix/X<N>` socket that has no matching `/tmp/.X<N>-lock` file. A live Xvfb always has both, so a socket without a lock file is unambiguously dead and safe to remove. Also stopped silently swallowing `display.stop()` failures, since that's exactly the kind of failure that let stale sockets go unnoticed in the first place.

## Test plan

- [x] Confirmed live on a running instance: found the exact two stale sockets described above (`X1`, `X2`), zero live Xvfb processes
- [x] Ran `_clean_stale_x11_sockets()` directly — both stale sockets removed
- [x] Ran a real `Display()` start/stop cycle immediately after — succeeded cleanly (`:1`)
- [x] Ran 3 consecutive `Display()` start/stop cycles back to back with the cleanup wired in — zero collisions, confirming the fix holds up across repeated use, not just the first call after a restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also included: fixed a related font-download warning

While digging into an unrelated font-related log flood on the same instance,
found `overlays/font_manager.py` had a system-font fallback (`DejaVuSans-Bold`)
that could never actually succeed - the `fonts-dejavu-core` package was
never installed in the image, so the local-file check always missed and
silently fell through to trying to download "DejaVuSans-Bold" from Google
Fonts, which isn't a real Google Fonts family and always failed. Added the
missing package (~2.3MB installed, same reasoning as the existing
fonts-liberation/fonts-unifont packages already in the same apt-get line).

## Also included: sibling-reuse now respects ffprobe-proven-dead torrents

Unrelated to the Xvfb/font fixes above, bundled into this PR at the user's request.

`not_wanted` blacklisting (hash/URL keyed, set by `_reject_unplayable_source` when
an ffprobe playability check fails) only stops a **fresh scrape** from re-picking
a bad release. Sibling-reuse (both the debrid and NZB paths) picks a candidate
straight from a known `torrent_id`/job without ever consulting that blacklist, so
a single dead release could get reused — and re-fail ffprobe — for every remaining
sibling episode in a season, looping indefinitely.

Added `utilities/session_bad_torrents.py`, an in-memory (not persisted) registry
of `(torrent_id, filename)` pairs proven unplayable this session, populated
alongside the existing `not_wanted` blacklisting in `_reject_unplayable_source`.

- **Debrid** sibling-reuse (`_try_reuse` in `queues/torrent_processor.py`) checks
  it **per-file**, since it already resolves the specific matching file within a
  candidate pack before deciding to reuse it — a mixed pack can have some playable
  and some broken files, so one bad file shouldn't block reuse of the torrent for
  a different, fine file.
- **NZB** sibling-reuse (`_process_nzb_result`, same file) checks it **per-job**
  instead, since the NZB reuse decision happens before the specific file within a
  job is resolved — a coarser check, but the finest one actually available at that
  decision point.

Confirmed live: reused an ffprobe-confirmed-dead torrent_id across a Law & Order
SVU S08 season pack (all 22 episodes cycling through the same dead
"newserial.tv" release), deployed the fix, and watched the season converge
cleanly afterward — 18+ of 22 episodes collected on real, working releases, with
no further reuse of the proven-dead torrent_id.

## Also included: dead torrents now actually get removed from the debrid service, and episode 1 can no longer get permanently stuck

Two more gaps found while live-testing the sibling-reuse fix above.

**Dead torrents were only ever blacklisted locally, never removed.** When an
ffprobe playability check fails, `_reject_unplayable_source` blacklisted the
torrent's hash/URL (stopping future scrapes from re-picking it) but never
actually removed it from the debrid service or cancelled the cli_mount NZB
job — unlike the existing "no matching files" Adding-queue failure path,
which does. Dead torrents were sitting in the debrid account indefinitely.
Fixed by extracting the existing `_torrent_has_other_active_owner` /
`remove_unwanted_torrent` methods out of `AddingQueue` into module-level
functions in `queues/adding_queue.py` (identical bodies — the class methods
now just delegate to them), so the ffprobe path can reuse the exact same
sibling-owner check before removing: a torrent still actively shared by
another episode's pack is left alone; only one nothing else depends on gets
removed.

**Episode 1 could get stuck in forced multi-pack mode forever.**
`fall_back_to_single_scraper` (which disables forced multi-pack scraping for
scrapes older than 7 days) only ever propagated from one episode's failure
to *later* episode numbers — so the earliest episode of a show could never
inherit it, since nothing "before" episode 1 can ever trigger that
propagation. If the only multi-pack candidate available for episode 1
specifically keeps getting filtered out, it could loop indefinitely with zero
usable results. Extracted the propagation logic into a shared
`enable_fallback_to_single_scraper()` in `database/database_writing.py`,
dropped the episode-ordering restriction, and now also call it from the
ffprobe-rejection path (previously only Adding-queue matching failures could
trigger it).

Confirmed live: on the next real ffprobe failure after deploying, the
sibling-owner check correctly skipped removal for a torrent still shared by
another episode, and the fallback flag was enabled for the failing item.

## Also included: Plex-mode ffprobe check deferred until an NZB job actually finishes downloading

A user reported ffprobe rejecting an NZB file that played fine moments
later when clicked manually. Root cause: an item reaches `Checking` as soon
as its NZB job is *matched* (file list known from NZB/par2 metadata), not
once the job has actually finished downloading. The readability probe
samples a random point 20-80% into the file's duration - if that point
hasn't downloaded yet, the read fails cleanly (not an inconclusive/timeout
case), so the probe's existing conservative "assume readable" fallback
never catches it, and a genuinely-fine, still-downloading file gets wrongly
rejected and re-scraped.

Plex mode's file-discovery (`task_check_plex_files`, 60s poll) has no
extra settle/retry delay before the probe fires, unlike Symlinked/Local
mode's webhook path - so it's more exposed to catching a file mid-download.
**Symlinked/Local mode is confirmed working (tested extensively tonight)
and left untouched** - this is scoped to Plex mode only until logs from the
reporting user confirm the same root cause applies there.

Uses the existing `get_job_status()` (`usenet/climount_client.py`, already
used elsewhere for `is_nzb_job_alive`) to check download progress before
probing - defers (does not reject) while the job is still downloading and
under 95% complete, letting the next 60s poll re-evaluate once more has
downloaded.
