### PR TITLE
Fix fallback still self-blocked, log-share freeze, Plex scan ms_item_id healing, and TMDB timeout hang

### DIFF
--- a/database/collected_items.py
+++ b/database/collected_items.py
@@ -958,7 +958,7 @@ def _add_collected_items_impl(media_items_batch, recent=False, backfill=False, d
                                         tmdb_id = COALESCE(NULLIF(tmdb_id, ''), ?),
                                         collected_at = COALESCE(collected_at, ?),
                                         last_updated = ?,
-                                        ms_item_id = COALESCE(ms_item_id, ?)
+                                        ms_item_id = COALESCE(NULLIF(ms_item_id, ''), ?)
                                     WHERE id = ?
                                 ''', (effective_location, new_resolution, new_size, imdb_id, tmdb_id, collected_at, datetime.now(), plex_ms_item_id, db_item_id))
 

--- a/database/database_writing.py
+++ b/database/database_writing.py
@@ -804,16 +804,24 @@ def add_media_item(item: dict, user_initiated: bool = False) -> int:
             apply_movie_release_override_to_item(item, conn=conn)
 
         # GHOSTLIST/BLACKLIST CHECK
+        # Scoped to the same normalized version being inserted for the 'Blacklisted'
+        # half: create_and_add_item_to_wanted_queue() blacklists the original item
+        # (e.g. '1080p') immediately before calling add_media_item() to insert the
+        # fallback item (e.g. '720 and below'), so an unscoped match here always found
+        # that just-blacklisted original row and silently killed every fallback
+        # insertion, mirroring the bug already fixed in queue_manager.py's own
+        # duplicate check. A genuine permanent ghostlist still blocks at any version.
+        target_version = (version or '').rstrip('*')
         if imdb_id or tmdb_id:
             # Build query to check for ghostlisted/blacklisted entries
             ghostlist_check_query = '''
                 SELECT id, version FROM media_items
                 WHERE (imdb_id = ? OR tmdb_id = ?)
                 AND type = ?
-                AND (ghostlisted = 1 OR state = 'Blacklisted')
+                AND (ghostlisted = 1 OR (state = 'Blacklisted' AND RTRIM(COALESCE(version, ''), '*') = ?))
                 LIMIT 1
             '''
-            ghostlist_check_params = [imdb_id, tmdb_id, item_type]
+            ghostlist_check_params = [imdb_id, tmdb_id, item_type, target_version]
 
             # For episodes, also check season/episode number
             if item_type == 'episode' and 'season_number' in item and 'episode_number' in item:
@@ -823,10 +831,10 @@ def add_media_item(item: dict, user_initiated: bool = False) -> int:
                     AND type = ?
                     AND season_number = ?
                     AND episode_number = ?
-                    AND (ghostlisted = 1 OR state = 'Blacklisted')
+                    AND (ghostlisted = 1 OR (state = 'Blacklisted' AND RTRIM(COALESCE(version, ''), '*') = ?))
                     LIMIT 1
                 '''
-                ghostlist_check_params = [imdb_id, tmdb_id, item_type, item['season_number'], item['episode_number']]
+                ghostlist_check_params = [imdb_id, tmdb_id, item_type, item['season_number'], item['episode_number'], target_version]
 
             ghostlist_result = conn.execute(ghostlist_check_query, ghostlist_check_params).fetchone()
 

--- a/routes/log_viewer_routes.py
+++ b/routes/log_viewer_routes.py
@@ -267,25 +267,31 @@ def process_log_upload(task_id):
             logging.warning(f"Task {task_id}: Failed to build settings snapshot for log upload: {e}")
             settings_snapshot = '(settings snapshot unavailable)'
 
+        # Belt-and-suspenders: RedactingFormatter scrubs new log lines as
+        # they're written, but rotated files predating that change (or a
+        # build without it yet) still have secrets in cleartext on disk.
+        # scrub() is built to run per formatted line (that's its normal call
+        # site, once per record); applying it to a single ~hundreds-of-MB
+        # string assembled from up to 1.5M lines instead means every one of
+        # its regex passes has to scan that entire blob, which can take long
+        # enough to hold up the whole app (this task runs on a background
+        # thread, but CPython regex matching doesn't release the GIL).
+        # Scrubbing each line individually keeps every regex call bounded to
+        # a single line's length, same as the live logging path already does
+        # continuously with no perf issue.
+        try:
+            from utilities.log_redaction import scrub
+            logs = [scrub(line) for line in logs]
+            settings_snapshot = scrub(settings_snapshot)
+        except Exception as e:
+            logging.warning(f"Task {task_id}: Log redaction scrub unavailable, uploading unscrubbed: {e}")
+
         log_content = (
             "=== Diagnostic settings snapshot (sensitive values redacted) ===\n"
             f"{settings_snapshot}\n"
             "=== End settings snapshot ===\n\n"
             + '\n'.join(logs)
         )
-
-        # Belt-and-suspenders: RedactingFormatter scrubs new log lines as
-        # they're written, but rotated files predating that change (or a
-        # build without it yet) still have secrets in cleartext on disk.
-        # Running the same value-based/pattern-based scrub over the fully
-        # assembled upload (raw log lines + our own settings snapshot) here
-        # catches those, using a second, independently-derived detection of
-        # what counts as sensitive.
-        try:
-            from utilities.log_redaction import scrub
-            log_content = scrub(log_content)
-        except Exception as e:
-            logging.warning(f"Task {task_id}: Log redaction scrub unavailable, uploading unscrubbed: {e}")
 
         upload_tasks[task_id].update({'status': 'compressing', 'progress': 30, 'message': 'Compressing logs...'})
         compressed_buffer = io.BytesIO()

--- a/tests/test_log_upload_scrub_integration.py
+++ b/tests/test_log_upload_scrub_integration.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
-"""Confirms the shared-log upload runs the final assembled content (raw log
-lines + our own settings snapshot) through utilities.log_redaction.scrub()
-as a second, independent pass before compression -- belt-and-suspenders on
-top of RedactingFormatter, which only covers lines written after it's
-active and never sees our snapshot text (built as a plain string, not
-emitted through a logging.Logger).
+"""Confirms the shared-log upload runs both the raw log lines and our own
+settings snapshot through utilities.log_redaction.scrub() before compression
+-- belt-and-suspenders on top of RedactingFormatter, which only covers lines
+written after it's active and never sees our snapshot text (built as a plain
+string, not emitted through a logging.Logger).
+
+scrub() is scrubbed per line (and once for the snapshot), not over the final
+assembled log_content string in one call: scrub() runs several regex passes
+per call, and the assembled content can be hundreds of MB across up to 1.5M
+lines -- one call over that whole blob can take long enough to hold up the
+whole app, since CPython regex matching doesn't release the GIL. Scrubbing
+each piece individually keeps every regex call bounded to a single line's
+length, matching the cost profile of the live per-record logging path.
 
 routes/log_viewer_routes.py imports flask (unavailable in this test
 environment), so this test inspects the source directly rather than
