### PR TITLE
Auto-import content added to the debrid mount outside cli_debrid

### DIFF
--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -335,6 +335,7 @@ class ProgramRunner:
             'task_repair_broken_debrids': 6 * 60 * 60, # Run every 6 hours
             'task_sync_cli_mount_changes': 5 * 60, # Run every 5 minutes
             'task_push_pending_climount_tags': 5 * 60, # Run every 5 minutes — catches tags changed on cli_debrid side only
+            'task_scan_mount_for_external_adds': 15 * 60, # Run every 15 minutes (disabled by default)
             'task_nzb_health_check': 10,             # Run every 10 seconds — polls NZB items in Adding
             'task_nzb_playback_repair_completion': 15, # Confirm only already-started playback repairs
             'task_nzb_playback_cleanup_retry': 20 * 60, # Background retry for old-file cleanup deferred after finalization
@@ -497,6 +498,7 @@ class ProgramRunner:
             'task_refresh_library_size_cache',
             # --- END EDIT ---
             'task_process_standalone_plex_removals', # Add to dynamic intervals as well
+            'task_scan_mount_for_external_adds',
             # --- START EDIT: Add media analysis task to dynamic intervals ---
             'task_analyze_media_files',
             # --- END EDIT ---
@@ -695,6 +697,22 @@ class ProgramRunner:
                  if 'task_verify_symlinked_files' in self.enabled_tasks and not is_symlink_toggled_on:
                      self.enabled_tasks.remove('task_verify_symlinked_files')
                      logging.info("Disabled symlink verification task as no media server settings are configured.")
+
+        # Enable the external-add mount scan only in symlink mode and only when opted in.
+        # Picks up content added straight to the debrid account (DMM, provider UI) on
+        # setups whose mount provider has no library-update webhook.
+        _ext_scan_task = 'task_scan_mount_for_external_adds'
+        if (file_management_mode == 'Symlinked/Local'
+                and get_setting('File Management', 'scan_mount_for_external_adds', False)):
+            _is_ext_toggled_off = saved_states.get(self._normalize_task_name(_ext_scan_task), True) is False
+            if not _is_ext_toggled_off and _ext_scan_task not in self.enabled_tasks:
+                self.enabled_tasks.add(_ext_scan_task)
+                logging.info(f"Enabled '{_ext_scan_task}' based on File Management setting.")
+        else:
+            _is_ext_toggled_on = saved_states.get(self._normalize_task_name(_ext_scan_task), False) is True
+            if _ext_scan_task in self.enabled_tasks and not _is_ext_toggled_on:
+                self.enabled_tasks.remove(_ext_scan_task)
+                logging.info(f"Disabled '{_ext_scan_task}' as the setting is off or mode is not Symlinked/Local.")
 
 
         if get_setting('Debug', 'not_add_plex_watch_history_items_to_queue', False):
@@ -4889,6 +4907,28 @@ class ProgramRunner:
                                    'service_name': None, 'status_code': None, 'retry_count': 0}
                 self.resume_queue()
                 logging.info('[CMSync] Initial full sync complete — queue resumed')
