### PR TITLE
Fail closed on unverified NZB playback

### DIFF
--- a/queues/run_program.py
+++ b/queues/run_program.py
@@ -339,6 +339,7 @@ class ProgramRunner:
             'task_push_pending_climount_tags': 5 * 60, # Run every 5 minutes — catches tags changed on cli_debrid side only
             'task_scan_mount_for_external_adds': 15 * 60, # Run every 15 minutes (disabled by default)
             'task_nzb_health_check': 10,             # Run every 10 seconds — polls NZB items in Adding
+            'task_nzb_idle_repair_watch': 60,        # Passive broken-state poll, independent of Adding
             'task_nzb_playback_repair_completion': 15, # Confirm only already-started playback repairs
             'task_nzb_playback_cleanup_retry': 20 * 60, # Background retry for old-file cleanup deferred after finalization
             'task_backfill_plex_guids': 24 * 60 * 60,    # Run once (disabled by default)
@@ -542,6 +543,7 @@ class ProgramRunner:
             'task_update_queue_views',
             'task_send_notifications',
             'task_nzb_health_check',
+            'task_nzb_idle_repair_watch',
             'task_nzb_playback_repair_completion',
             'task_nzb_playback_cleanup_retry',
             # Essential Periodic Tasks
@@ -4844,6 +4846,14 @@ class ProgramRunner:
         except Exception as exc:
             logging.error('[NZBPlayback] Completion task failed: %s', exc, exc_info=True)
 
+    def task_nzb_idle_repair_watch(self):
+        """Poll cli_mount's passive broken list even when no NZB is being added."""
+        try:
+            from utilities.nzb_idle_repair_watch import run_idle_repair_watch
+            run_idle_repair_watch()
+        except Exception as exc:
+            logging.error('[NZBIdleRepair] Watch task failed: %s', exc, exc_info=True)
+
     def task_nzb_playback_cleanup_retry(self):
         """Slow-cadence background retry for old-file cleanup deferred by the
         fast completion worker — repairs already finalized as replaced."""
@@ -6320,7 +6330,8 @@ class ProgramRunner:
             file is rejected and re-scraped before Plex has any chance to add
             it, avoiding a "recently added" flicker.
             Returns True if the item should proceed, False if it was rejected
