### PR TITLE
Fix symlink template silently dropping empty original_filename

### DIFF
--- a/utilities/local_library_scan.py
+++ b/utilities/local_library_scan.py
@@ -396,6 +396,7 @@ def remap_plex_paths_to_mount(items: List[Dict[str, Any]], mount_path: str) -> L
 
 def _clean_separators_in_string(s: str) -> str:
     """Clean up orphaned separators after removing template components."""
+    original = s
     s = re.sub(r'\s*-\s*\(\s*\)', '', s)
     s = re.sub(r'\(\s*\)', '', s)
     s = re.sub(r'\s*-\s*\[\s*\]', '', s)
@@ -404,7 +405,14 @@ def _clean_separators_in_string(s: str) -> str:
     s = re.sub(r'^\s*-\s*', '', s)
     s = re.sub(r'\s*-\s*$', '', s)
     s = re.sub(r'\s{2,}', ' ', s)
-    return s.strip()
+    s = s.strip()
+    # A bare "- {value}" placeholder (not wrapped in parens/brackets) that was empty
+    # gets silently dropped by the trailing-dash cleanup above, unlike the optional
+    # "(...)"/"[...]" wrapped components. Log it so a missing template value is
+    # visible instead of just producing an unexpectedly short filename.
+    if s != original and not re.search(r'[()\[\]]', original):
+        logging.warning(f"[SymlinkPath] Dropped an empty template component while cleaning: {original!r} -> {s!r}")
+    return s
 
 
 def truncate_path_components(
@@ -809,13 +817,30 @@ def get_symlink_path(item: Dict[str, Any], original_file: str, skip_jikan_lookup
                 f"items released in {item.get('year', '')!r}"
             )
 
+        # filled_by_file is normally the discovered source filename, but can be empty for
+        # some items (e.g. certain debrid discovery paths never set it). Fall back through
+        # the other filename-ish fields we track rather than leaving original_filename
+        # blank, which _clean_separators_in_string silently swallows from templates that
+        # reference it outside of optional "(...)"/"[...]" wrapping.
+        original_filename_source = (
+            item.get('filled_by_file')
+            or item.get('original_filename')
+            or item.get('original_scraped_torrent_title')
+            or ''
+        )
+        if not original_filename_source:
+            logging.warning(
+                f"[SymlinkPath] No filename source found for item {item.get('id', '?')} "
+                f"({item.get('title', 'Unknown')!r}) — original_filename template variable will be empty."
+            )
+
         template_vars = {
             'title': effective_title,
             'year': item.get('year', ''),
             'imdb_id': imdb_id,
             'tmdb_id': item.get('tmdb_id', ''),
             'version': item.get('version', '').strip('*'),  # Remove all asterisks for template placeholder use
-            'original_filename': os.path.splitext(item.get('filled_by_file', ''))[0],
+            'original_filename': os.path.splitext(original_filename_source)[0],
             'content_source': item.get('content_source', ''),
             'resolution': item.get('resolution', '')
         }


### PR DESCRIPTION
## Summary
- Reported by kact: a custom `symlink_episode_template` ending in a bare `- {original_filename}` (no parens) produced filenames with that segment missing entirely, looking like a normal but shorter name rather than an obvious error.
- Root cause: `template_vars['original_filename']` is derived from `filled_by_file`, which can be empty on collection for some items. `_clean_separators_in_string` treats a resulting bare `- ` the same as an optional `()`/`[]` wrapper and silently deletes it.
- Fix: add a fallback chain (`filled_by_file` -> `original_filename` -> `original_scraped_torrent_title`) so a real filename is used when one is available anywhere on the item, and log a warning when no source is found at all or when the cleanup step drops a bare (non-bracketed) empty component.
- This only affects symlink filename computation, which runs after file discovery/collection — no change to matching or collection behavior.

## Test plan
- [x] `python3 -m py_compile utilities/local_library_scan.py`
- [x] Reproduced the reported filename (`Monarch Legacy of Monsters (2023) - S02E04 - Trespass - tt17220216.mkv`) via a standalone simulation of the old template-formatting/cleanup path with an empty `original_filename`, confirming it matches exactly.
- [ ] Live verification pending — will confirm once kact hits this path again with debug logging on.