+
+    def task_scan_mount_for_external_adds(self):
+        """Import content that appeared in the debrid mount without cli_debrid putting it there.
+
+        Covers mount providers with no library-update webhook (Decypharr, plain
+        rclone). Zurg calls /webhook/rclone via on_library_update instead, which
+        runs the same import pipeline.
+        """
+        from utilities.external_mount_scan import scan_mount_for_external_adds
+        try:
+            summary = scan_mount_for_external_adds()
+            if summary.get('skipped_reason'):
+                logging.debug(f"[ExternalScan] Skipped: {summary['skipped_reason']}")
+            elif summary.get('baselined'):
+                logging.info(f"[ExternalScan] Baselined {summary['baselined']} existing mount entries.")
+            elif summary.get('imported') or summary.get('failed'):
+                logging.info(
+                    f"[ExternalScan] Scanned {summary.get('entries_seen', 0)} entries — "
+                    f"imported {summary.get('imported', 0)}, failed {summary.get('failed', 0)}."
+                )
+        except Exception as e:
+            logging.error(f"[ExternalScan] Task error: {e}", exc_info=True)
 
     def task_push_pending_climount_tags(self):
         """Push tags for media_items rows whose tags changed on the cli_debrid

--- a/routes/program_operation_routes.py
+++ b/routes/program_operation_routes.py
@@ -1006,6 +1006,7 @@ def get_task_timings():
         'task_sync_cli_mount_changes',
         'task_repair_broken_nzbs',
         'task_repair_broken_debrids',
+        'task_scan_mount_for_external_adds',
     }
     _METADATA_TASKS = {
         'task_refresh_release_dates',

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -86,6 +86,7 @@ function togglePlexSection() {
     // Toggle path input fields and Plex symlink settings
     const originalFilesPath = document.getElementById('file management-original_files_path');
     const symlinkedFilesPath = document.getElementById('file management-symlinked_files_path');
+    const externalAddScan = document.getElementById('file management-scan_mount_for_external_adds');
     const plexSymlinkSettings = document.querySelectorAll('.symlink-plex-setting');
 
     if (fileManagementSelect) {
@@ -94,7 +95,9 @@ function togglePlexSection() {
         // Handle path fields
         const pathElements = [
             originalFilesPath?.closest('.settings-form-group'),
-            symlinkedFilesPath?.closest('.settings-form-group')
+            symlinkedFilesPath?.closest('.settings-form-group'),
+            // Symlink-mode only: the scan imports mount content by symlinking it
+            externalAddScan?.closest('.settings-form-group')
         ].filter(Boolean);
 
         pathElements.forEach(element => {

--- a/templates/task_timings.html
+++ b/templates/task_timings.html
@@ -498,6 +498,8 @@ function createTaskTile(taskName, taskData) {
             displayName = 'Check Local Files for Plex Update';
         } else if (taskName === 'task_refresh_library_size_cache') {
             displayName = 'Refresh Debrid Library Size';
+        } else if (taskName === 'task_scan_mount_for_external_adds') {
+            displayName = 'Scan Mount for External Adds';
         } else if (taskName === 'final_check_queue' || taskName === 'Final_check_queue') {
             displayName = 'Final Scrape';
         } else {
@@ -1240,6 +1242,7 @@ function tngDisplayName(taskName, info) {
     if (n === 'task_repair_broken_nzbs')         return 'Repair Broken NZBs';
     if (n === 'task_repair_broken_debrids')      return 'Repair Broken Debrids';
     if (n === 'task_backfill_nzb_torrent_ids')   return 'Backfill NZB Torrent IDs';
+    if (n === 'task_scan_mount_for_external_adds') return 'Scan Mount for External Adds';
     if (n === 'final_check_queue' || n === 'Final_check_queue') return 'Final Scrape';
     if (n.endsWith('_wanted')) n = n.replace('task_', '').replace('_wanted', '');
     else                       n = n.replace('task_', '');

--- a/utilities/external_mount_scan.py
+++ b/utilities/external_mount_scan.py
@@ -1,0 +1,305 @@
+"""
+Periodic scan of the debrid mount for content added outside cli_debrid.
+
+Symlink mode only. cli_debrid normally learns about new files because it put
+them there itself (Wanted -> Scraping -> Adding -> Checking). Content added
+straight to the debrid account by something else -- DMM, the provider's own
+web UI, a manual magnet -- shows up in the mount with nothing in the database
+pointing at it, so no symlink is created and the media server is never told.
+
+Zurg users get this handled by its on_library_update hook calling
+/webhook/rclone. Decypharr and plain rclone mounts have no such hook, so this
+task polls the mount instead and feeds anything new into the exact same
+pipeline the webhook uses (_run_rclone_to_symlink_task).
+
+First run records everything already in the mount as a baseline without
+importing it -- otherwise enabling this on an established library would mass
+import years of untracked content in one go. Delete the state file to
+re-baseline.
+"""
+
+import json
+import logging
+import os
+import time
+import uuid
+from typing import Dict, List, Set
+
+from utilities.settings import get_setting
+
+STATE_FILENAME = 'external_mount_scan_state.json'
+
+# Cap per run so a mount full of untracked folders can't spend hours in one
+# pass hammering the metadata APIs. The remainder is picked up next run.
+MAX_IMPORTS_PER_RUN = 25
+
+# A folder whose metadata lookup keeps failing shouldn't be retried forever.
+MAX_ATTEMPTS = 3
+RETRY_AFTER_SECONDS = 6 * 60 * 60
+
+
+def _state_path() -> str:
+    db_content_dir = os.environ.get('USER_DB_CONTENT', '/user/db_content')
+    return os.path.join(db_content_dir, STATE_FILENAME)
+
+
+def _load_state() -> Dict:
+    path = _state_path()
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError) as e:
+        logging.warning(f"[ExternalScan] Could not read state file {path}: {e}. Treating as empty.")
+        return {}
+
+
+def _save_state(state: Dict) -> None:
+    path = _state_path()
+    try:
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(state, f, indent=2)
+    except OSError as e:
+        logging.error(f"[ExternalScan] Could not write state file {path}: {e}")
+
+
+def _list_top_level(mount_path: str) -> List[str]:
+    """Top-level directory names only -- one directory listing, no recursive
+    walk. A recursive walk over a WebDAV-backed mount is far too expensive to
+    run on a timer.
+
+    Directories only: debrid mounts expose one folder per torrent (even
+    single-file ones), and _run_rclone_to_symlink_task rejects a non-directory
+    scan path outright.
+    """
+    try:
+        with os.scandir(mount_path) as it:
+            return [entry.name for entry in it
+                    if not entry.name.startswith('.') and entry.is_dir()]
+    except OSError as e:
+        logging.error(f"[ExternalScan] Could not list mount path '{mount_path}': {e}")
+        return []
+
+
+def _build_known_sets() -> tuple:
+    """Build in-memory lookups of what the DB already knows about.
+
+    This is only a fast pre-filter for the common 'already tracked' case. The
+    per-folder helpers the webhook uses do a full-table scan in Python each
+    call, which is fine for one webhook but not for thousands of folders per
+    run. Anything this filter does not positively identify still goes through
+    those authoritative helpers, so the semantics match the webhook exactly.
+    """
+    from database.core import get_db_connection
+    from database.database_reading import normalize_string_for_comparison
+
+    known_titles: Set[str] = set()
+    known_components: Set[str] = set()
+
+    conn = None
+    try:
+        conn = get_db_connection()
+
+        rows = conn.execute(
+            'SELECT filled_by_title, real_debrid_original_title FROM media_items '
+            'WHERE filled_by_title IS NOT NULL OR real_debrid_original_title IS NOT NULL'
+        ).fetchall()
+        for row in rows:
+            for value in (row['filled_by_title'], row['real_debrid_original_title']):
+                if value:
+                    known_titles.add(normalize_string_for_comparison(value))
+
+        rows = conn.execute(
+            'SELECT original_path_for_symlink FROM media_items '
+            'WHERE original_path_for_symlink IS NOT NULL'
+        ).fetchall()
+        for row in rows:
+            path = row['original_path_for_symlink']
+            if not path:
+                continue
+            for part in path.replace('\\', '/').split('/'):
+                if part:
+                    known_components.add(normalize_string_for_comparison(part))
+    except Exception as e:
+        logging.error(f"[ExternalScan] Could not build known-item lookups: {e}", exc_info=True)
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    return known_titles, known_components
+
+
+def _already_tracked(folder_name: str, known_titles: Set[str], known_components: Set[str]) -> bool:
+    """Fast pre-filter, then the same checks the rclone webhook makes."""
+    from database.database_reading import (
+        normalize_string_for_comparison,
+        check_item_exists_by_directory_name,
+        check_item_exists_with_symlink_path_containing,
+    )
+
+    normalized = normalize_string_for_comparison(folder_name)
+    if normalized in known_titles or normalized in known_components:
+        return True
+
+    # Not positively identified above -- fall through to the authoritative
+    # (expensive) checks. Only runs for the handful of genuinely new folders.
+    if check_item_exists_by_directory_name(folder_name):
+        return True
+    if check_item_exists_with_symlink_path_containing(folder_name):
+        return True
+    return False
+
+
+def _should_retry(entry: Dict, now: float) -> bool:
+    # Present in the mount before the feature was turned on. Never auto-import
+    # these -- the whole point of the baseline is that enabling the task does
+    # not drag an established library's worth of untracked content into the DB.
+    if entry.get('baseline'):
+        return False
+    if entry.get('imported'):
+        return False
+    if entry.get('attempts', 0) >= MAX_ATTEMPTS:
+        return False
+    last = entry.get('last_attempt', 0)
+    return (now - last) >= RETRY_AFTER_SECONDS
+
+
+def scan_mount_for_external_adds() -> Dict:
+    """Scan the mount for folders cli_debrid has no record of and import them.
+
+    Returns a summary dict for logging.
+    """
+    summary = {
+        'skipped_reason': None,
+        'entries_seen': 0,
+        'new_candidates': 0,
+        'imported': 0,
+        'failed': 0,
+        'baselined': 0,
+    }
+
+    if get_setting('File Management', 'file_collection_management', 'Symlinked/Local') != 'Symlinked/Local':
+        summary['skipped_reason'] = 'file collection management is not Symlinked/Local'
+        return summary
+
+    mount_path = get_setting('File Management', 'original_files_path', '')
+    if not mount_path or not os.path.isdir(mount_path):
+        summary['skipped_reason'] = f"original_files_path '{mount_path}' is not a readable directory"
+        return summary
+
+    symlink_base_path = get_setting('File Management', 'symlinked_files_path', '')
+    if not symlink_base_path:
+        summary['skipped_reason'] = 'symlinked_files_path is not configured'
+        return summary
+
+    entries = _list_top_level(mount_path)
+    summary['entries_seen'] = len(entries)
+    if not entries:
+        return summary
+
+    state = _load_state()
+    is_first_run = not state
+    now = time.time()
+
+    # First run: record what's already there and import none of it.
+    if is_first_run:
+        for name in entries:
+            state[name] = {'imported': False, 'baseline': True, 'first_seen': now}
+        _save_state(state)
+        summary['baselined'] = len(entries)
+        logging.info(
+            f"[ExternalScan] First run - recorded {len(entries)} existing mount entries as baseline "
+            f"without importing. Content appearing from now on will be imported. "
+            f"Delete {_state_path()} to re-baseline."
+        )
+        return summary
+
+    # Drop state for folders that have gone from the mount, so the file
+    # doesn't grow without bound.
+    present = set(entries)
+    for name in [n for n in state if n not in present]:
+        del state[name]
+
+    candidates = []
+    for name in entries:
+        entry = state.get(name)
+        if entry is not None and not _should_retry(entry, now):
+            continue
+        candidates.append(name)
+
+    if not candidates:
+        _save_state(state)
+        return summary
+
+    known_titles, known_components = _build_known_sets()
+
+    new_folders = []
+    for name in candidates:
+        if _already_tracked(name, known_titles, known_components):
+            # Tracked by cli_debrid already - record it so we don't re-check
+            # it against the DB on every run.
+            state[name] = {'imported': True, 'tracked_existing': True, 'first_seen': now}
+            continue
+        new_folders.append(name)
+
+    summary['new_candidates'] = len(new_folders)
+    if not new_folders:
+        _save_state(state)
+        return summary
+
+    logging.info(f"[ExternalScan] {len(new_folders)} mount entries with no database record; "
+                 f"importing up to {MAX_IMPORTS_PER_RUN} this run.")
+
+    # Imported lazily: routes.debug_routes pulls in a large chunk of the app,
+    # and importing it at module level from utilities risks a circular import.
+    from routes.debug_routes import _run_rclone_to_symlink_task, rclone_scan_progress
+
+    for name in new_folders[:MAX_IMPORTS_PER_RUN]:
+        entry = state.get(name) or {'first_seen': now}
+        entry['attempts'] = entry.get('attempts', 0) + 1
+        entry['last_attempt'] = now
+
+        scan_path = os.path.join(mount_path, name)
+        task_id = str(uuid.uuid4())
+
+        logging.info(f"[ExternalScan] Importing external add: {scan_path}")
+        try:
+            # Same call the rclone webhook makes - metadata lookup, DB insert
+            # as Collected, symlink creation, media server scan and the
+            # 'collected' notification all happen inside.
+            _run_rclone_to_symlink_task(
+                scan_path,
+                symlink_base_path,
+                False,               # dry_run
+                task_id,
+                True,                # trigger_plex_update_on_success
+                name,                # assumed_item_title_from_path
+            )
+            progress = rclone_scan_progress.get(task_id) or {}
+            added = progress.get('items_added_to_db', 0)
+            symlinks = progress.get('symlinks_created', 0)
+            if added > 0:
+                entry['imported'] = True
+                summary['imported'] += 1
+                logging.info(f"[ExternalScan] Imported '{name}' - {added} item(s) added, "
+                             f"{symlinks} symlink(s) created.")
+            else:
+                summary['failed'] += 1
+                logging.warning(
+                    f"[ExternalScan] '{name}' produced no database entries "
+                    f"(attempt {entry['attempts']}/{MAX_ATTEMPTS}): "
+                    f"{progress.get('message', 'no progress reported')}"
+                )
+        except Exception as e:
+            summary['failed'] += 1
+            logging.error(f"[ExternalScan] Import failed for '{name}': {e}", exc_info=True)
+
+        state[name] = entry
+
+    _save_state(state)
+    return summary

--- a/utilities/external_mount_scan.py
+++ b/utilities/external_mount_scan.py
@@ -219,11 +219,17 @@ def scan_mount_for_external_adds() -> Dict:
         )
         return summary
 
+    # Only write the state file when something actually changed. The steady
+    # state is a large mount where every entry is already known, and rewriting
+    # a file with one key per mount folder on every run buys nothing.
+    dirty = False
+
     # Drop state for folders that have gone from the mount, so the file
     # doesn't grow without bound.
     present = set(entries)
     for name in [n for n in state if n not in present]:
         del state[name]
+        dirty = True
 
     candidates = []
     for name in entries:
@@ -233,7 +239,8 @@ def scan_mount_for_external_adds() -> Dict:
         candidates.append(name)
 
     if not candidates:
-        _save_state(state)
+        if dirty:
+            _save_state(state)
         return summary
 
     known_titles, known_components = _build_known_sets()
@@ -244,12 +251,14 @@ def scan_mount_for_external_adds() -> Dict:
             # Tracked by cli_debrid already - record it so we don't re-check
             # it against the DB on every run.
             state[name] = {'imported': True, 'tracked_existing': True, 'first_seen': now}
+            dirty = True
             continue
         new_folders.append(name)
 
     summary['new_candidates'] = len(new_folders)
     if not new_folders:
-        _save_state(state)
+        if dirty:
+            _save_state(state)
         return summary
 
     logging.info(f"[ExternalScan] {len(new_folders)} mount entries with no database record; "

--- a/utilities/settings_schema.py
+++ b/utilities/settings_schema.py
@@ -256,6 +256,11 @@ SETTINGS_SCHEMA = {
             "description": "Process files in rclone webhook even if they don't match any items in the checking state",
             "default": False
         },
+        "scan_mount_for_external_adds": {
+            "type": "boolean",
+            "description": "Periodically scan the original files path for content added outside cli_debrid (e.g. via DMM or the debrid provider's own UI) and import it - symlink it and trigger a media server scan. Use this when your mount provider has no library-update webhook (Decypharr, plain rclone); zurg users already get this via its on_library_update hook. The first run records existing mount content as a baseline without importing it.",
+            "default": False
+        },
         "plex_url_for_symlink": {
             "type": "string",
             "description": "Plex server URL for symlink updates (optional)",


### PR DESCRIPTION
### Problem

In **Symlinked/Local** mode, cli_debrid only knows about files it put in the mount itself (Wanted → Scraping → Adding → Checking). Content added straight to the debrid account by something else — DMM, the provider's web UI, a manual magnet — appears in the mount with nothing in the database pointing at it. No symlink gets created, and the media server is never told, so it never shows up in Plex.

The import pipeline for this already exists and works. Its only automatic trigger is `GET /webhook/rclone`, which **zurg** calls via its `on_library_update` hook. Setups without that hook — **Decypharr**, plain rclone — have no way to reach it, so the content stays invisible indefinitely.

`task_sync_cli_mount_changes` doesn't cover this: it targets cli_mount's `/api/sync/changes`, and it only *updates* rows that already match an item. Unmatched entries are skipped and dropped, so it never creates anything.

## What this adds

A new opt-in task, `task_scan_mount_for_external_adds`, that polls the mount and feeds anything new into the **same** pipeline the webhook uses (`_run_rclone_to_symlink_task`) — so metadata lookup, DB insert as `Collected`, symlink creation, the media server scan, and the `collected` notification all come from existing code paths.

- **Symlink mode only**, off by default, behind a new `scan_mount_for_external_adds` setting under File Management.
- Runs every 15 minutes by default; adjustable from Task Timings like any other task.
- Lists **only the top level** of `original_files_path` (`os.scandir`, directories only). No recursive walk — that matters a lot on a WebDAV-backed mount.

### Design notes

**The first run imports nothing.** It records everything currently in the mount as a baseline and only imports what appears afterwards. Without this, enabling the task on an established library would mass-import years of untracked content in a single pass. Delete `db_content/external_mount_scan_state.json` to re-baseline.

**Dedup is a two-stage filter.** `check_item_exists_by_directory_name()` and `check_item_exists_with_symlink_path_containing()` each do a full-table scan in Python per call — fine for one webhook, far too slow across thousands of folders per run. In-memory lookups are built once per run as a fast pre-filter that can only return "definitely known"; anything it doesn't positively identify still goes through both authoritative helpers, so semantics match the webhook exactly.

**Work and retries are bounded.** 25 imports per run, 3 attempts per folder with a 6-hour backoff before giving up, state pruned for folders that vanish from the mount, and the state file only rewritten when something actually changed.

### Testing

Verified against a fake mount covering: baseline on first run, no import on the second, import of only the new folder on the third, no re-import on the fourth, pruning on removal, retry-cap enforcement, no state-file write on a no-op run, and a clean no-op in Plex mode. 12/12 pass.

Also confirmed live on a real Decypharr setup — 1728 existing mount entries baselined in ~45ms with nothing imported.