-            (already reverted to Wanted; caller should skip further processing).
+            (already reverted to Wanted), or None when verification must retry
+            later while the item remains in Checking.
             """
             # In Symlinked/Local mode, check_local_file_for_item is already the
             # authoritative ffprobe gate for this item - it runs synchronously
@@ -6382,18 +6393,43 @@ class ProgramRunner:
                 try:
                     job_hash = torrent_id[4:] if torrent_id.startswith('nzb:') else torrent_id
                     from usenet.climount_client import get_climount_client
+                    from utilities.nzb_playability_guard import nzb_job_ready
                     job_status = get_climount_client().get_job_status(job_hash)
-                    if job_status and job_status.get('state') != 'completed' and job_status.get('progress', 100) < 95:
-                        logging.info(f"[ffprobe] Deferring {probe_key} for item {item.get('id')} — job {job_hash} still downloading ({job_status.get('progress', 0)}%)")
-                        return True
+                    if not nzb_job_ready(job_status):
+                        progress = job_status.get('progress', 0) if job_status else 'unknown'
+                        state = job_status.get('state', 'unknown') if job_status else 'unavailable'
+                        logging.info(
+                            f"[ffprobe] Deferring {probe_key} for item {item.get('id')} — "
+                            f"job {job_hash} is not conclusively complete "
+                            f"(state={state}, progress={progress}%)"
+                        )
+                        return None
                 except Exception as e:
-                    logging.debug(f"[ffprobe] Could not check job download progress for {torrent_id}: {e}")
+                    logging.warning(
+                        f"[ffprobe] Could not establish cli_mount completion for item "
+                        f"{item.get('id')} — keeping it in Checking: {e}"
+                    )
+                    return None
 
-            logging.info(f"[ffprobe] Running playability check ({probe_key}) on '{actual_file_path}'")
-            from usenet.repair_engine import _verify_file_readable
-            if _verify_file_readable(actual_file_path):
-                logging.info(f"[ffprobe] Playability check passed for '{actual_file_path}'")
-                return True
+            if is_nzb:
+                logging.info(f"[ffprobe] Running conclusive playability check ({probe_key}) on '{actual_file_path}'")
+                from utilities.nzb_playability_guard import HEALTHY, UNKNOWN, classify_new_nzb
+                verdict = classify_new_nzb(actual_file_path)
+                if verdict == HEALTHY:
+                    logging.info(f"[ffprobe] Playability check passed for '{actual_file_path}'")
+                    return True
+                if verdict == UNKNOWN:
+                    logging.warning(
+                        f"[ffprobe] Playability check inconclusive for item {item.get('id')} — "
+                        "keeping it in Checking and retrying later"
+                    )
+                    return None
+            else:
+                logging.info(f"[ffprobe] Running playability check ({probe_key}) on '{actual_file_path}'")
+                from usenet.repair_engine import _verify_file_readable
+                if _verify_file_readable(actual_file_path):
+                    logging.info(f"[ffprobe] Playability check passed for '{actual_file_path}'")
+                    return True
 
             logging.warning(f"[ffprobe] Playability check FAILED for '{actual_file_path}' — rejecting and reverting item {item.get('id')} to Wanted")
             from utilities.local_library_scan import _reject_unplayable_source
@@ -6552,7 +6588,7 @@ class ProgramRunner:
                     logging.info(f"Confirmed file exists on disk: {actual_file_path} for item {item_id}") # Log actual path found
                     self.file_location_cache[cache_key] = 'exists'
 
-                    if not _ffprobe_gate_or_reject(item_dict, actual_file_path, cache_key):
+                    if _ffprobe_gate_or_reject(item_dict, actual_file_path, cache_key) is not True:
                         continue
 
                     # --- START EDIT: Add Tick Check and Scan Path Gathering ---
@@ -6821,7 +6857,7 @@ class ProgramRunner:
                     current_tick = self.plex_scan_tick_counts.get(cache_key, 0) + 1
                     self.plex_scan_tick_counts[cache_key] = current_tick
 
-                    if not _ffprobe_gate_or_reject(item_dict, actual_file_path, cache_key):
+                    if _ffprobe_gate_or_reject(item_dict, actual_file_path, cache_key) is not True:
                         continue
 
                     # Option C: Direct Plex library lookup.

--- a/tests/test_nzb_fail_closed_lifecycle.py
+++ b/tests/test_nzb_fail_closed_lifecycle.py
@@ -1,0 +1,178 @@
+from pathlib import Path
+
+from utilities.nzb_idle_repair_watch import REDISPATCH_SECONDS, run_idle_repair_watch
+from utilities.nzb_playability_guard import (
+    BROKEN,
+    HEALTHY,
+    UNKNOWN,
+    classify_new_nzb,
+    nzb_job_ready,
+)
+
+
+class _Connection:
+    def __init__(self, in_flight):
+        self.in_flight = in_flight
+        self.closed = False
+
+    def execute(self, sql):
+        assert "state IN ('Adding','Checking')" in sql
+        return self
+
+    def fetchone(self):
+        return (self.in_flight,)
+
+    def close(self):
+        self.closed = True
+
+
+def _classify(results, duration=100):
+    values = iter(results)
+    return classify_new_nzb(
+        "/mount/item.mkv",
+        attempts=len(results),
+        duration_reader=lambda *_a, **_k: duration,
+        packet_reader=lambda *_a, **_k: next(values),
+        sleep_fn=lambda _seconds: None,
+        fraction_reader=lambda: 0.5,
+    )
+
+
+def test_new_nzb_requires_one_conclusive_success():
+    assert _classify([None, False, True]) == HEALTHY
+
+
+def test_new_nzb_all_clean_failures_are_broken():
+    assert _classify([False, False, False]) == BROKEN
+
+
+def test_new_nzb_timeout_is_unknown_not_healthy_or_broken():
+    assert _classify([False, None, False]) == UNKNOWN
+
+
+def test_new_nzb_uses_one_stable_deep_offset_for_all_attempts():
+    offsets = []
+    verdict = classify_new_nzb(
+        "/mount/item.mkv",
+        attempts=3,
+        duration_reader=lambda *_a, **_k: 200,
+        packet_reader=lambda *_a, **kw: offsets.append(kw["offset_seconds"]) or False,
+        sleep_fn=lambda _seconds: None,
+        fraction_reader=lambda: 0.25,
+    )
+    assert verdict == BROKEN
+    assert offsets == [50, 50, 50]
+
+
+def test_nzb_job_must_be_conclusively_completed_before_probe():
+    assert nzb_job_ready({"state": "completed", "progress": 100}) is True
+    assert nzb_job_ready({"state": "downloading", "progress": 99}) is False
+    assert nzb_job_ready({"state": "unknown", "progress": 100}) is False
+    assert nzb_job_ready(None) is False
+
+
+def test_idle_watch_does_not_poll_or_repair_while_nzb_is_in_flight():
+    conn = _Connection(2)
+    called = []
+    result = run_idle_repair_watch(
+        connection_factory=lambda: conn,
+        fetch_broken=lambda: called.append("fetch"),
+        run_repair=lambda **_kwargs: called.append("repair"),
+    )
+    assert result == {"outcome": "busy", "in_flight": 2}
+    assert called == []
+    assert conn.closed
+
+
+def test_idle_watch_is_passive_when_health_state_is_clean():
+    conn = _Connection(0)
+    called = []
+    result = run_idle_repair_watch(
+        connection_factory=lambda: conn,
+        fetch_broken=lambda: called.append("fetch") or [],
+        run_repair=lambda **_kwargs: called.append("repair"),
+    )
+    assert result == {"outcome": "clean", "broken": 0}
+    assert called == ["fetch"]
+
+
+def test_idle_watch_invokes_existing_repair_once_for_reported_breakage():
+    conn = _Connection(0)
+    calls = []
+    result = run_idle_repair_watch(
+        connection_factory=lambda: conn,
+        fetch_broken=lambda: [{"status": "broken"}, {"status": "broken"}],
+        run_repair=lambda **kwargs: calls.append(kwargs) or {"replaced": 1},
+    )
+    assert result["outcome"] == "repair_started"
+    assert result["broken"] == 2
+    assert calls == [{"triggered_by": "idle_watch"}]
+
+
+def test_idle_watch_suppresses_unchanged_broken_set_until_redispatch_window():
+    state = {"fingerprint": None, "dispatched_at": 0.0}
+    calls = []
+    broken = [{"info_hash": "one", "file_name": "episode.mkv"}]
+
+    first = run_idle_repair_watch(
+        connection_factory=lambda: _Connection(0),
+        fetch_broken=lambda: broken,
+        run_repair=lambda **kwargs: calls.append(kwargs) or {},
+        state=state,
+        time_fn=lambda: 100.0,
+    )
+    unchanged = run_idle_repair_watch(
+        connection_factory=lambda: _Connection(0),
+        fetch_broken=lambda: list(reversed(broken)),
+        run_repair=lambda **kwargs: calls.append(kwargs) or {},
+        state=state,
+        time_fn=lambda: 160.0,
+    )
+    redispatched = run_idle_repair_watch(
+        connection_factory=lambda: _Connection(0),
+        fetch_broken=lambda: broken,
+        run_repair=lambda **kwargs: calls.append(kwargs) or {},
+        state=state,
+        time_fn=lambda: 100.0 + REDISPATCH_SECONDS,
+    )
+
+    assert first["outcome"] == "repair_started"
+    assert unchanged == {"outcome": "unchanged", "broken": 1}
+    assert redispatched["outcome"] == "repair_started"
+    assert calls == [
+        {"triggered_by": "idle_watch"},
+        {"triggered_by": "idle_watch"},
+    ]
+
+
+def test_idle_watch_new_broken_identity_dispatches_immediately():
+    state = {"fingerprint": None, "dispatched_at": 0.0}
+    calls = []
+    common = dict(
+        connection_factory=lambda: _Connection(0),
+        run_repair=lambda **kwargs: calls.append(kwargs) or {},
+        state=state,
+        time_fn=lambda: 100.0,
+    )
+    run_idle_repair_watch(fetch_broken=lambda: [{"info_hash": "one"}], **common)
+    changed = run_idle_repair_watch(
+        fetch_broken=lambda: [{"info_hash": "one"}, {"info_hash": "two"}],
+        **common,
+    )
+    assert changed["outcome"] == "repair_started"
+    assert len(calls) == 2
+
+
+def test_run_program_wires_independent_idle_watch_and_fail_closed_gate():
+    source = (Path(__file__).parents[1] / "queues" / "run_program.py").read_text()
+    assert "'task_nzb_idle_repair_watch': 60" in source
+    assert "'task_nzb_idle_repair_watch'," in source
+    assert "def task_nzb_idle_repair_watch(self):" in source
+    assert source.count("is not True:\n                        continue") >= 2
+    queue_tasks = source.split("_QUEUE_TASKS = {", 1)[1].split("}", 1)[0]
+    assert "task_nzb_idle_repair_watch" not in queue_tasks
+    assert "if not nzb_job_ready(job_status):" in source
+    assert "if is_nzb:\n                logging.info" in source
+    assert "verdict = classify_new_nzb(actual_file_path)" in source
+    assert "if verdict == UNKNOWN:" in source
+    assert "from usenet.repair_engine import _verify_file_readable" in source

--- a/utilities/nzb_idle_repair_watch.py
+++ b/utilities/nzb_idle_repair_watch.py
@@ -1,0 +1,93 @@
+"""Idle-safe polling of cli_mount's already-produced broken-entry state."""
+
+import logging
+import time
+
+
+log = logging.getLogger(__name__)
+
+REDISPATCH_SECONDS = 6 * 60 * 60
+_watch_state = {"fingerprint": None, "dispatched_at": 0.0}
+
+
+def _broken_fingerprint(entries):
+    """Build a stable in-memory identity without logging provider data."""
+    identities = []
+    for entry in entries:
+        identities.append(
+            (
+                str(entry.get("info_hash") or entry.get("hash") or ""),
+                str(entry.get("entry_name") or entry.get("name") or ""),
+                str(entry.get("file_name") or ""),
+                str(entry.get("cli_debrid_id") or ""),
+            )
+        )
+    return tuple(sorted(identities))
+
+
+def run_idle_repair_watch(
+    *,
+    connection_factory=None,
+    fetch_broken=None,
+    run_repair=None,
+    state=None,
+    time_fn=time.time,
+):
+    """Start the existing repair engine only when NZB acquisition is idle.
+
+    ``fetch_broken`` reads cli_mount's already-produced health state; it does
+    not start a provider scan. Waiting until no NZB is Adding or Checking keeps
+    the repair engine from observing a just-submitted job as broken.
+    """
+    if connection_factory is None:
+        from database.core import get_db_connection
+
+        connection_factory = get_db_connection
+    if fetch_broken is None or run_repair is None:
+        from usenet.repair_engine import fetch_broken_items, run_repair as repair
+
+        fetch_broken = fetch_broken or fetch_broken_items
+        run_repair = run_repair or repair
+    state = _watch_state if state is None else state
+
+    conn = connection_factory()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM media_items "
+            "WHERE state IN ('Adding','Checking') "
+            "AND filled_by_torrent_id LIKE 'nzb:%'"
+        ).fetchone()
+        in_flight = int(row[0] or 0)
+    finally:
+        conn.close()
+
+    if in_flight:
+        log.debug(
+            "[NZBIdleRepair] Deferring passive broken-item poll; %s NZB item(s) are in flight",
+            in_flight,
+        )
+        return {"outcome": "busy", "in_flight": in_flight}
+
+    broken = fetch_broken() or []
+    if not broken:
+        state["fingerprint"] = None
+        state["dispatched_at"] = 0.0
+        return {"outcome": "clean", "broken": 0}
+
+    now = float(time_fn())
+    fingerprint = _broken_fingerprint(broken)
+    if (
+        fingerprint == state.get("fingerprint")
+        and now - float(state.get("dispatched_at") or 0) < REDISPATCH_SECONDS
+    ):
+        return {"outcome": "unchanged", "broken": len(broken)}
+
+    log.warning(
+        "[NZBIdleRepair] cli_mount reports %s broken item(s) while acquisition is idle; "
+        "starting the existing bounded repair workflow",
+        len(broken),
+    )
+    result = run_repair(triggered_by="idle_watch")
+    state["fingerprint"] = fingerprint
+    state["dispatched_at"] = now
+    return {"outcome": "repair_started", "broken": len(broken), "result": result}