@@ -28,32 +35,34 @@ class TestLogUploadRunsScrub(unittest.TestCase):
     def setUp(self):
         self.source = _read("routes/log_viewer_routes.py")
 
-    def test_process_log_upload_scrubs_final_content(self):
+    def test_process_log_upload_scrubs_both_pieces_per_line(self):
         start = self.source.index("def process_log_upload(task_id):")
         end = self.source.index("def upload_to_paste_cnet(", start)
         body = self.source[start:end]
 
         self.assertIn("from utilities.log_redaction import scrub", body)
-        self.assertIn("log_content = scrub(log_content)", body)
+        # Logs are scrubbed line-by-line, not as one assembled blob -- see
+        # module docstring for why (unbounded regex cost / GIL hold time).
+        self.assertIn("logs = [scrub(line) for line in logs]", body)
+        self.assertIn("settings_snapshot = scrub(settings_snapshot)", body)
 
-        # Must run on the fully assembled content (snapshot + logs), not
-        # just the raw logs -- scrub() call has to come after log_content
-        # is built from both pieces.
+        # Must run before log_content is assembled from both pieces, not
+        # after -- otherwise the joined blob never gets scrubbed at all.
+        scrub_call_idx = body.index("logs = [scrub(line) for line in logs]")
         snapshot_build_idx = body.index("f\"{settings_snapshot}\\n\"")
-        scrub_call_idx = body.index("log_content = scrub(log_content)")
-        self.assertLess(snapshot_build_idx, scrub_call_idx)
+        self.assertLess(scrub_call_idx, snapshot_build_idx)
 
     def test_scrub_failure_does_not_break_upload(self):
         start = self.source.index("def process_log_upload(task_id):")
         end = self.source.index("def upload_to_paste_cnet(", start)
         body = self.source[start:end]
-        scrub_idx = body.index("log_content = scrub(log_content)")
-        # The scrub call must be wrapped so an import/runtime error there
+        scrub_idx = body.index("logs = [scrub(line) for line in logs]")
+        # The scrub calls must be wrapped so an import/runtime error there
         # can't take down the whole upload: nearest preceding 'try:' within
         # a tight window, and a matching 'except Exception' right after.
         preceding_window = body[max(0, scrub_idx - 200):scrub_idx]
         self.assertIn("try:", preceding_window)
-        self.assertIn("except Exception", body[scrub_idx:scrub_idx + 300])
+        self.assertIn("except Exception", body[scrub_idx:scrub_idx + 400])
 
 
 if __name__ == "__main__":