--- a/utilities/nzb_playability_guard.py
+++ b/utilities/nzb_playability_guard.py
@@ -1,0 +1,74 @@
+"""Conclusive playability classification for newly collected NZB media.
+
+The general repair engine deliberately treats an inconclusive FUSE read as
+readable because its caller may otherwise delete a healthy historical file.
+That is the right destructive-repair bias, but the wrong admission rule for a
+new item: Plex must not be told that an NZB is collected until one probe has
+actually returned media data.
+"""
+
+import random
+import time
+
+
+HEALTHY = "healthy"
+BROKEN = "broken"
+UNKNOWN = "unknown"
+
+
+def nzb_job_ready(job_status):
+    """Return True only when cli_mount conclusively reports completion."""
+    return bool(job_status and job_status.get("state") == "completed")
+
+
+def classify_new_nzb(
+    file_path,
+    timeout=10,
+    attempts=3,
+    *,
+    duration_reader=None,
+    packet_reader=None,
+    sleep_fn=time.sleep,
+    fraction_reader=None,
+):
+    """Return ``healthy``, ``broken``, or ``unknown`` for a new NZB file.
+
+    A successful attempt is conclusive. All-clean failures are conclusive.
+    Any timeout/internal error without a success is unknown and must remain in
+    Checking for a later retry; it is neither accepted nor destroyed.
+    """
+    if not file_path:
+        return BROKEN
+
+    if duration_reader is None or packet_reader is None:
+        from usenet.repair_engine import _media_duration_seconds, _probe_readable_once
+
+        duration_reader = duration_reader or _media_duration_seconds
+        packet_reader = packet_reader or _probe_readable_once
+
+    fraction_reader = fraction_reader or (lambda: random.uniform(0.2, 0.8))
+    try:
+        duration = duration_reader(file_path, timeout=timeout)
+    except Exception:
+        duration = None
+    offset = duration * fraction_reader() if duration and duration > 1 else None
+
+    results = []
+    for attempt in range(max(1, attempts)):
+        try:
+            result = packet_reader(
+                file_path,
+                offset_seconds=offset,
+                timeout=timeout,
+            )
+        except Exception:
+            result = None
+        if result is True:
+            return HEALTHY
+        results.append(result)
+        if attempt < attempts - 1:
+            sleep_fn(1.0)
+
+    if any(result is None for result in results):
+        return UNKNOWN
+    return BROKEN


### PR DESCRIPTION
Fixes #498

## Summary

- require cli_mount to report an NZB job as completed before the Plex-mode playability gate can pass;
- classify new-NZB probes as healthy, broken, or unknown instead of treating probe timeouts/errors as readable;
- keep unknown and incomplete items in Checking for a later retry;
- preserve the existing conservative read policy for historical repair and for non-NZB debrid additions;
- poll cli_mount's existing broken state independently while acquisition is idle;
- reuse the existing locked/backoff-aware repair engine;
- suppress redispatch of an unchanged broken set for six hours while reacting immediately to new or changed identities.

The idle watcher is passive: it does not start a provider health scan. The existing repair engine may contact configured services only after cli_mount has already reported a broken entry.

## Tests

```
python3 -m pytest -q \
  tests/test_nzb_fail_closed_lifecycle.py \
  tests/test_nzb_playback_scheduler.py \
  tests/test_repair_readcheck.py \
  tests/test_nzb_playback_repair.py
```

Result: `50 passed`.

`py_compile` and `git diff --check` also pass.

AI-assisted implementation: Codex. The defect, patch scope, and sanitized diff were verified against current upstream `dev` before submission.