--- a/tests/test_plex_scan_ms_item_id_heal.py
+++ b/tests/test_plex_scan_ms_item_id_heal.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regression test: the already-collected update path in
+database/collected_items.py must heal an empty-string ms_item_id the same
+way it already heals empty-string imdb_id/tmdb_id in the same query.
+
+SQLite's COALESCE treats '' as a non-NULL value, so
+`ms_item_id = COALESCE(ms_item_id, ?)` never replaces an existing empty
+string even though the should_update check above it (which treats a falsy
+ms_item_id, including '', as "needs update") decided an update was needed.
+The sibling imdb_id/tmdb_id assignments in the same UPDATE already use
+`COALESCE(NULLIF(x, ''), ?)` -- ms_item_id was just missed.
+"""
+
+import os
+import sqlite3
+import unittest
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+UPDATE_QUERY = """
+    UPDATE media_items
+    SET ms_item_id = COALESCE(NULLIF(ms_item_id, ''), ?)
+    WHERE id = ?
+"""
+
+
+def _make_conn():
+    conn = sqlite3.connect(':memory:')
+    conn.execute(
+        """
+        CREATE TABLE media_items (
+            id INTEGER PRIMARY KEY,
+            ms_item_id TEXT
+        )
+        """
+    )
+    return conn
+
+
+class TestMsItemIdHeal(unittest.TestCase):
+    def test_empty_string_is_healed(self):
+        conn = _make_conn()
+        conn.execute("INSERT INTO media_items (id, ms_item_id) VALUES (1, '')")
+        conn.execute(UPDATE_QUERY, ('plex-rating-key-123', 1))
+        row = conn.execute("SELECT ms_item_id FROM media_items WHERE id = 1").fetchone()
+        self.assertEqual(row[0], 'plex-rating-key-123')
+
+    def test_null_is_healed(self):
+        conn = _make_conn()
+        conn.execute("INSERT INTO media_items (id, ms_item_id) VALUES (1, NULL)")
+        conn.execute(UPDATE_QUERY, ('plex-rating-key-123', 1))
+        row = conn.execute("SELECT ms_item_id FROM media_items WHERE id = 1").fetchone()
+        self.assertEqual(row[0], 'plex-rating-key-123')
+
+    def test_existing_value_is_preserved(self):
+        conn = _make_conn()
+        conn.execute("INSERT INTO media_items (id, ms_item_id) VALUES (1, 'already-linked')")
+        conn.execute(UPDATE_QUERY, ('plex-rating-key-123', 1))
+        row = conn.execute("SELECT ms_item_id FROM media_items WHERE id = 1").fetchone()
+        self.assertEqual(row[0], 'already-linked')
+
+    def test_source_uses_healing_coalesce(self):
+        # Guard against the fix regressing back to the plain COALESCE form.
+        path = os.path.join(PROJECT_ROOT, "database", "collected_items.py")
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        self.assertIn("ms_item_id = COALESCE(NULLIF(ms_item_id, ''), ?)", source)
+        self.assertNotIn("ms_item_id = COALESCE(ms_item_id, ?)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tmdb_media_meta_timeout.py
+++ b/tests/test_tmdb_media_meta_timeout.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Regression test: get_media_meta()'s TMDB requests must carry a timeout.
+
+utilities/web_scraper.py's get_media_meta() is called synchronously from
+database/collected_items.py's _cache_tmdb_artwork(), which the Plex full
+scan's DB-reconciliation step (add_collected_items()) calls directly. The
+underlying api.get() (routes/api_tracker.py's APITracker.get()) is a bare
+requests.Session.get(url, **kwargs) passthrough with no default timeout, so
+a stalled TMDB connection with no timeout kwarg blocks the whole scan
+indefinitely -- observed live as task_plex_full_scan remaining "Running" for
+over 24 hours.
+
+utilities/web_scraper.py pulls in heavy optional deps (fuzzywuzzy, the
+scraper package) not available in this test environment, so this test
+inspects the source directly rather than importing the module -- consistent
+with the other source-inspection regression tests in this suite (see
+test_log_upload_scrub_integration.py).
+"""
+
+import os
+import unittest
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestGetMediaMetaTimeout(unittest.TestCase):
+    def setUp(self):
+        path = os.path.join(PROJECT_ROOT, "utilities", "web_scraper.py")
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        start = source.index("def get_media_meta(")
+        # Slice to the next top-level def so we only inspect this function's body.
+        end = source.index("\ndef ", start + 1)
+        self.body = source[start:end]
+
+    def test_details_request_has_timeout(self):
+        self.assertIn("api.get(details_url, timeout=", self.body)
+
+    def test_images_request_has_timeout(self):
+        self.assertIn("api.get(images_url, timeout=", self.body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utilities/web_scraper.py
+++ b/utilities/web_scraper.py
@@ -788,7 +788,7 @@ def get_media_meta(tmdb_id: str, media_type: str) -> Optional[Tuple[str, str, li
 
     try:
         # Fetch details (overview, genres, ratings, backdrop)
-        details_response = api.get(details_url)
+        details_response = api.get(details_url, timeout=15)
         details_response.raise_for_status()
         details_data = details_response.json()
 
@@ -798,7 +798,7 @@ def get_media_meta(tmdb_id: str, media_type: str) -> Optional[Tuple[str, str, li
         # no English results exist (e.g. non-English original content with no EN poster).
         poster_url = None
         try:
-            images_response = api.get(images_url)
+            images_response = api.get(images_url, timeout=15)
             images_response.raise_for_status()
             all_posters = images_response.json().get('posters', [])
             # Prefer English posters; fall back to all results only if none found


### PR DESCRIPTION
## Summary

Four issues found live-testing #484 immediately after it merged:

- **Fallback versions still don't work.** #484's fix only version-scoped the ghostlist/blacklist guard in `queue_manager.py`'s `create_and_add_item_to_wanted_queue()`. That function calls `add_media_item()` in `database/database_writing.py`, which has its own separate, unscoped copy of the identical guard (matches on imdb_id/season/episode only, no version). `blacklisted_queue.py` always blacklists the original item (e.g. `1080p`) immediately before requesting the fallback (e.g. `720 and below`), so the outer check now correctly lets the fallback through, only for this inner check to immediately re-block it for the exact same reason as the original bug. Scoped the `Blacklisted` half of this second guard to the same normalized version, matching the fix already applied to the `queue_manager.py` copy. A genuine permanent ghostlist still blocks at any version.

- **"Share cli_debrid Logs" freezes the whole app.** #484's redaction belt-and-suspenders pass runs `utilities.log_redaction.scrub()` once over the entire assembled upload as a single string. `scrub()` is built to run per formatted log line (its normal call site, via `RedactingFormatter`) and does several regex passes per call; called once over a string built from up to 1.5M lines (hundreds of MB on an active install), each pass has to scan the whole blob, and CPython regex matching doesn't release the GIL — so the whole app stalls for the duration, not just the upload request. Scrubs each log line individually (and the settings snapshot separately) before assembling `log_content`, bounding every regex call to normal log-line length — the same cost profile as the always-on per-record logging path.

- **Plex full scan doesn't repair empty-string `ms_item_id`** (#490). The already-collected-item update's `should_update` check correctly treats an empty-string `ms_item_id` as "needs update," but the `UPDATE` itself used `ms_item_id = COALESCE(ms_item_id, ?)`. SQLite's `COALESCE` treats `''` as non-NULL, so it never replaced the empty string — the item stayed permanently blank and kept showing up under the Library UI's Broken filter after every full scan, even though Plex had it indexed fine. The sibling `imdb_id`/`tmdb_id` assignments in the exact same query already use the correct `COALESCE(NULLIF(x, ''), ?)` form; `ms_item_id` was just missed.

- **Plex full scan can hang indefinitely on TMDB artwork requests** (#489). `get_media_meta()`'s two TMDB requests (details, images) had no timeout, unlike every other `api.get()` call in this file. `api.get()` (`routes/api_tracker.py`'s `APITracker.get()`) is a bare `requests.Session.get(url, **kwargs)` passthrough with no default timeout, so a stalled connection blocks forever. `get_media_meta()` is called synchronously from `_cache_tmdb_artwork()`, which the Plex full scan's DB-reconciliation step calls directly — so a single hung TMDB request left `task_plex_full_scan` stuck "Running" indefinitely, well past reconciling the DB rows that would have picked up the `ms_item_id` fix above. Added `timeout=15` to both calls, matching the existing `RequestException` handling that already treats a failed fetch as "skip artwork, keep going."

All four confirmed against the current codebase before fixing (not taken on the reporters' word) and reproduced/verified live against a running install with #484 merged.

## Test plan

- [x] Updated `tests/test_log_upload_scrub_integration.py`'s two source-inspection tests to match the new per-line call sites.
- [x] Added `tests/test_plex_scan_ms_item_id_heal.py` (in-memory SQLite, mirrors `test_nzb_coalesce_version_match.py`'s style) and `tests/test_tmdb_media_meta_timeout.py` (source-inspection, mirrors `test_log_upload_scrub_integration.py`'s approach since `web_scraper.py` pulls in optional deps unavailable in this test environment).
- [x] `tests/test_fallback_version_ghostlist_check.py`, `tests/test_log_upload_scrub_integration.py`, `tests/test_plex_scan_ms_item_id_heal.py`, `tests/test_tmdb_media_meta_timeout.py` all pass.
- [x] Full suite: same pre-existing failures as baseline (missing optional deps in this env, cross-test mock pollution when run all together — confirmed by re-running the affected files in isolation), no new failures from this change.

Closes #489, closes #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)